### PR TITLE
#53: split system-integration concerns into a subfolder

### DIFF
--- a/docs/product/features/README.md
+++ b/docs/product/features/README.md
@@ -37,8 +37,16 @@ Note on `Status` here vs. GitHub Issues: an issue can exist (and even be in prog
 | Pairing | Pairing / Security | scoped | [pairing.md](pairing.md) | #9 (key exchange), #10 (PIN + CLI), #11 (Android UI); iOS, Desktop UI _tbd_ |
 | Device list screen | UI | scoped | [device-list.md](device-list.md) | #7 (Android); iOS, Desktop _tbd_ |
 | File transfer | Transfer / UI | idea | [file-transfer.md](file-transfer.md) (stub) | #8 (Android send UI); iOS, Desktop, receive-side UI _tbd_ |
-| Permissions strategy | Cross-platform / UX | idea | [permissions-strategy.md](permissions-strategy.md) (stub) | _tbd_ |
 | Device name bootstrapping | Onboarding | idea | [device-name-bootstrapping.md](device-name-bootstrapping.md) (stub) | _tbd_ |
+
+### System integration
+
+Small, separate features about how Tether reacts to the OS state around it. Each is its own concern; the [`system/`](system/) subfolder groups them. Add a new spec here when a new system surface earns its own behaviour.
+
+| Feature | Status | Doc | Issues |
+|---------|--------|-----|--------|
+| Permissions | idea | [system/permissions.md](system/permissions.md) (stub) | _tbd_ |
+| Wi-Fi availability | idea | [system/wifi-availability.md](system/wifi-availability.md) (stub) | _tbd_ |
 
 ---
 

--- a/docs/product/features/system/permissions.md
+++ b/docs/product/features/system/permissions.md
@@ -1,6 +1,6 @@
-# Permissions strategy
+# Permissions
 
-**Area:** Cross-platform / UX
+**Area:** System integration
 **Status:** `idea`
 **GitHub Issues:** _tbd_
 
@@ -14,18 +14,24 @@ Each platform has its own permission surface — and currently each issue (#7, #
 
 Permissions involved:
 
-- **Android** — Local Network discovery (multicast), foreground service for receive, file read (`READ_MEDIA_*` on API 33+).
+- **Android** — Local Network discovery (multicast), file read (`READ_MEDIA_*` on API 33+).
 - **iOS** — Local Network usage description.
 - **macOS** — Local Network access on Sonoma+.
-- **Desktop (Windows/Linux)** — firewall prompts on first server bind.
 
 ## What it does (sketch)
 
 - Defines **when** each prompt is shown — at launch, at first relevant action, or deferred until the system itself triggers it.
-- Defines **what** the user sees if a permission is denied (graceful empty state, not a crash).
-- Names the user-facing strings used in iOS / macOS Info.plist explanations.
+- Defines **what** the user sees if a permission is denied — a graceful empty state with a way to open OS settings, not a crash and not a silent dead-end.
+- Names the user-facing strings used in iOS / macOS Info.plist explanations and Android rationale dialogs.
+
+## Not in this feature
+
+- Wi-Fi availability — that is a system **state**, not a grant. See [wifi-availability.md](wifi-availability.md).
+- Android foreground service for background receive — that is a lifecycle question, surfaces inside [file-transfer.md](../file-transfer.md).
+- Desktop firewall prompts on first server bind — narrow, fixed as a Platform note in the relevant feature.
 
 ## Open product questions
 
 - Do we ask for file read on Android up front, or only when the user picks a file? Both are common patterns; pick one and stick to it.
 - iOS Local Network prompt — first launch (predictable but front-loaded) or on-demand (smoother but surprises some users).
+- When a permission is denied permanently ("Don't ask again"), what does the empty state look like, and how clearly do we route the user to OS settings?

--- a/docs/product/features/system/wifi-availability.md
+++ b/docs/product/features/system/wifi-availability.md
@@ -1,0 +1,35 @@
+# Wi-Fi availability
+
+**Area:** System integration
+**Status:** `idea`
+**GitHub Issues:** _tbd_
+
+---
+
+> Stub. Captures the gap. Flesh out before the feature enters a sprint.
+
+## Why
+
+Tether is local-first: every capability — discovery, pairing, transfer — depends on the device being on a Wi-Fi network. When Wi-Fi is off, none of it works. Today the app would silently show the empty "Searching for devices…" state, which is misleading: nothing is being searched, the network is simply absent.
+
+The user must understand that the cause of "nothing is happening" is "Wi-Fi is off" — not a Tether bug, not an empty room, not a slow network. One quick toggle in the OS shade and it works again. Tether's job is to make that obvious.
+
+## What it does (sketch)
+
+- Detects the current network state: Wi-Fi on with a network, Wi-Fi off, no network at all (e.g. ethernet-only desktop).
+- Surfaces a clear, distinguishable message in places that depend on the network — primarily the [device list](../device-list.md), but also pre-flight on transfer and pairing screens.
+- The message is short and actionable: "Wi-Fi is off — turn it on to find devices nearby." Not a generic "no connection" toast.
+- When the user turns Wi-Fi back on, the app recovers without needing a manual restart.
+
+## Not in this feature
+
+- Wi-Fi credentials, network selection, captive portals — Tether does not manage networks, only reacts to their state.
+- Cellular / mobile-data fallback — out by design, see [vision.md](../../vision.md): "If the LAN can't carry it, we say so honestly."
+- Internet connectivity check — Tether is local; reaching the internet is not relevant.
+- Ethernet-only desktop as a usable transport — open question, see below. For now Tether's surface is Wi-Fi.
+
+## Open product questions
+
+- **Ethernet-only desktop.** A Mac or Windows tower on Ethernet without Wi-Fi *can* host mDNS and Tether on the LAN — so technically it works. Do we say "Wi-Fi is off" anyway (lying, but consistent), say "no network" (vague), or detect Ethernet and say nothing (correct, but adds platform-specific code)?
+- **Recovery latency.** When Wi-Fi flicks back on, how fast does the device list repopulate — instantly, or after the next mDNS scan tick? User-visible.
+- **Transient drops mid-transfer.** Wi-Fi briefly disappearing during a transfer is a different surface — covered by transfer-failure UX in [file-transfer.md](../file-transfer.md), not here.


### PR DESCRIPTION
## Summary

Apply the «one feature = one user-visible product capability» rule, just landed in #56, to a new gap: Wi-Fi availability. Result is a small refactor of the feature index.

- Wi-Fi off, permission prompts and similar app-system concerns are **small distinct features**, not one umbrella — they share an *area* but not a story. Group them in a [`system/`](docs/product/features/system/) subfolder so the top-level index stays readable.
- Rename `permissions-strategy.md` → [`system/permissions.md`](docs/product/features/system/permissions.md). Narrow scope back to actual grants (Local Network, READ_MEDIA_*). Foreground service moves to `file-transfer`'s territory (lifecycle); Desktop firewall drops out as a per-feature platform note.
- Add [`system/wifi-availability.md`](docs/product/features/system/wifi-availability.md) (stub): Wi-Fi off / network unreachable, treated as a system *state* (distinct from permissions, which are *grants*).
- [`features/README.md`](docs/product/features/README.md) gets a «System integration» subsection.

No issues filed yet — both stubs will get tickets when they enter a sprint.

## Test plan

- [x] Docs only.
- [x] Pre-push hook (`allTests`) is green.