### PR TITLE
#17: automate local.properties copy to worktrees

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "hooks": {
+    "worktreeCreate": {
+      "description": "Copy local.properties from repo root to new worktree",
+      "command": "bash -c 'REPO_ROOT=$(git rev-parse --show-toplevel); cp \"$REPO_ROOT/local.properties\" local.properties 2>/dev/null || true'"
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,11 +159,3 @@ GitHub Actions (`.github/workflows/ci.yml`) runs on all pushes and PRs to main:
 ## Code Review
 
 When reviewing a PR, follow the process in [`.claude/commands/code-review.md`](.claude/commands/code-review.md).
-
-## Worktree и окружение
-
-При работе в git worktree (`.claude/worktrees/*`) скопируй `local.properties` из корня репозитория в директорию worktree — иначе pre-push хук (`./gradlew allTests`) не найдёт Android SDK и заблокирует push:
-
-```bash
-cp /path/to/repo/local.properties /path/to/worktree/local.properties
-```


### PR DESCRIPTION
Automate copying of local.properties to new worktrees via settings.json hook.