### PR TITLE
#4: streaming file upload — POST /upload и FileClient.send()

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -82,6 +82,8 @@ kotlin {
             implementation(libs.kotlin.testJunit)
             implementation(libs.ktor.client.core)
             implementation(libs.ktor.client.cio)
+            implementation(libs.ktor.client.content.negotiation)
+            implementation(libs.ktor.serialization.kotlinx.json)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
@@ -1,10 +1,19 @@
 package com.tubetoast.tether.network
 
 import com.tubetoast.tether.protocol.Device
-import io.ktor.client.*
-import io.ktor.client.engine.cio.*
-import io.ktor.client.plugins.contentnegotiation.*
-import io.ktor.serialization.kotlinx.json.*
+import com.tubetoast.tether.protocol.SendResult
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.core.Closeable
 
 class FileClient : Closeable {
@@ -15,6 +24,23 @@ class FileClient : Closeable {
     suspend fun ping(device: Device): Boolean {
         // TODO: GET http://${device.host}:${device.port}/health
         throw NotImplementedError("ping() is not yet implemented")
+    }
+
+    suspend fun send(device: Device, channel: ByteReadChannel, fileName: String): SendResult = try {
+        val response = client.post("http://${device.host}:${device.port}/upload") {
+            parameter("name", fileName)
+            contentType(ContentType.Application.OctetStream)
+            setBody(channel)
+        }
+        if (response.status == HttpStatusCode.OK) {
+            val body = response.body<Map<String, String>>()
+            SendResult.Success(body["savedPath"] ?: "")
+        } else {
+            val body = response.body<Map<String, String>>()
+            SendResult.Failure(body["error"] ?: response.status.description)
+        }
+    } catch (e: Exception) {
+        SendResult.Failure(e.message ?: "unknown error")
     }
 
     override fun close() {

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/protocol/SendResult.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/protocol/SendResult.kt
@@ -1,0 +1,16 @@
+package com.tubetoast.tether.protocol
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed class SendResult {
+    @Serializable
+    data class Success(
+        val savedPath: String,
+    ) : SendResult()
+
+    @Serializable
+    data class Failure(
+        val reason: String,
+    ) : SendResult()
+}

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/network/FileClientJvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/network/FileClientJvm.kt
@@ -1,0 +1,14 @@
+package com.tubetoast.tether.network
+
+import com.tubetoast.tether.protocol.Device
+import com.tubetoast.tether.protocol.SendResult
+import io.ktor.utils.io.jvm.javaio.toByteReadChannel
+import java.io.FileNotFoundException
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.inputStream
+
+suspend fun FileClient.send(device: Device, file: Path): SendResult {
+    if (!file.exists()) throw FileNotFoundException(file.toString())
+    return send(device, file.inputStream().toByteReadChannel(), file.fileName.toString())
+}

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/network/FileServer.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/network/FileServer.kt
@@ -1,27 +1,72 @@
 package com.tubetoast.tether.network
 
-import io.ktor.http.*
-import io.ktor.serialization.kotlinx.json.*
-import io.ktor.server.application.*
-import io.ktor.server.cio.*
-import io.ktor.server.engine.*
-import io.ktor.server.plugins.contentnegotiation.*
-import io.ktor.server.response.*
-import io.ktor.server.routing.*
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.cio.CIO
+import io.ktor.server.cio.CIOApplicationEngine
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.request.receiveStream
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
 import kotlinx.coroutines.runBlocking
+import java.io.File
+
+private const val BUFFER_SIZE = 64 * 1024
 
 class FileServer(
     private val port: Int,
+    private val downloadsDir: File = File(System.getProperty("user.home"), "Downloads/Tether"),
 ) {
     private var server: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
 
     fun start(): Int {
         check(server == null) { "FileServer is already running" }
+        downloadsDir.mkdirs()
         val srv = embeddedServer(CIO, port = port) {
             install(ContentNegotiation) { json() }
             routing {
                 get("/health") { call.respond(HttpStatusCode.OK, "Tether OK") }
-                // TODO: POST /upload — receive file bytes from a peer
+                post("/upload") {
+                    val rawName = call.request.queryParameters["name"]
+                    if (rawName.isNullOrBlank()) {
+                        call.respond(HttpStatusCode.BadRequest, mapOf("error" to "missing 'name' query parameter"))
+                        return@post
+                    }
+                    // Strip path components to prevent traversal attacks
+                    val fileName = File(rawName).name
+                    val dest = resolveDestination(downloadsDir, fileName)
+                    var uploadComplete = false
+                    try {
+                        call.receiveStream().use { input ->
+                            dest.outputStream().use { output ->
+                                input.copyTo(output, bufferSize = BUFFER_SIZE)
+                            }
+                        }
+                        uploadComplete = true
+                        call.respond(HttpStatusCode.OK, mapOf("savedPath" to dest.absolutePath))
+                    } catch (e: Exception) {
+                        System.err.println("ERROR: upload failed for '$fileName' — ${e.message}")
+                        try {
+                            call.respond(
+                                HttpStatusCode.InternalServerError,
+                                mapOf("error" to (e.message ?: "upload failed")),
+                            )
+                        } catch (_: Exception) {
+                        }
+                    } finally {
+                        if (!uploadComplete) {
+                            try {
+                                dest.delete()
+                            } catch (_: Exception) {
+                            }
+                        }
+                    }
+                }
             }
         }.start(wait = false)
         server = srv
@@ -34,4 +79,17 @@ class FileServer(
         server?.stop(gracePeriodMillis = 500, timeoutMillis = 1_000)
         server = null
     }
+}
+
+private fun resolveDestination(dir: File, fileName: String): File {
+    var dest = File(dir, fileName)
+    if (!dest.exists()) return dest
+    val ext = fileName.substringAfterLast('.', "")
+    val base = if (ext.isEmpty()) fileName else fileName.removeSuffix(".$ext")
+    var i = 1
+    do {
+        dest = File(dir, if (ext.isEmpty()) "${base}_$i" else "${base}_$i.$ext")
+        i++
+    } while (dest.exists())
+    return dest
 }

--- a/composeApp/src/jvmTest/kotlin/com/tubetoast/tether/network/FileClientTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/tubetoast/tether/network/FileClientTest.kt
@@ -1,0 +1,101 @@
+package com.tubetoast.tether.network
+
+import com.tubetoast.tether.protocol.Device
+import com.tubetoast.tether.protocol.SendResult
+import kotlinx.coroutines.runBlocking
+import java.io.FileNotFoundException
+import java.nio.file.Files
+import kotlin.io.path.writeBytes
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class FileClientTest {
+    private val device
+        get() = Device(id = "test@127.0.0.1:$serverPort", name = "test", host = "127.0.0.1", port = serverPort)
+
+    private var serverPort = 0
+    private var tmpDir = Files.createTempDirectory("tether-client-test").toFile()
+    private val server = FileServer(0, downloadsDir = tmpDir)
+
+    private fun setup(): FileClient {
+        serverPort = server.start()
+        return FileClient()
+    }
+
+    private fun teardown(client: FileClient) {
+        client.close()
+        server.stop()
+        tmpDir.deleteRecursively()
+    }
+
+    @Test
+    fun `send returns Success with saved path`() {
+        val client = setup()
+        try {
+            val file = Files.createTempFile("send-test", ".txt")
+            file.writeBytes("hello from client".toByteArray())
+            runBlocking {
+                val result = client.send(device, file)
+                assertIs<SendResult.Success>(result)
+                assertTrue(result.savedPath.endsWith(".txt"))
+                assertEquals("hello from client", java.io.File(result.savedPath).readText())
+            }
+            Files.deleteIfExists(file)
+        } finally {
+            teardown(client)
+        }
+    }
+
+    @Test
+    fun `send throws FileNotFoundException for missing file`() {
+        val client = setup()
+        try {
+            val missing = Files.createTempDirectory("gone").resolve("no-such-file.bin")
+            runBlocking {
+                assertFailsWith<FileNotFoundException> {
+                    client.send(device, missing)
+                }
+            }
+        } finally {
+            teardown(client)
+        }
+    }
+
+    @Test
+    fun `send preserves file content exactly`() {
+        val client = setup()
+        try {
+            val content = ByteArray(256) { it.toByte() }
+            val file = Files.createTempFile("binary-test", ".bin")
+            file.writeBytes(content)
+            runBlocking {
+                val result = client.send(device, file) as SendResult.Success
+                val saved = java.io.File(result.savedPath).readBytes()
+                assertTrue(content.contentEquals(saved), "Saved content does not match sent content")
+            }
+            Files.deleteIfExists(file)
+        } finally {
+            teardown(client)
+        }
+    }
+
+    @Test
+    fun `send returns Failure when server is not running`() {
+        val client = FileClient()
+        try {
+            val file = Files.createTempFile("no-server", ".txt")
+            file.writeBytes("data".toByteArray())
+            val unreachable = Device(id = "x@127.0.0.1:1", name = "x", host = "127.0.0.1", port = 1)
+            runBlocking {
+                val result = client.send(unreachable, file)
+                assertIs<SendResult.Failure>(result)
+            }
+            Files.deleteIfExists(file)
+        } finally {
+            client.close()
+        }
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/com/tubetoast/tether/network/FileServerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/tubetoast/tether/network/FileServerTest.kt
@@ -1,13 +1,23 @@
 package com.tubetoast.tether.network
 
-import io.ktor.client.*
-import io.ktor.client.engine.cio.*
-import io.ktor.client.request.*
-import io.ktor.client.statement.*
-import io.ktor.http.*
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.runBlocking
+import java.io.File
+import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class FileServerTest {
@@ -58,6 +68,109 @@ class FileServerTest {
             assertTrue(threw, "Expected IllegalStateException on double start")
         } finally {
             server.stop()
+        }
+    }
+
+    @Test
+    fun `upload saves file with correct content`() {
+        val tmpDir = Files.createTempDirectory("tether-test").toFile()
+        val server = FileServer(0, downloadsDir = tmpDir)
+        val port = server.start()
+        val client = HttpClient(CIO) { install(ContentNegotiation) { json() } }
+        try {
+            val content = "hello tether upload".toByteArray()
+            runBlocking {
+                val response = client.post("http://localhost:$port/upload?name=hello.txt") {
+                    contentType(ContentType.Application.OctetStream)
+                    setBody(content)
+                }
+                assertEquals(HttpStatusCode.OK, response.status)
+                val body = response.body<Map<String, String>>()
+                val savedPath = body["savedPath"]!!
+                val saved = File(savedPath)
+                assertTrue(saved.exists())
+                assertEquals("hello tether upload", saved.readText())
+            }
+        } finally {
+            client.close()
+            server.stop()
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `upload without name returns 400`() {
+        val tmpDir = Files.createTempDirectory("tether-test").toFile()
+        val server = FileServer(0, downloadsDir = tmpDir)
+        val port = server.start()
+        val client = HttpClient(CIO) { install(ContentNegotiation) { json() } }
+        try {
+            runBlocking {
+                val response = client.post("http://localhost:$port/upload") {
+                    contentType(ContentType.Application.OctetStream)
+                    setBody(ByteArray(0))
+                }
+                assertEquals(HttpStatusCode.BadRequest, response.status)
+            }
+        } finally {
+            client.close()
+            server.stop()
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `upload duplicate filename gets numeric suffix`() {
+        val tmpDir = Files.createTempDirectory("tether-test").toFile()
+        val server = FileServer(0, downloadsDir = tmpDir)
+        val port = server.start()
+        val client = HttpClient(CIO) { install(ContentNegotiation) { json() } }
+        try {
+            runBlocking {
+                val r1 = client.post("http://localhost:$port/upload?name=dup.txt") {
+                    contentType(ContentType.Application.OctetStream)
+                    setBody("first".toByteArray())
+                }
+                val path1 = r1.body<Map<String, String>>()["savedPath"]!!
+
+                val r2 = client.post("http://localhost:$port/upload?name=dup.txt") {
+                    contentType(ContentType.Application.OctetStream)
+                    setBody("second".toByteArray())
+                }
+                val path2 = r2.body<Map<String, String>>()["savedPath"]!!
+
+                assertTrue(path1.endsWith("dup.txt"), "first should be dup.txt, got $path1")
+                assertTrue(path2.endsWith("dup_1.txt"), "second should be dup_1.txt, got $path2")
+                assertEquals("first", File(path1).readText())
+                assertEquals("second", File(path2).readText())
+            }
+        } finally {
+            client.close()
+            server.stop()
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `upload creates downloads dir if missing`() {
+        val tmpDir = Files.createTempDirectory("tether-test").toFile()
+        val nested = File(tmpDir, "deep/nested")
+        assertFalse(nested.exists())
+        val server = FileServer(0, downloadsDir = nested)
+        val port = server.start()
+        val client = HttpClient(CIO)
+        try {
+            runBlocking {
+                client.post("http://localhost:$port/upload?name=x.bin") {
+                    contentType(ContentType.Application.OctetStream)
+                    setBody(ByteArray(1))
+                }
+            }
+            assertTrue(nested.exists())
+        } finally {
+            client.close()
+            server.stop()
+            tmpDir.deleteRecursively()
         }
     }
 }

--- a/composeApp/src/jvmTest/kotlin/com/tubetoast/tether/network/FileServerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/tubetoast/tether/network/FileServerTest.kt
@@ -173,4 +173,31 @@ class FileServerTest {
             tmpDir.deleteRecursively()
         }
     }
+
+    @Test
+    fun `upload strips path traversal from filename`() {
+        val tmpDir = Files.createTempDirectory("tether-test").toFile()
+        val server = FileServer(0, downloadsDir = tmpDir)
+        val port = server.start()
+        val client = HttpClient(CIO) { install(ContentNegotiation) { json() } }
+        try {
+            runBlocking {
+                val response = client.post("http://localhost:$port/upload?name=../evil.txt") {
+                    contentType(ContentType.Application.OctetStream)
+                    setBody("malicious".toByteArray())
+                }
+                assertEquals(HttpStatusCode.OK, response.status)
+                val savedPath = response.body<Map<String, String>>()["savedPath"]!!
+                assertFalse(File(tmpDir.parentFile, "evil.txt").exists(), "file must not escape downloads dir")
+                assertTrue(
+                    File(savedPath).canonicalPath.startsWith(tmpDir.canonicalPath),
+                    "saved path must be inside downloads dir",
+                )
+            }
+        } finally {
+            client.close()
+            server.stop()
+            tmpDir.deleteRecursively()
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- `POST /upload?name={filename}` endpoint на `FileServer` — стриминг байтов в `~/Downloads/Tether/` с буфером 64 KiB
- `FileClient.send(device, channel, fileName)` в `commonMain` — универсальный метод для стриминговой отправки
- `FileClient.send(device, file: Path)` в `jvmMain` — JVM-расширение для отправки файла по пути
- `SendResult` sealed class (`Success(savedPath)` / `Failure(reason)`) в `commonMain/protocol/`
- Дубли имён → суффикс `_1`, `_2`, …; sanitization имени файла против path traversal
- Частичный файл удаляется при ошибке соединения

## Edge cases covered

- Файл не существует → `FileNotFoundException` до соединения
- Пустой/отсутствующий `name` параметр → `400 Bad Request`
- Дублирующееся имя → авто-суффикс `_1`, `_2`, …
- Директория назначения создаётся при старте сервера
- Path traversal в имени файла → sanitization через `File(name).name`

## Tests

- `FileServerTest`: upload с корректным содержимым, 400 при отсутствии name, суффиксы для дублей, создание директории
- `FileClientTest`: success + savedPath, `FileNotFoundException` для несуществующего файла, точное совпадение содержимого, `Failure` при недоступном сервере

## Test plan

- [x] `./gradlew allTests -q` — зелёный
- [x] Ручной E2E: `./gradlew :composeApp:run --args="--name Receiver --port 9090"` + `curl -X POST "http://localhost:9090/upload?name=test.txt" -H "Content-Type: application/octet-stream" --data-binary @/path/to/file`

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)