### PR TITLE
#51: ADR for presentation layer architecture (Decompose)

### DIFF
--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -9,6 +9,13 @@ Product-side docs (vision, audience, features) live in [`docs/product/`](../prod
 - [Architecture Principles](architecture-principles.md) — Clean Architecture as a principle, not dogma. What we follow and what we explicitly skip.
 - [Modules](modules.md) — current monolith, target module split, and the triggers that move a piece of code into its own module.
 - [Dependency Injection](dependency-injection.md) — DI strategy now (manual composition root) and later (Metro). Concrete rules for new code.
+- [Presentation Layer](presentation-layer.md) — Decompose-based components; how to write them, subscribe from Compose, and test.
+
+## Architecture Decision Records
+
+ADRs in [`adr/`](adr/) capture the *why* behind one-time architectural choices. Living docs above; ADRs are append-only history.
+
+- [Presentation & Navigation](adr/adr-presentation-and-navigation.md) — chose Decompose over Voyager / custom thin layer / Compose Navigation MP / Premo.
 
 ## For the AI agent / contributor
 

--- a/docs/engineering/adr/adr-presentation-and-navigation.md
+++ b/docs/engineering/adr/adr-presentation-and-navigation.md
@@ -1,0 +1,220 @@
+# Presentation & Navigation Architecture (ADR)
+
+**Status:** Accepted — 2026-05-07
+**Issue:** #51
+**Blocks:** #7, #8, #11
+
+This ADR fixes how presentation logic and navigation are structured in Tether across Android, iOS, Desktop JVM, and macOS native. It supersedes the "Decompose is deferred" note in [architecture-principles.md](../architecture-principles.md).
+
+## Context
+
+Tether is a Compose Multiplatform app. Today `commonMain/App.kt` holds the project-template button — there are zero product screens. Several UI tasks are queued in parallel:
+
+- #7 — Android device list
+- #8 — Android send + progress
+- #11 — Android pairing UI
+- iOS / Desktop / macOS counterparts of all of the above (currently *tbd*)
+
+Each of those tasks would otherwise have to answer the same architectural question on its own: **what is the ViewModel-equivalent, and how does navigation work across all four targets?** If the answer crystallizes inside the first UI task, it forms around one screen on one platform, and every later screen inherits accidental constraints. We fix it here, before the first product screen exists, so it can be validated against device list / send-with-progress / pairing dialog / UIKit entry points *simultaneously*.
+
+### Constraints
+
+- **Four targets:** Android, iOS, Desktop JVM, macOS native.
+- **Single UI codebase.** Compose-MP is the rendering layer everywhere; we will not maintain a parallel SwiftUI tree.
+- **Android config-change survival** is required.
+- **iOS UIKit integration** is plausible — share sheet, file pickers, document camera. The presentation layer must let a UIKit entry point drive the same state holder a Compose screen drives.
+- **Existing DI shape.** Composition happens in `AppGraph` (see [dependency-injection.md](../dependency-injection.md)). Components receive collaborators via constructor; presentation must keep that style.
+
+## Decision drivers
+
+| Criterion | Why it matters |
+|---|---|
+| KMP coverage | All four targets must be first-class. |
+| Back stack semantics | Multi-step flows (device list → send → progress) need a real stack with predictable back/up behaviour. |
+| Android config-change survival | Required (rotation, dark/light theme, locale). |
+| UIKit interop | Some iOS flows enter from native UI (share sheet) and must drive the same state holder. |
+| Testability without Compose | Presentation logic should be testable as plain Kotlin in `commonTest`. |
+| Fit with `AppGraph` constructor DI | Components must take dependencies via constructor, not look them up. |
+| Maturity | This is a load-bearing choice; replacing it later is expensive. |
+
+### Validation scenarios
+
+Each option below is judged against the same five scenarios:
+
+1. **Device list.** Subscribe to `Flow<List<Device>>` from discovery; lifecycle of that subscription is tied to the screen.
+2. **Send + progress.** Long-running operation; state survives Android rotation.
+3. **Pairing dialog.** Modal overlay on top of another screen; back press closes the dialog, not the screen behind it.
+4. **Back from active transfer.** Intercept back press, show a confirmation dialog before discarding the transfer.
+5. **iOS share sheet.** Native UIKit entry point hands a payload to the presentation layer.
+
+## Considered options
+
+### 1. Decompose (chosen)
+
+[Decompose](https://github.com/arkivanov/Decompose) is a KMP library for component-based architecture. A Component is a plain Kotlin class with explicit lifecycle, state holder, and child navigation. UI (Compose, SwiftUI, or UIKit) is a thin renderer that subscribes to the Component's `Value<State>`.
+
+- **Targets:** all four (`androidTarget`, `iosArm64`, `iosX64`, `iosSimulatorArm64`, `jvm`, `macosArm64`, `macosX64`). Decompose's core has no Compose dependency.
+- **Back stack:** first-class via `ChildStack` / `StackNavigation`. Push/pop/replace/deep-link.
+- **Config-change survival:** `StateKeeper` (saved state) + `InstanceKeeper` (retained objects, ViewModel-style). Hooked into `AppCompatActivity` on Android.
+- **UIKit interop:** the Component is UI-agnostic. A UIKit entry point can call Component methods directly without going through Compose first.
+- **Testability:** Components are constructed with fakes; tests assert on `Value<State>` snapshots. No Compose runtime needed.
+- **DI fit:** native — Components take a `ComponentContext` plus their collaborators via constructor. The composition root creates the root Component fully wired.
+- **Maturity:** v3.x stable, actively maintained by Arkadii Ivanov, used in production at multiple JetBrains-adjacent projects.
+
+**Cost:** new primitives every contributor must learn (`ComponentContext`, `ChildStack`, `Value`, `StateKeeper`, `InstanceKeeper`); a one-screen feature still needs a Component, a Composable, and a wire-up at the root.
+
+**How it handles the scenarios:**
+
+1. Device list — `coroutineScope()` extension binds the discovery `collect` to component lifetime; cancelled on destroy.
+2. Send + progress — transfer state lives in an `AppGraph` repository, not in the Component. The send Component observes the repository; rotation rebuilds the Component, the transfer keeps running.
+3. Pairing dialog — `ChildSlot` overlay; its own back handler closes the slot before the screen.
+4. Back from transfer — Component reads "is anything in progress?" from the AppGraph repository and registers a `BackHandler` accordingly to show a confirmation.
+5. iOS share sheet — `RootComponent.onSharedFile(uri)` is called from the UIViewController code path.
+
+### 2. Voyager
+
+[Voyager](https://github.com/adrielcafe/voyager) is a Compose-only navigation library: Screens are Composables with attached ScreenModels.
+
+- **Targets:** all Compose-MP targets, but logic is Compose-coupled.
+- **Back stack:** built-in `Navigator` API.
+- **Config-change survival:** ScreenModels are retained; `SavedStateHandle` integration on Android.
+- **UIKit interop:** limited to what Compose-MP gives you (a single root `UIViewController`). A UIKit-side entry point cannot drive a Voyager Screen without going through Compose first.
+- **Testability:** ScreenModels are testable, but their lifecycle is owned by the hosting Composable, which couples test setup to Compose fixtures.
+- **DI fit:** acceptable — `getScreenModel { ... }` accepts constructor args, but the canonical pattern leans on a service-locator, fighting `AppGraph`'s "no global lookups" rule.
+- **Maturity:** stable, popular, smaller maintainer team and slower release cadence than Decompose.
+
+**Why not chosen:** the UIKit blind spot is decisive. The native iOS pickers / share sheet path is plausible from day one (see `docs/product/features/file-transfer.md` and `pairing.md`). With Voyager, that path forces a parallel non-Voyager state holder for the native side — exactly the fork the ADR is meant to prevent.
+
+### 3. Thin custom layer (StateFlow + rememberSaveable + manual nav)
+
+A hand-rolled approach: `class FooViewModel(scope: CoroutineScope, ...)` exposing `StateFlow<FooState>`, screens picked by a top-level `sealed class Screen`, back stack as a `List<Screen>` in a saveable.
+
+- **Targets:** all, trivially.
+- **Back stack:** ours to build. Realistic for two screens; gets expensive once nested flows, dialogs, and deep links appear.
+- **Config-change survival:** `rememberSaveable` covers `Bundle`-serializable state; long-running ViewModels need their own retention plumbing (custom `ViewModelStoreOwner` or accept loss).
+- **UIKit interop:** trivial — `StateFlow` is platform-agnostic.
+- **Testability:** excellent.
+- **DI fit:** native — constructor injection is the only style.
+- **Maturity:** the code we write is exactly as mature as we make it.
+
+**Why not chosen:** the absent pieces — back stack semantics, state restoration, deep linking, lifecycle hooks — are precisely what a navigation library provides. Re-implementing them would dominate the next two sprints and lock in macOS-native trade-offs before we know what they should be.
+
+### 4. Compose Navigation Multiplatform (AndroidX Navigation, KMP port)
+
+The AndroidX Navigation Compose library, recently extended to non-Android KMP targets (2.8.x+).
+
+- **Targets:** Android stable; iOS / Desktop in beta; macOS native unverified.
+- **Back stack:** native AndroidX Nav semantics.
+- **Config-change survival:** `ViewModelStoreOwner` integration on Android; less clear on iOS.
+- **UIKit interop:** none — Compose-only.
+- **DI fit:** ViewModel factories work, but the Android-leaning lifecycle assumptions (e.g., `SavedStateHandle` semantics) leak into common code.
+- **Maturity on non-Android:** the non-Android KMP support is recent; macOS native is the platform with the least track record.
+
+**Why not chosen:** same UIKit blind spot as Voyager, plus the non-Android maturity story is years behind Decompose. Worth re-evaluating once iOS / macOS support stabilises.
+
+### 5. Premo
+
+[Premo](https://github.com/dmdevgo/Premo) is a KMP library implementing the Presentation Model pattern (Martin Fowler). `PresentationModel` is the state holder + lifecycle owner; navigation is a separate `premo-navigation` module with `StackNavigator`, `SetNavigator`, `MasterDetailNavigator`, and `DialogNavigator`. The library is intentionally UI-agnostic — the official sample drives the same PMs from Compose-MP, SwiftUI, UIKit, and React.
+
+- **Targets:** Android, iOS (X64 / Arm64 / SimulatorArm64), JVM, JS, wasmJs. **macOS native is not configured** in Premo's Kotlin Multiplatform setup — adopting it would mean forking or upstreaming the target.
+- **Back stack:** built-in via `StackNavigator`; siblings cover tabs, dialogs, master-detail.
+- **Config-change survival + process-death restoration:** persistence is a first-class feature — PMs serialise via `PmStateHandler` and restore after process recreation. Stronger out-of-the-box than Decompose's default.
+- **UIKit interop:** PMs are pure Kotlin; native UIKit code can drive them directly. Same property as Decompose.
+- **Testability:** dedicated `premo-test` module with `runPmTest`. No Compose runtime needed.
+- **DI fit:** PMs accept `PmArgs` (serializable) and a parent reference via constructor. Compatible with `AppGraph`.
+- **Maturity:** v1.0.0-alpha.15 (May 2024), no commits since, single maintainer, ~200 stars. README explicitly warns: *"the library is in the pre-release alpha version. Stable work and backward compatibility are not guaranteed."* No stable release in five years.
+
+**Why not chosen:** two blocking issues. (1) **macOS native is not supported** by the library's KMP configuration — and macOS native is one of our four required targets. (2) **Pre-release alpha + ~2 years of no commits + single maintainer** make this a risky bet for a load-bearing layer. The good ideas in Premo — process-death persistence as a first-class concern, parent-intercepts-navigation messaging — are noted as inspiration when extending the Decompose-based layer.
+
+## Decision
+
+**Tether adopts [Decompose](https://github.com/arkivanov/Decompose) as the presentation framework across all four targets.**
+
+The pattern:
+
+```kotlin
+// commonMain — pure presentation, no Compose
+class DeviceListComponent(
+    componentContext: ComponentContext,
+    private val discovery: MdnsDiscovery,
+    coroutineScope: CoroutineScope = componentContext.coroutineScope(),
+) : ComponentContext by componentContext {
+
+    private val _state = MutableValue(DeviceListState.empty())
+    val state: Value<DeviceListState> = _state
+
+    init {
+        coroutineScope.launch { discovery.devices.collect { _state.update { ... } } }
+    }
+
+    fun onDeviceClicked(id: DeviceId) { /* ... */ }
+}
+
+// commonMain — Compose UI, thin
+@Composable
+fun DeviceList(component: DeviceListComponent) {
+    val state by component.state.subscribeAsState()
+    // render state, forward events to component
+}
+
+// platform entry point (jvmMain / androidMain / iosMain / macosMain)
+val root = DefaultRootComponent(
+    componentContext = defaultComponentContext(),
+    appGraph = appGraph,
+)
+setContent { RootContent(root) }
+```
+
+Shape rules:
+
+- **Components are plain Kotlin** — they take their dependencies and a `ComponentContext` via constructor. No globals, no service locators.
+- **Naming follows Decompose** — classes are `XxxComponent`, not `XxxViewModel`. They are not Android `ViewModel`s; the difference matters for tests, lifecycle, and KMP.
+- **CoroutineScope is a default constructor argument** wired to the library's `coroutineScope()` extension on `ComponentContext`. Lifecycle-bound by default; tests pass an injected `TestScope` instead.
+- **`AppGraph` builds the root Component**; child Components are created by their parents (or by a `ChildStack` configuration).
+- **Compose subscribes via `subscribeAsState`** and forwards events as method calls. No `LaunchedEffect`-driven business logic.
+- **`ChildStack` for the main back stack**, **`ChildSlot` for modal overlays** (pairing dialog, confirmations).
+- **One Component per logical screen / dialog.** Sub-state inside a screen stays inside the Component; we don't split presentation into ceremonial layers.
+- **Long-lived domain state stays out of Components.** Active transfers, peer state, and other state that must outlive a screen live in repositories owned by `AppGraph`. Components observe these repositories; they never own such state and do not use `InstanceKeeper` for it.
+
+## Consequences
+
+**Positive:**
+
+- Presentation logic is testable as plain Kotlin in `commonTest` — no Compose runtime, no Robolectric.
+- Back stack, lifecycle, and state restoration come from a maintained library instead of from us.
+- iOS UIKit integration is on the table from day one; share-sheet / native pickers don't force a rewrite.
+- DI shape (`AppGraph` + constructor injection) generalises naturally — Components are constructor-injected like everything else.
+- Per-screen scope question from [dependency-injection.md](../dependency-injection.md) is answered: long-lived domain state stays in `AppGraph` repositories; Components own only screen-local view state (and only for as long as the screen lives). `AppGraph` stays singleton.
+
+**Negative / cost:**
+
+- Every contributor must learn Decompose's primitives (`ComponentContext`, `ChildStack`, `Value`, `StateKeeper`, `InstanceKeeper`).
+- One-screen features still carry the Component / Composable / wire-up split — small ceremony tax.
+- `ChildStack` configurations must be `@Serializable` (kotlinx.serialization) — a tiny constraint on what state goes into route arguments.
+- Locks us into a third-party library at a load-bearing layer. Mitigated by Decompose's maturity and the fact that Components are isolated from UI — swapping the navigation framework later would not require rewriting screens.
+
+**Effects on existing decisions:**
+
+- [architecture-principles.md](../architecture-principles.md) is updated: the "Decompose is deferred" line becomes a pointer to this ADR.
+- The composition-root sketch in [dependency-injection.md](../dependency-injection.md) extends to `RootComponent` construction; nothing in the existing rules changes.
+- `App.kt` (the template button) will be replaced by the skeleton task that follows this ADR. That task adds the `decompose` dependency to `composeApp/build.gradle.kts`. **Out of scope here.**
+
+## Per-platform feasibility
+
+| Platform | Status | Notes |
+|---|---|---|
+| Android | ✅ Supported | `AppCompatActivity` integration via `defaultComponentContext()`; `StateKeeper` + `InstanceKeeper` covered. |
+| iOS | ✅ Supported | `MainViewController` builds the root Component; UIKit entry points call Component methods directly. |
+| Desktop JVM | ✅ Supported | `LifecycleRegistry()` driven by the Compose window. |
+| macOS native | ✅ Supported | Decompose's core is pure Kotlin and supports `macosArm64` / `macosX64`. UI rendering is a separate concern (Compose-MP for macOS) and is out of scope for this ADR. |
+
+## Open questions
+
+1. **`ChildStack` vs flat root.** First iteration may not need a back stack at all — a single root Component with `ChildSlot` overlays may be enough. Decide concretely once device list and pairing are both implemented.
+
+## References
+
+- [Decompose documentation](https://arkivanov.github.io/Decompose/)
+- [architecture-principles.md](../architecture-principles.md)
+- [dependency-injection.md](../dependency-injection.md)
+- [modules.md](../modules.md)

--- a/docs/engineering/adr/adr-presentation-and-navigation.md
+++ b/docs/engineering/adr/adr-presentation-and-navigation.md
@@ -61,7 +61,7 @@ Each option below is judged against the same five scenarios:
 - **DI fit:** native — Components take a `ComponentContext` plus their collaborators via constructor. The composition root creates the root Component fully wired.
 - **Maturity:** v3.x stable, actively maintained by Arkadii Ivanov, used in production at multiple JetBrains-adjacent projects.
 
-**Cost:** new primitives every contributor must learn (`ComponentContext`, `ChildStack`, `Value`, `StateKeeper`, `InstanceKeeper`); a one-screen feature still needs a Component, a Composable, and a wire-up at the root.
+**Cost:** new primitives every contributor must learn (`ComponentContext`, `ChildStack`, `Value`, `StateKeeper`); a one-screen feature still needs a Component, a Composable, and a wire-up at the root.
 
 **How it handles the scenarios:**
 
@@ -122,7 +122,7 @@ The AndroidX Navigation Compose library, recently extended to non-Android KMP ta
 - **UIKit interop:** PMs are pure Kotlin; native UIKit code can drive them directly. Same property as Decompose.
 - **Testability:** dedicated `premo-test` module with `runPmTest`. No Compose runtime needed.
 - **DI fit:** PMs accept `PmArgs` (serializable) and a parent reference via constructor. Compatible with `AppGraph`.
-- **Maturity:** v1.0.0-alpha.15 (May 2024), no commits since, single maintainer, ~200 stars. README explicitly warns: *"the library is in the pre-release alpha version. Stable work and backward compatibility are not guaranteed."* No stable release in five years.
+- **Maturity:** v1.0.0-alpha.15 (May 2024), no commits since May 2024, single maintainer, ~200 stars. README explicitly warns: *"the library is in the pre-release alpha version. Stable work and backward compatibility are not guaranteed."* No stable release in five years.
 
 **Why not chosen:** two blocking issues. (1) **macOS native is not supported** by the library's KMP configuration — and macOS native is one of our four required targets. (2) **Pre-release alpha + ~2 years of no commits + single maintainer** make this a risky bet for a load-bearing layer. The good ideas in Premo — process-death persistence as a first-class concern, parent-intercepts-navigation messaging — are noted as inspiration when extending the Decompose-based layer.
 
@@ -158,7 +158,7 @@ fun DeviceList(component: DeviceListComponent) {
 }
 
 // platform entry point (jvmMain / androidMain / iosMain / macosMain)
-val root = DefaultRootComponent(
+val root = RootComponent(
     componentContext = defaultComponentContext(),
     appGraph = appGraph,
 )
@@ -172,7 +172,7 @@ Shape rules:
 - **CoroutineScope is a default constructor argument** wired to the library's `coroutineScope()` extension on `ComponentContext`. Lifecycle-bound by default; tests pass an injected `TestScope` instead.
 - **`AppGraph` builds the root Component**; child Components are created by their parents (or by a `ChildStack` configuration).
 - **Compose subscribes via `subscribeAsState`** and forwards events as method calls. No `LaunchedEffect`-driven business logic.
-- **`ChildStack` for the main back stack**, **`ChildSlot` for modal overlays** (pairing dialog, confirmations).
+- **Start with a single root Component and `ChildSlot` for modal overlays** (pairing dialog, confirmations). Add **`ChildStack`** when the first explicit back-press flow lands (likely send + progress).
 - **One Component per logical screen / dialog.** Sub-state inside a screen stays inside the Component; we don't split presentation into ceremonial layers.
 - **Long-lived domain state stays out of Components.** Active transfers, peer state, and other state that must outlive a screen live in repositories owned by `AppGraph`. Components observe these repositories; they never own such state and do not use `InstanceKeeper` for it.
 
@@ -188,9 +188,10 @@ Shape rules:
 
 **Negative / cost:**
 
-- Every contributor must learn Decompose's primitives (`ComponentContext`, `ChildStack`, `Value`, `StateKeeper`, `InstanceKeeper`).
+- Every contributor must learn Decompose's primitives (`ComponentContext`, `ChildStack`, `Value`, `StateKeeper`).
 - One-screen features still carry the Component / Composable / wire-up split — small ceremony tax.
 - `ChildStack` configurations must be `@Serializable` (kotlinx.serialization) — a tiny constraint on what state goes into route arguments.
+- **Process-death state restoration is shallower than Premo's first-class story** — full restoration takes more wiring on top of `StateKeeper`. Acceptable for Tether: flows are short-lived enough that a killed process means a fresh start. Revisit if persistence requirements emerge.
 - Locks us into a third-party library at a load-bearing layer. Mitigated by Decompose's maturity and the fact that Components are isolated from UI — swapping the navigation framework later would not require rewriting screens.
 
 **Effects on existing decisions:**
@@ -207,10 +208,6 @@ Shape rules:
 | iOS | ✅ Supported | `MainViewController` builds the root Component; UIKit entry points call Component methods directly. |
 | Desktop JVM | ✅ Supported | `LifecycleRegistry()` driven by the Compose window. |
 | macOS native | ✅ Supported | Decompose's core is pure Kotlin and supports `macosArm64` / `macosX64`. UI rendering is a separate concern (Compose-MP for macOS) and is out of scope for this ADR. |
-
-## Open questions
-
-1. **`ChildStack` vs flat root.** First iteration may not need a back stack at all — a single root Component with `ChildSlot` overlays may be enough. Decide concretely once device list and pairing are both implemented.
 
 ## References
 

--- a/docs/engineering/architecture-principles.md
+++ b/docs/engineering/architecture-principles.md
@@ -12,7 +12,7 @@ Concretely, this gives us a layering — from most stable to most volatile:
 
 1. **Protocol / domain.** Pure Kotlin types and rules — what gets exchanged between devices and what's true about them. No platform, no framework. Changes when the network protocol or core domain rules change.
 2. **Network / discovery / platform.** Transport, peer discovery, platform adapters. Depends on (1). Changes when we swap an underlying mechanism or add a target.
-3. **Presentation.** ViewModels and the navigation graph. Depends on (2) through interfaces, not concretes. Owns UI state shape but not visual rendering.
+3. **Presentation.** Components (Decompose) and the navigation graph. Depends on (2) via constructor injection. Owns UI state shape but not visual rendering.
 4. **UI.** Compose composables. The thinnest layer — renders state, fires events. Treated as replaceable.
 
 **Dependencies always point toward more stable code.** UI depends on the discovery interface. Discovery does not depend on UI. Protocol depends on nothing in this project except kotlinx.serialization.
@@ -42,7 +42,7 @@ When refactoring existing code, the same questions apply in reverse: a layer tha
 
 - Components that create their own collaborators (`HttpClient()` inside `FileClient`). Breaks testability and lifecycle. Fixed by constructor injection — see [dependency-injection.md](dependency-injection.md).
 - Platform context (`TetherApp.context`) reached for from inside discovery/network code. Pushes platform details across layers. Fixed by passing what's needed explicitly into the platform-specific `actual`.
-- UI directly orchestrating discovery + networking. Drag-bottom layer concerns into the most volatile one. Fixed by an `AppGraph` composition root that wires lifecycle, and a thin view-model surface for UI.
+- UI directly orchestrating discovery + networking. Drag-bottom layer concerns into the most volatile one. Fixed by an `AppGraph` composition root that wires lifecycle, and a thin Component surface for UI (see [presentation-layer.md](presentation-layer.md)).
 
 ## Decisions
 

--- a/docs/engineering/architecture-principles.md
+++ b/docs/engineering/architecture-principles.md
@@ -46,7 +46,7 @@ When refactoring existing code, the same questions apply in reverse: a layer tha
 
 ## Decisions
 
-- **ViewModel lives in its own layer** between UI and the layers below it. Reason: keep Compose as a thin, replaceable UI framework — when we eventually adopt [Decompose](https://github.com/arkivanov/Decompose) for navigation and component lifecycle, the presentation layer is already isolated and the change is contained. Decompose itself is deferred until the screen count justifies it.
+- **Presentation layer is built on [Decompose](https://github.com/arkivanov/Decompose).** Components hold state and lifecycle in plain Kotlin; Compose subscribes via `subscribeAsState` and is treated as a thin, replaceable renderer. Conventions and how to write/test components: [presentation-layer.md](presentation-layer.md). Rationale, alternatives considered, and per-platform notes: [adr/adr-presentation-and-navigation.md](adr/adr-presentation-and-navigation.md).
 - **Unidirectional data flow** (state down, events up) is the default. The specific framework — MVI library, Molecule, plain Compose state — is chosen per component as it appears, not declared globally up front.
 
 ## Open questions

--- a/docs/engineering/dependency-injection.md
+++ b/docs/engineering/dependency-injection.md
@@ -192,9 +192,12 @@ Things to notice:
 - Different platforms build different graphs (Android passes `Context`, JVM also builds a `FileServer`).
 - No component in the graph reaches across to construct another.
 - `commonMain` defines the *shape* (`AppGraph` data class), platforms fill it in.
+- The platform entry point also builds the **root Component** (Decompose), passing `AppGraph` to it. The root creates its children with the dependencies they need. See [presentation-layer.md](presentation-layer.md).
+
+### Per-screen scoping
+
+`AppGraph` is a singleton. There is no separate per-screen DI scope and no `ViewModelStoreOwner` integration — per-screen state and lifecycle are owned by Decompose Components, not by an Android-style ViewModel container. Each Component receives the dependencies it needs from `AppGraph` (or from its parent Component) and constructs its children directly.
 
 ## Open questions
 
-- When we get to Phase 2, do scopes (per-screen, per-transfer) make sense, or stick to a single application graph? Decide when the first scoped need appears.
-- For per-screen view models, does Compose's `ViewModelStoreOwner` integration matter, or do we just instantiate them inside the graph? Address when 3+ screens exist.
 - iOS receive-side: when a non-Ktor `FileServer` implementation lands, the graph branches per-platform more aggressively. May be the moment to flip to Metro.

--- a/docs/engineering/modules.md
+++ b/docs/engineering/modules.md
@@ -37,7 +37,7 @@ The shape we'll move toward, in priority order:
 | `:network` | common + jvm | `:protocol` | `FileClient` (common, Ktor CIO). `FileServer` lives in the JVM source set — there is no Native Ktor server. |
 | `:platform` | all | — | `Platform` `expect` + `actual`. Tiny by design; not a kitchen sink. |
 | `:cli` | jvmMain | `:network`, `:discovery`, `:platform` | `Main.kt`, Clikt argument parsing. JVM-only. |
-| `:composeApp` | all | everything above | Compose UI, view models, entry points. |
+| `:composeApp` | all | everything above | Compose UI, Decompose Components, entry points. |
 
 The split is not about Gradle modules per se — it's about **where the dependency arrow gets enforced by the compiler instead of by good intentions.**
 

--- a/docs/engineering/presentation-layer.md
+++ b/docs/engineering/presentation-layer.md
@@ -1,0 +1,139 @@
+# Presentation Layer
+
+The presentation layer in Tether is built on [Decompose](https://github.com/arkivanov/Decompose). This document describes how it's structured and how to add to it. For the *why* — variants considered and trade-offs — see [adr/adr-presentation-and-navigation.md](adr/adr-presentation-and-navigation.md).
+
+> **Status.** The skeleton (root Component + first screen + `decompose` dependency) lands in the task that follows the ADR. The conventions below are what the skeleton installs and what every screen written after it should follow.
+
+## How it works
+
+A **Component** is a plain Kotlin class that holds the state and lifecycle of one screen (or one logical flow). Compose subscribes to the Component's state and forwards events as method calls. A Component never imports Compose; UI never owns business state.
+
+```
++-------------------+      +-----------------+      +----------------+
+|  Composable       |      |  Component      |      |  AppGraph      |
+|  DeviceList(...)  +------> state: Value    +------> repositories,  |
+|  events as calls  |      |  fun onClick()  |      |  discovery,    |
++-------------------+      +-----------------+      |  network       |
+                                                    +----------------+
+```
+
+Compose talks down to the Component. The Component talks down to `AppGraph` collaborators received via constructor — never the other way around.
+
+## Component anatomy
+
+```kotlin
+class DeviceListComponent(
+    componentContext: ComponentContext,
+    private val discovery: MdnsDiscovery,
+    coroutineScope: CoroutineScope = componentContext.coroutineScope(),
+) : ComponentContext by componentContext {
+
+    private val _state = MutableValue(DeviceListState.empty())
+    val state: Value<DeviceListState> = _state
+
+    init {
+        coroutineScope.launch {
+            discovery.devices.collect { devices ->
+                _state.update { it.copy(devices = devices) }
+            }
+        }
+    }
+
+    fun onDeviceClicked(id: DeviceId) { /* ... */ }
+}
+```
+
+Conventions:
+
+- **Naming.** Classes are `XxxComponent`. We follow Decompose's convention rather than calling them `ViewModel` — they are not Android `ViewModel`s, and the difference matters for tests, lifecycle, and KMP.
+- **`ComponentContext` first, delegated.** Every Component takes `ComponentContext` as its first parameter and `: ComponentContext by componentContext` exposes lifecycle / state-keeper / instance-keeper / back-handler without ceremony.
+- **`CoroutineScope` is a default constructor argument** wired to the library's `coroutineScope()` extension. Lifecycle-bound by default; tests pass an injected `TestScope` instead.
+- **Dependencies via constructor.** Same rule as everywhere else (see [dependency-injection.md](dependency-injection.md)). No globals, no service locators.
+
+See [Decompose: Component overview](https://arkivanov.github.io/Decompose/component/overview/) for the full primitive surface.
+
+## State and events
+
+State is exposed as `Value<T>` — a Decompose primitive analogous to `StateFlow<T>`. Mutations go through `MutableValue<T>`:
+
+```kotlin
+private val _state = MutableValue(MyState.initial())
+val state: Value<MyState> = _state
+
+_state.update { it.copy(...) }
+```
+
+Compose subscribes via `subscribeAsState`:
+
+```kotlin
+@Composable
+fun DeviceList(component: DeviceListComponent) {
+    val state by component.state.subscribeAsState()
+    Button(onClick = { component.onDeviceClicked(state.devices.first().id) }) { /* ... */ }
+}
+```
+
+Events are plain method calls on the Component. No `LaunchedEffect` business logic, no event channels through the Composable.
+
+## Long-lived state lives outside Components
+
+A Component's lifetime is bound to the screen (or flow) it represents. Anything that must outlive a screen — active file transfers, peer state, long-running connections — lives in repositories owned by `AppGraph`. Components observe these repositories via injected dependencies and never duplicate the state internally.
+
+In particular: **we do not use `InstanceKeeper` to retain domain state across configuration changes.** The repository in `AppGraph` already outlives the Activity; the Component just rebuilds and re-subscribes on rotation.
+
+## Navigation
+
+Once the screen count grows past one, navigation is handled by:
+
+- **`ChildStack`** — the back stack. Push / pop / replace, with `@Serializable` configurations.
+- **`ChildSlot`** — modal overlays. Pairing dialog, confirmations, anything that sits on top of a screen.
+
+Both are wired in a parent Component and observed in Compose via `Children { ... }` / `subscribeAsState`. The skeleton starts with a single root Component and only adds these primitives when the first multi-screen flow appears.
+
+See [Decompose: Navigation overview](https://arkivanov.github.io/Decompose/navigation/overview/).
+
+## Configuration change (Android)
+
+Decompose hooks into `AppCompatActivity` via `defaultComponentContext(...)`. When the activity is recreated on rotation, the root Component is rebuilt, but `StateKeeper` restores serializable view state and the underlying `AppGraph` repositories are untouched. No work needed in individual Components beyond putting any session-local view state through `stateKeeper.consume(...)` / `register(...)`.
+
+Process-death state restoration is **not currently a goal** — Tether's flows are short-lived enough that a killed process means a fresh start. Revisit if persistence requirements emerge.
+
+## Testing
+
+Components are testable as plain Kotlin — no Compose runtime, no Robolectric:
+
+```kotlin
+class DeviceListComponentTest {
+
+    @Test fun emits_devices_from_discovery() = runTest {
+        val discovery = FakeDiscovery()
+        val context = DefaultComponentContext(LifecycleRegistry())
+        val component = DeviceListComponent(
+            componentContext = context,
+            discovery = discovery,
+            coroutineScope = backgroundScope,
+        )
+
+        discovery.emit(listOf(deviceA, deviceB))
+        runCurrent()
+
+        assertEquals(listOf(deviceA, deviceB), component.state.value.devices)
+    }
+}
+```
+
+Patterns:
+
+- Construct with `DefaultComponentContext(LifecycleRegistry())` — the registry becomes the test's lifecycle handle. Drive lifecycle transitions with `lifecycle.resume()` / `destroy()` when the test depends on them.
+- Inject the test's `backgroundScope` (or a `TestScope`) as `coroutineScope` so coroutines run under the test dispatcher.
+- Use **fakes**, not mocks of `HttpClient` / `MdnsDiscovery` (see [dependency-injection.md](dependency-injection.md)).
+- Assert against `component.state.value` snapshots, or capture emissions via `Value.subscribe { ... }` for sequences.
+- Common-test placement: presentation tests live in `commonTest` because the Component itself is `commonMain`.
+
+## References
+
+- [Decompose documentation](https://arkivanov.github.io/Decompose/)
+- [Decompose: Component overview](https://arkivanov.github.io/Decompose/component/overview/)
+- [Decompose: Navigation overview](https://arkivanov.github.io/Decompose/navigation/overview/)
+- [Decompose: State preservation](https://arkivanov.github.io/Decompose/component/state-preservation/)
+- ADR: [adr/adr-presentation-and-navigation.md](adr/adr-presentation-and-navigation.md)

--- a/docs/engineering/presentation-layer.md
+++ b/docs/engineering/presentation-layer.md
@@ -46,7 +46,7 @@ class DeviceListComponent(
 Conventions:
 
 - **Naming.** Classes are `XxxComponent`. We follow Decompose's convention rather than calling them `ViewModel` — they are not Android `ViewModel`s, and the difference matters for tests, lifecycle, and KMP.
-- **`ComponentContext` first, delegated.** Every Component takes `ComponentContext` as its first parameter and `: ComponentContext by componentContext` exposes lifecycle / state-keeper / instance-keeper / back-handler without ceremony.
+- **`ComponentContext` first, delegated.** Every Component takes `ComponentContext` as its first parameter and `: ComponentContext by componentContext` exposes lifecycle, `StateKeeper`, `InstanceKeeper`, and `BackHandler` without ceremony.
 - **`CoroutineScope` is a default constructor argument** wired to the library's `coroutineScope()` extension. Lifecycle-bound by default; tests pass an injected `TestScope` instead.
 - **Dependencies via constructor.** Same rule as everywhere else (see [dependency-injection.md](dependency-injection.md)). No globals, no service locators.
 
@@ -83,12 +83,12 @@ In particular: **we do not use `InstanceKeeper` to retain domain state across co
 
 ## Navigation
 
-Once the screen count grows past one, navigation is handled by:
+Decompose provides two navigation primitives we use, introduced one at a time as flows require them:
 
-- **`ChildStack`** — the back stack. Push / pop / replace, with `@Serializable` configurations.
-- **`ChildSlot`** — modal overlays. Pairing dialog, confirmations, anything that sits on top of a screen.
+- **`ChildSlot`** — modal overlays (dialogs, confirmations, anything that sits on top of a screen). Added when the first dialog lands — e.g. the pairing dialog (#11).
+- **`ChildStack`** — back stack with push / pop / replace; configurations are `@Serializable`. Added when the first explicit back-press flow lands — likely send + progress on top of device list (#8).
 
-Both are wired in a parent Component and observed in Compose via `Children { ... }` / `subscribeAsState`. The skeleton starts with a single root Component and only adds these primitives when the first multi-screen flow appears.
+Both are wired in a parent Component and observed in Compose via `Children { ... }` / `subscribeAsState`. The skeleton itself starts with a single root Component; primitives are added incrementally.
 
 See [Decompose: Navigation overview](https://arkivanov.github.io/Decompose/navigation/overview/).
 


### PR DESCRIPTION
## Summary

- New ADR [`docs/engineering/adr/adr-presentation-and-navigation.md`](docs/engineering/adr/adr-presentation-and-navigation.md) — chooses **Decompose** as the presentation framework across all four targets, after comparing it against Voyager, a thin custom layer (StateFlow + rememberSaveable), Compose Navigation Multiplatform, and Premo on seven criteria and five validation scenarios (device list / send + progress / pairing dialog / back-from-transfer / iOS share sheet).
- New practical [`docs/engineering/presentation-layer.md`](docs/engineering/presentation-layer.md) — how Components are written and tested in this project. Captures the conventions decided during review: `XxxComponent` naming, `coroutineScope: CoroutineScope = componentContext.coroutineScope()` as a default constructor arg, and long-lived domain state lives in `AppGraph` repositories, not in Components / `InstanceKeeper`.
- Engineering [`README.md`](docs/engineering/README.md) gains a separate **Architecture Decision Records** section pointing at `adr/`.
- [`architecture-principles.md`](docs/engineering/architecture-principles.md) no longer marks Decompose as deferred — link now resolves to the practical doc and the ADR.

Out of scope (next sprint): the skeleton task — root Component + first screen + `decompose` Gradle dependency. The ADR and practical doc both flag this explicitly.

Closes #51. Unblocks #7, #8, #11.

## Test plan

- [x] Docs-only change, no code touched.
- [x] `./gradlew allTests -q` — green.
- [x] Pre-push hook (`allTests` + `ktlintFormat`) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)