### PR TITLE
#3: mDNS peer discovery на JVM через JmDNS

### DIFF
--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/Main.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/Main.kt
@@ -41,7 +41,7 @@ class TetherCommand :
 
         val discovery = MdnsDiscovery()
         discovery.start(deviceName, actualPort)
-        echo("mDNS started (JmDNS stub — not wired yet)\n")
+        echo("mDNS started  →  advertising '$deviceName' on port $actualPort\n")
 
         launch {
             discovery.discoveredDevices.collect { peers ->

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/Main.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/Main.kt
@@ -40,7 +40,13 @@ class TetherCommand :
         echo("FileServer started  →  http://localhost:$actualPort/health")
 
         val discovery = MdnsDiscovery()
-        discovery.start(deviceName, actualPort)
+        try {
+            discovery.start(deviceName, actualPort)
+        } catch (e: Exception) {
+            echo("ERROR: Could not start mDNS — ${e.message}", err = true)
+            server.stop()
+            throw ProgramResult(1)
+        }
         echo("mDNS started → advertising '$deviceName' on port $actualPort\n")
 
         launch {

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/Main.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/Main.kt
@@ -41,7 +41,7 @@ class TetherCommand :
 
         val discovery = MdnsDiscovery()
         discovery.start(deviceName, actualPort)
-        echo("mDNS started  →  advertising '$deviceName' on port $actualPort\n")
+        echo("mDNS started → advertising '$deviceName' on port $actualPort\n")
 
         launch {
             discovery.discoveredDevices.collect { peers ->

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
@@ -15,10 +15,10 @@ actual class MdnsDiscovery actual constructor() {
     private val _discoveredDevices = MutableStateFlow<List<Device>>(emptyList())
     actual val discoveredDevices: Flow<List<Device>> = _discoveredDevices.asStateFlow()
 
-    @Volatile private var jmdns: JmDNS? = null
+    private var jmdns: JmDNS? = null
+    private var ownName: String? = null
 
-    @Volatile private var ownName: String? = null
-
+    @Synchronized
     actual fun start(deviceName: String, port: Int) {
         if (jmdns != null) throw IllegalStateException("MdnsDiscovery already started; call stop() first")
 
@@ -76,6 +76,7 @@ actual class MdnsDiscovery actual constructor() {
         )
     }
 
+    @Synchronized
     actual fun stop() {
         try {
             jmdns?.unregisterAllServices()

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
@@ -16,8 +16,9 @@ actual class MdnsDiscovery actual constructor() {
     private val _discoveredDevices = MutableStateFlow<List<Device>>(emptyList())
     actual val discoveredDevices: Flow<List<Device>> = _discoveredDevices.asStateFlow()
 
-    private var jmdns: JmDNS? = null
-    private var ownName: String? = null
+    @Volatile private var jmdns: JmDNS? = null
+
+    @Volatile private var ownName: String? = null
 
     @Synchronized
     actual fun start(deviceName: String, port: Int) {
@@ -102,8 +103,16 @@ actual class MdnsDiscovery actual constructor() {
     @Synchronized
     actual fun stop() {
         try {
-            jmdns?.unregisterAllServices()
-            jmdns?.close()
+            try {
+                jmdns?.unregisterAllServices()
+            } catch (e: Exception) {
+                System.err.println("WARN: unregisterAllServices failed — ${e.message}")
+            }
+            try {
+                jmdns?.close()
+            } catch (e: Exception) {
+                System.err.println("WARN: jmdns close failed — ${e.message}")
+            }
         } finally {
             jmdns = null
             ownName = null

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
@@ -10,6 +10,7 @@ import javax.jmdns.ServiceInfo
 import javax.jmdns.ServiceListener
 
 private const val SERVICE_TYPE = "_tether._tcp.local."
+private val IPV4_REGEX = Regex("""\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}""")
 
 actual class MdnsDiscovery actual constructor() {
     private val _discoveredDevices = MutableStateFlow<List<Device>>(emptyList())
@@ -23,7 +24,12 @@ actual class MdnsDiscovery actual constructor() {
         if (jmdns != null) throw IllegalStateException("MdnsDiscovery already started; call stop() first")
 
         ownName = deviceName
-        val instance = JmDNS.create()
+        val instance = try {
+            JmDNS.create()
+        } catch (e: Exception) {
+            ownName = null
+            throw e
+        }
         jmdns = instance
 
         instance.addServiceListener(
@@ -39,11 +45,18 @@ actual class MdnsDiscovery actual constructor() {
                 }
 
                 override fun serviceResolved(event: ServiceEvent) {
+                    if (jmdns == null) return
                     try {
                         if (event.name == ownName) return
 
                         val info: ServiceInfo = event.info
-                        val ipv4 = info.getHostAddresses().firstOrNull { it.contains('.') }
+
+                        if (info.port !in 1..65535) {
+                            System.err.println("WARN: invalid port ${info.port} for '${event.name}', skipping")
+                            return
+                        }
+
+                        val ipv4 = info.getHostAddresses().firstOrNull { IPV4_REGEX.matches(it) }
                         if (ipv4 == null) {
                             System.err.println(
                                 "WARN: serviceResolved — no IPv4 for '${event.name}', skipping",
@@ -66,14 +79,24 @@ actual class MdnsDiscovery actual constructor() {
             },
         )
 
-        instance.registerService(
-            ServiceInfo.create(
-                SERVICE_TYPE,
-                deviceName,
-                port,
-                "",
-            ),
-        )
+        try {
+            instance.registerService(
+                ServiceInfo.create(
+                    SERVICE_TYPE,
+                    deviceName,
+                    port,
+                    "",
+                ),
+            )
+        } catch (e: Exception) {
+            jmdns = null
+            ownName = null
+            try {
+                instance.close()
+            } catch (ignored: Exception) {
+            }
+            throw e
+        }
     }
 
     @Synchronized

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
@@ -15,8 +15,9 @@ actual class MdnsDiscovery actual constructor() {
     private val _discoveredDevices = MutableStateFlow<List<Device>>(emptyList())
     actual val discoveredDevices: Flow<List<Device>> = _discoveredDevices.asStateFlow()
 
-    private var jmdns: JmDNS? = null
-    private var ownName: String? = null
+    @Volatile private var jmdns: JmDNS? = null
+
+    @Volatile private var ownName: String? = null
 
     actual fun start(deviceName: String, port: Int) {
         if (jmdns != null) throw IllegalStateException("MdnsDiscovery already started; call stop() first")
@@ -29,7 +30,7 @@ actual class MdnsDiscovery actual constructor() {
             SERVICE_TYPE,
             object : ServiceListener {
                 override fun serviceAdded(event: ServiceEvent) {
-                    instance.requestServiceInfo(event.type, event.name)
+                    jmdns?.requestServiceInfo(event.type, event.name)
                 }
 
                 override fun serviceRemoved(event: ServiceEvent) {

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
@@ -4,19 +4,85 @@ import com.tubetoast.tether.protocol.Device
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import javax.jmdns.JmDNS
+import javax.jmdns.ServiceEvent
+import javax.jmdns.ServiceInfo
+import javax.jmdns.ServiceListener
+
+private const val SERVICE_TYPE = "_tether._tcp.local."
 
 actual class MdnsDiscovery actual constructor() {
     private val _discoveredDevices = MutableStateFlow<List<Device>>(emptyList())
     actual val discoveredDevices: Flow<List<Device>> = _discoveredDevices.asStateFlow()
 
+    private var jmdns: JmDNS? = null
+    private var ownName: String? = null
+
     actual fun start(deviceName: String, port: Int) {
-        // TODO: val jmdns = JmDNS.create()
-        // TODO: jmdns.registerService(ServiceInfo.create("_tether._tcp.local.", deviceName, port, ""))
-        // TODO: jmdns.addServiceListener("_tether._tcp.local.", listener)
+        if (jmdns != null) throw IllegalStateException("MdnsDiscovery already started; call stop() first")
+
+        ownName = deviceName
+        val instance = JmDNS.create()
+        jmdns = instance
+
+        instance.addServiceListener(
+            SERVICE_TYPE,
+            object : ServiceListener {
+                override fun serviceAdded(event: ServiceEvent) {
+                    instance.requestServiceInfo(event.type, event.name)
+                }
+
+                override fun serviceRemoved(event: ServiceEvent) {
+                    _discoveredDevices.value = _discoveredDevices.value
+                        .filterNot { it.name == event.name }
+                }
+
+                override fun serviceResolved(event: ServiceEvent) {
+                    try {
+                        if (event.name == ownName) return
+
+                        val info: ServiceInfo = event.info
+                        val ipv4 = info.getHostAddresses().firstOrNull { it.contains('.') }
+                        if (ipv4 == null) {
+                            System.err.println(
+                                "WARN: serviceResolved — no IPv4 for '${event.name}', skipping",
+                            )
+                            return
+                        }
+
+                        val device = Device(
+                            id = "${event.name}@$ipv4:${info.port}",
+                            name = event.name,
+                            host = ipv4,
+                            port = info.port,
+                        )
+                        _discoveredDevices.value = _discoveredDevices.value
+                            .filterNot { it.name == device.name } + device
+                    } catch (e: Exception) {
+                        System.err.println("WARN: serviceResolved error for '${event.name}' — ${e.message}")
+                    }
+                }
+            },
+        )
+
+        instance.registerService(
+            ServiceInfo.create(
+                SERVICE_TYPE,
+                deviceName,
+                port,
+                "",
+            ),
+        )
     }
 
     actual fun stop() {
-        // TODO: jmdns.unregisterAllServices(); jmdns.close()
-        _discoveredDevices.value = emptyList()
+        try {
+            jmdns?.unregisterAllServices()
+            jmdns?.close()
+        } finally {
+            jmdns = null
+            ownName = null
+            _discoveredDevices.value = emptyList()
+        }
     }
 }

--- a/composeApp/src/jvmTest/kotlin/com/tubetoast/tether/discovery/MdnsDiscoveryTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/tubetoast/tether/discovery/MdnsDiscoveryTest.kt
@@ -77,9 +77,38 @@ class MdnsDiscoveryTest {
             withTimeout(10_000) {
                 a.discoveredDevices.first { peers -> peers.any { it.name == "SelfB" } }
             }
+            withTimeout(10_000) {
+                b.discoveredDevices.first { peers -> peers.any { it.name == "SelfA" } }
+            }
 
             assertTrue(a.discoveredDevices.first().none { it.name == "SelfA" })
             assertTrue(b.discoveredDevices.first().none { it.name == "SelfB" })
+        } finally {
+            a.stop()
+            b.stop()
+        }
+    }
+
+    @Test
+    fun `restart — stop then start works correctly`() = runBlocking {
+        val a = MdnsDiscovery()
+        val b = MdnsDiscovery()
+        try {
+            a.start("RestartA", 19050)
+            b.start("RestartB", 19051)
+
+            withTimeout(10_000) {
+                a.discoveredDevices.first { peers -> peers.any { it.name == "RestartB" } }
+            }
+
+            a.stop()
+            assertTrue(a.discoveredDevices.first().isEmpty())
+
+            a.start("RestartA", 19050)
+            withTimeout(10_000) {
+                a.discoveredDevices.first { peers -> peers.any { it.name == "RestartB" } }
+            }
+            assertEquals(1, a.discoveredDevices.first().size)
         } finally {
             a.stop()
             b.stop()

--- a/composeApp/src/jvmTest/kotlin/com/tubetoast/tether/discovery/MdnsDiscoveryTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/tubetoast/tether/discovery/MdnsDiscoveryTest.kt
@@ -1,0 +1,128 @@
+package com.tubetoast.tether.discovery
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class MdnsDiscoveryTest {
+    @Test
+    fun `stop before start does not throw`() {
+        MdnsDiscovery().stop()
+    }
+
+    @Test
+    fun `start twice without stop throws IllegalStateException`() {
+        val discovery = MdnsDiscovery()
+        discovery.start("DoubleStart", 19001)
+        try {
+            assertFailsWith<IllegalStateException> {
+                discovery.start("DoubleStart2", 19002)
+            }
+        } finally {
+            discovery.stop()
+        }
+    }
+
+    @Test
+    fun `stop emits empty list`() = runBlocking {
+        val discovery = MdnsDiscovery()
+        discovery.start("StopEmits", 19003)
+        discovery.stop()
+        assertTrue(discovery.discoveredDevices.first().isEmpty())
+    }
+
+    @Test
+    fun `two instances discover each other`() = runBlocking {
+        val a = MdnsDiscovery()
+        val b = MdnsDiscovery()
+        try {
+            a.start("PeerA", 19010)
+            b.start("PeerB", 19011)
+
+            withTimeout(10_000) {
+                a.discoveredDevices.first { peers -> peers.any { it.name == "PeerB" } }
+            }
+            withTimeout(10_000) {
+                b.discoveredDevices.first { peers -> peers.any { it.name == "PeerA" } }
+            }
+
+            val seenByA = a.discoveredDevices.first()
+            val seenByB = b.discoveredDevices.first()
+
+            assertEquals(1, seenByA.size)
+            assertEquals("PeerB", seenByA[0].name)
+            assertEquals(19011, seenByA[0].port)
+
+            assertEquals(1, seenByB.size)
+            assertEquals("PeerA", seenByB[0].name)
+            assertEquals(19010, seenByB[0].port)
+        } finally {
+            a.stop()
+            b.stop()
+        }
+    }
+
+    @Test
+    fun `instances do not discover themselves`() = runBlocking {
+        val a = MdnsDiscovery()
+        val b = MdnsDiscovery()
+        try {
+            a.start("SelfA", 19020)
+            b.start("SelfB", 19021)
+
+            withTimeout(10_000) {
+                a.discoveredDevices.first { peers -> peers.any { it.name == "SelfB" } }
+            }
+
+            assertTrue(a.discoveredDevices.first().none { it.name == "SelfA" })
+            assertTrue(b.discoveredDevices.first().none { it.name == "SelfB" })
+        } finally {
+            a.stop()
+            b.stop()
+        }
+    }
+
+    @Test
+    fun `stop clears previously discovered peers`() = runBlocking {
+        val a = MdnsDiscovery()
+        val b = MdnsDiscovery()
+        try {
+            a.start("ClearA", 19030)
+            b.start("ClearB", 19031)
+
+            withTimeout(10_000) {
+                a.discoveredDevices.first { peers -> peers.any { it.name == "ClearB" } }
+            }
+
+            a.stop()
+            assertTrue(a.discoveredDevices.first().isEmpty())
+        } finally {
+            b.stop()
+        }
+    }
+
+    @Test
+    fun `discovered device has correct host and port`() = runBlocking {
+        val a = MdnsDiscovery()
+        val b = MdnsDiscovery()
+        try {
+            a.start("HostA", 19040)
+            b.start("HostB", 19041)
+
+            val peers = withTimeout(10_000) {
+                a.discoveredDevices.first { peers -> peers.any { it.name == "HostB" } }
+            }
+
+            val device = peers.first { it.name == "HostB" }
+            assertTrue(device.host.matches(Regex("""\d+\.\d+\.\d+\.\d+""")), "host should be IPv4: ${device.host}")
+            assertEquals(19041, device.port)
+        } finally {
+            a.stop()
+            b.stop()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Реализован `actual class MdnsDiscovery` для JVM-таргета через библиотеку JmDNS (уже была в зависимостях)
- Регистрирует сервис `_tether._tcp.local.` и слушает появление/исчезновение пиров через `ServiceListener`
- Обновлён лог-вывод в `Main.kt` — убран комментарий о заглушке

## Краевые случаи

- Двойной `start()` без `stop()` → `IllegalStateException`
- Пир без IPv4-адреса → пропускается с `WARN` в stderr
- Сам себя не видит — фильтрация по имени в `serviceResolved`
- `stop()` → `unregisterAllServices()` + `close()` в `finally`, эмитит пустой список

## Тесты (`MdnsDiscoveryTest`)

7 тестов в `jvmTest/`:
- `stop` до `start` не бросает исключение
- Двойной `start` бросает `IllegalStateException`
- `stop` эмитит пустой список
- Два экземпляра находят друг друга по сети
- Экземпляры не видят себя
- `stop` сбрасывает ранее найденных пиров
- Найденный `Device` содержит корректный IPv4 и порт

## Проверка DoD

```bash
./gradlew :composeApp:run --args="--name DevA --port 8080"
./gradlew :composeApp:run --args="--name DevB --port 8081"
# Оба терминала видят друг друга в течение ~5 с
```

Closes #3