### PR TITLE
#52: CLI stdin command loop — send, list, quit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,23 @@ Before making commits, identify the relevant GitHub issue. If no issue exists fo
 curl http://localhost:{port}/health  # → "Tether OK"
 ```
 
+Once the runner is up, it reads commands from stdin:
+
+| Command | Description |
+|---------|-------------|
+| `list` | Print currently discovered peers |
+| `send <peer-name> <path>` | Send a file to the named peer; prints live progress and a final OK/FAIL line |
+| `quit` | Stop FileServer + mDNS and exit |
+
+```
+send Phone /tmp/photo.jpg
+[send] 12.3 MB / 50.0 MB  (3.4 MB/s)
+[send] OK — 14523 ms  →  /tmp/tether-downloads/photo.jpg
+```
+
+- Peers are matched by `Device.name`; if multiple peers share a name the first is used (warning printed to stderr).
+- Unknown commands, empty lines, missing file, or missing peer all produce a message and return to the prompt without killing the runner.
+
 **Android APK**
 ```bash
 ./gradlew :composeApp:assembleDebug

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
@@ -35,8 +35,8 @@ class FileClient : Closeable {
         device: Device,
         channel: ByteReadChannel,
         fileName: String,
-        totalBytes: Long = -1L,
-        onProgress: ((bytesTransferred: Long, totalBytes: Long) -> Unit)? = null,
+        totalBytes: Long? = null,
+        onProgress: ((bytesTransferred: Long, totalBytes: Long?) -> Unit)? = null,
     ): SendResult = if (onProgress == null) {
         doSend(device, channel, fileName)
     } else {
@@ -81,8 +81,8 @@ private const val COPY_BUFFER_SIZE = 8 * 1024
 private suspend fun copyWithProgress(
     source: ByteReadChannel,
     dest: ByteChannel,
-    totalBytes: Long,
-    onProgress: (Long, Long) -> Unit,
+    totalBytes: Long?,
+    onProgress: (Long, Long?) -> Unit,
 ) {
     val buf = ByteArray(COPY_BUFFER_SIZE)
     var transferred = 0L

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
@@ -13,8 +13,13 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteChannel
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.core.Closeable
+import io.ktor.utils.io.readAvailable
+import io.ktor.utils.io.writeFully
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 
 class FileClient : Closeable {
     private val client = HttpClient(CIO) {
@@ -26,7 +31,34 @@ class FileClient : Closeable {
         throw NotImplementedError("ping() is not yet implemented")
     }
 
-    suspend fun send(device: Device, channel: ByteReadChannel, fileName: String): SendResult = try {
+    suspend fun send(
+        device: Device,
+        channel: ByteReadChannel,
+        fileName: String,
+        totalBytes: Long = -1L,
+        onProgress: ((bytesTransferred: Long, totalBytes: Long) -> Unit)? = null,
+    ): SendResult = if (onProgress == null) {
+        doSend(device, channel, fileName)
+    } else {
+        // Launch the copy into a pipe concurrently with the Ktor upload so that
+        // Ktor reads from the pipe while we are filling it. coroutineScope waits
+        // for the copy job after the Ktor call returns.
+        coroutineScope {
+            val pipe = ByteChannel(autoFlush = true)
+            launch { copyWithProgress(channel, pipe, totalBytes, onProgress) }
+            doSend(device, pipe, fileName)
+        }
+    }
+
+    override fun close() {
+        client.close()
+    }
+
+    private suspend fun doSend(
+        device: Device,
+        channel: ByteReadChannel,
+        fileName: String,
+    ): SendResult = try {
         val response = client.post("http://${device.host}:${device.port}/upload") {
             parameter("name", fileName)
             contentType(ContentType.Application.OctetStream)
@@ -42,8 +74,28 @@ class FileClient : Closeable {
     } catch (e: Exception) {
         SendResult.Failure(e.message ?: "unknown error")
     }
+}
 
-    override fun close() {
-        client.close()
+private const val COPY_BUFFER_SIZE = 8 * 1024
+
+private suspend fun copyWithProgress(
+    source: ByteReadChannel,
+    dest: ByteChannel,
+    totalBytes: Long,
+    onProgress: (Long, Long) -> Unit,
+) {
+    val buf = ByteArray(COPY_BUFFER_SIZE)
+    var transferred = 0L
+    try {
+        while (!source.isClosedForRead) {
+            val read = source.readAvailable(buf)
+            if (read > 0) {
+                dest.writeFully(buf, 0, read)
+                transferred += read
+                onProgress(transferred, totalBytes)
+            }
+        }
+    } finally {
+        dest.close()
     }
 }

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import java.io.IOException
 import java.nio.file.Path
-import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.io.path.exists
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeSource
@@ -71,30 +70,33 @@ class TetherCommand :
 
         val fileClient = FileClient()
 
-        // cleanup() stops JmDNS/Ktor threads so the JVM can exit. AtomicBoolean
-        // prevents double-close when quit calls it explicitly and the shutdown hook
-        // fires afterwards (or on Ctrl+C alone).
-        val cleanedUp = AtomicBoolean(false)
-
-        fun cleanup() {
-            if (!cleanedUp.compareAndSet(false, true)) return
-            try {
-                discovery.stop()
-            } catch (e: Exception) {
-                System.err.println("WARN: mDNS stop failed — ${e.message}")
-            }
-            try {
-                server.stop()
-            } catch (e: Exception) {
-                System.err.println("WARN: FileServer stop failed — ${e.message}")
-            }
-            try {
-                fileClient.close()
-            } catch (e: Exception) {
-                System.err.println("WARN: FileClient close failed — ${e.message}")
-            }
-        }
-        Runtime.getRuntime().addShutdownHook(Thread { cleanup() })
+        // Shutdown hook runs cleanup in a thread with a 2 s timeout so JmDNS
+        // can send goodbye packets but never blocks the JVM exit indefinitely.
+        // After all hooks finish the JVM halts and kills any remaining threads.
+        Runtime.getRuntime().addShutdownHook(
+            Thread {
+                val t = Thread {
+                    try {
+                        discovery.stop()
+                    } catch (e: Exception) {
+                        System.err.println("WARN: mDNS stop failed — ${e.message}")
+                    }
+                    try {
+                        server.stop()
+                    } catch (e: Exception) {
+                        System.err.println("WARN: FileServer stop failed — ${e.message}")
+                    }
+                    try {
+                        fileClient.close()
+                    } catch (e: Exception) {
+                        System.err.println("WARN: FileClient close failed — ${e.message}")
+                    }
+                }
+                t.isDaemon = true
+                t.start()
+                t.join(2_000)
+            },
+        )
 
         echo("Commands: send <peer-name> <path>, list, quit")
 
@@ -131,7 +133,7 @@ class TetherCommand :
                 else -> echo("unknown command: '${tokens[0]}'. Available: send, list, quit.")
             }
         }
-        cleanup()
+        System.exit(0)
     }
 }
 

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt
@@ -108,7 +108,11 @@ class TetherCommand :
 
         var running = true
         while (running) {
-            val line = withContext(Dispatchers.IO) { readLine() } ?: break
+            val line = try {
+                withContext(Dispatchers.IO) { readLine() }
+            } catch (_: java.nio.charset.MalformedInputException) {
+                continue
+            } ?: break
             val tokens = line.trim().split("\\s+".toRegex(), limit = 3)
             when (tokens.firstOrNull()?.lowercase()) {
                 "", null -> continue

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import java.io.IOException
 import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.io.path.exists
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeSource
@@ -70,26 +71,30 @@ class TetherCommand :
 
         val fileClient = FileClient()
 
-        // Shutdown hook handles cleanup for both Ctrl+C and normal exit via `quit`.
-        Runtime.getRuntime().addShutdownHook(
-            Thread {
-                try {
-                    discovery.stop()
-                } catch (e: Exception) {
-                    System.err.println("WARN: mDNS stop failed — ${e.message}")
-                }
-                try {
-                    server.stop()
-                } catch (e: Exception) {
-                    System.err.println("WARN: FileServer stop failed — ${e.message}")
-                }
-                try {
-                    fileClient.close()
-                } catch (e: Exception) {
-                    System.err.println("WARN: FileClient close failed — ${e.message}")
-                }
-            },
-        )
+        // cleanup() stops JmDNS/Ktor threads so the JVM can exit. AtomicBoolean
+        // prevents double-close when quit calls it explicitly and the shutdown hook
+        // fires afterwards (or on Ctrl+C alone).
+        val cleanedUp = AtomicBoolean(false)
+
+        fun cleanup() {
+            if (!cleanedUp.compareAndSet(false, true)) return
+            try {
+                discovery.stop()
+            } catch (e: Exception) {
+                System.err.println("WARN: mDNS stop failed — ${e.message}")
+            }
+            try {
+                server.stop()
+            } catch (e: Exception) {
+                System.err.println("WARN: FileServer stop failed — ${e.message}")
+            }
+            try {
+                fileClient.close()
+            } catch (e: Exception) {
+                System.err.println("WARN: FileClient close failed — ${e.message}")
+            }
+        }
+        Runtime.getRuntime().addShutdownHook(Thread { cleanup() })
 
         echo("Commands: send <peer-name> <path>, list, quit")
 
@@ -126,6 +131,7 @@ class TetherCommand :
                 else -> echo("unknown command: '${tokens[0]}'. Available: send, list, quit.")
             }
         }
+        cleanup()
     }
 }
 

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt
@@ -70,6 +70,7 @@ class TetherCommand :
 
         val fileClient = FileClient()
 
+        // Shutdown hook handles cleanup for both Ctrl+C and normal exit via `quit`.
         Runtime.getRuntime().addShutdownHook(
             Thread {
                 try {
@@ -111,23 +112,17 @@ class TetherCommand :
                         echo("usage: send <peer-name> <path>")
                         continue
                     }
-                    launch {
-                        handleSend(
-                            client = fileClient,
-                            peers = discovery.discoveredDevices.value,
-                            peerName = tokens[1],
-                            rawPath = tokens[2],
-                        )
-                    }.join()
+                    handleSend(
+                        client = fileClient,
+                        peers = discovery.discoveredDevices.value,
+                        peerName = tokens[1],
+                        rawPath = tokens[2],
+                    )
                 }
                 "quit" -> running = false
                 else -> echo("unknown command: '${tokens[0]}'. Available: send, list, quit.")
             }
         }
-
-        discovery.stop()
-        server.stop()
-        fileClient.close()
     }
 }
 
@@ -137,6 +132,10 @@ internal suspend fun handleSend(
     peerName: String,
     rawPath: String,
     output: (String) -> Unit = ::println,
+    progressOutput: (String) -> Unit = { s ->
+        print(s)
+        System.out.flush()
+    },
 ) {
     val file = Path.of(rawPath)
     if (!file.exists()) {
@@ -165,15 +164,14 @@ internal suspend fun handleSend(
             val intervalSec = (now - lastPrint).inWholeMilliseconds / 1000.0
             val speed = if (intervalSec > 0) (transferred - lastBytes) / intervalSec else 0.0
             val totalStr = if (total > 0) " / ${formatBytes(total)}" else ""
-            print("\r[send] ${formatBytes(transferred)}$totalStr  (${formatBytes(speed.toLong())}/s)   ")
-            System.out.flush()
+            progressOutput("\r[send] ${formatBytes(transferred)}$totalStr  (${formatBytes(speed.toLong())}/s)   ")
             lastPrint = now
             lastBytes = transferred
         }
     }
 
+    progressOutput("\n") // end progress line
     val elapsed = started.elapsedNow()
-    println() // end progress line
     when (result) {
         is SendResult.Success -> output("[send] OK — ${elapsed.inWholeMilliseconds} ms  →  ${result.savedPath}")
         is SendResult.Failure -> output("[send] FAIL: ${result.reason}")

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt
@@ -21,6 +21,8 @@ import kotlin.io.path.exists
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeSource
 
+private const val ESC = ""
+
 class TetherCommand :
     CliktCommand(
         name = "tether",
@@ -58,13 +60,17 @@ class TetherCommand :
         }
         echo("mDNS started → advertising '$deviceName' on port $actualPort\n")
 
-        val peersJob = launch {
+        var peersLinePrinted = false
+        launch {
             discovery.discoveredDevices.collect { peers ->
-                if (peers.isEmpty()) {
-                    echo("[peers] none")
+                val ids = if (peers.isEmpty()) "none" else peers.joinToString(", ") { it.id }
+                if (peersLinePrinted) {
+                    print("$ESC[1A\r$ESC[K[peers] $ids\n")
                 } else {
-                    peers.forEach { echo("[peers] $it") }
+                    print("[peers] $ids\n")
+                    peersLinePrinted = true
                 }
+                System.out.flush()
             }
         }
 
@@ -126,10 +132,7 @@ class TetherCommand :
                         rawPath = tokens[2],
                     )
                 }
-                "quit" -> {
-                    peersJob.cancel()
-                    running = false
-                }
+                "quit" -> running = false
                 else -> echo("unknown command: '${tokens[0]}'. Available: send, list, quit.")
             }
         }
@@ -181,7 +184,7 @@ internal suspend fun handleSend(
         }
     }
 
-    progressOutput("\n") // end progress line
+    progressOutput("\n")
     val elapsed = started.elapsedNow()
     when (result) {
         is SendResult.Success -> output("[send] OK — ${elapsed.inWholeMilliseconds} ms  →  ${result.savedPath}")

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt
@@ -133,7 +133,7 @@ class TetherCommand :
                         client = fileClient,
                         peers = discovery.discoveredDevices.value,
                         peerName = tokens[1],
-                        rawPath = tokens[2],
+                        file = Path.of(tokens[2]),
                     )
                 }
                 "quit" -> running = false
@@ -148,16 +148,16 @@ internal suspend fun handleSend(
     client: FileClient,
     peers: List<Device>,
     peerName: String,
-    rawPath: String,
+    file: Path,
     output: (String) -> Unit = ::println,
+    errorOutput: (String) -> Unit = System.err::println,
     progressOutput: (String) -> Unit = { s ->
         print(s)
         System.out.flush()
     },
 ) {
-    val file = Path.of(rawPath)
     if (!file.exists()) {
-        output("[send] ERROR: file not found: $rawPath")
+        output("[send] ERROR: file not found: $file")
         return
     }
 
@@ -167,7 +167,7 @@ internal suspend fun handleSend(
         return
     }
     if (matching.size > 1) {
-        System.err.println("WARN: multiple peers named '$peerName', using first")
+        errorOutput("WARN: multiple peers named '$peerName', using first")
     }
     val peer = matching.first()
 
@@ -181,7 +181,7 @@ internal suspend fun handleSend(
         if ((now - lastPrint) >= 500.milliseconds) {
             val intervalSec = (now - lastPrint).inWholeMilliseconds / 1000.0
             val speed = if (intervalSec > 0) (transferred - lastBytes) / intervalSec else 0.0
-            val totalStr = if (total > 0) " / ${formatBytes(total)}" else ""
+            val totalStr = total?.let { " / ${formatBytes(it)}" } ?: ""
             progressOutput("\r[send] ${formatBytes(transferred)}$totalStr  (${formatBytes(speed.toLong())}/s)   ")
             lastPrint = now
             lastBytes = transferred
@@ -197,7 +197,6 @@ internal suspend fun handleSend(
 }
 
 internal fun formatBytes(bytes: Long): String = when {
-    bytes < 0 -> "? B"
     bytes < 1_024 -> "$bytes B"
     bytes < 1_024 * 1_024 -> "%.1f KB".format(bytes / 1_024.0)
     bytes < 1_024 * 1_024 * 1_024 -> "%.1f MB".format(bytes / (1_024.0 * 1_024))

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt
@@ -6,11 +6,20 @@ import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.int
 import com.tubetoast.tether.discovery.MdnsDiscovery
+import com.tubetoast.tether.network.FileClient
 import com.tubetoast.tether.network.FileServer
-import kotlinx.coroutines.awaitCancellation
+import com.tubetoast.tether.network.send
+import com.tubetoast.tether.protocol.Device
+import com.tubetoast.tether.protocol.SendResult
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import java.io.IOException
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TimeSource
 
 class TetherCommand :
     CliktCommand(
@@ -59,6 +68,8 @@ class TetherCommand :
             }
         }
 
+        val fileClient = FileClient()
+
         Runtime.getRuntime().addShutdownHook(
             Thread {
                 try {
@@ -71,12 +82,110 @@ class TetherCommand :
                 } catch (e: Exception) {
                     System.err.println("WARN: FileServer stop failed — ${e.message}")
                 }
+                try {
+                    fileClient.close()
+                } catch (e: Exception) {
+                    System.err.println("WARN: FileClient close failed — ${e.message}")
+                }
             },
         )
 
-        echo("Ctrl+C to stop")
-        awaitCancellation()
+        echo("Commands: send <peer-name> <path>, list, quit")
+
+        var running = true
+        while (running) {
+            val line = withContext(Dispatchers.IO) { readLine() } ?: break
+            val tokens = line.trim().split("\\s+".toRegex(), limit = 3)
+            when (tokens.firstOrNull()?.lowercase()) {
+                "", null -> continue
+                "list" -> {
+                    val peers = discovery.discoveredDevices.value
+                    if (peers.isEmpty()) {
+                        echo("[list] no peers found")
+                    } else {
+                        peers.forEach { echo("[list] ${it.name}  (${it.host}:${it.port})") }
+                    }
+                }
+                "send" -> {
+                    if (tokens.size < 3) {
+                        echo("usage: send <peer-name> <path>")
+                        continue
+                    }
+                    launch {
+                        handleSend(
+                            client = fileClient,
+                            peers = discovery.discoveredDevices.value,
+                            peerName = tokens[1],
+                            rawPath = tokens[2],
+                        )
+                    }.join()
+                }
+                "quit" -> running = false
+                else -> echo("unknown command: '${tokens[0]}'. Available: send, list, quit.")
+            }
+        }
+
+        discovery.stop()
+        server.stop()
+        fileClient.close()
     }
+}
+
+internal suspend fun handleSend(
+    client: FileClient,
+    peers: List<Device>,
+    peerName: String,
+    rawPath: String,
+    output: (String) -> Unit = ::println,
+) {
+    val file = Path.of(rawPath)
+    if (!file.exists()) {
+        output("[send] ERROR: file not found: $rawPath")
+        return
+    }
+
+    val matching = peers.filter { it.name == peerName }
+    if (matching.isEmpty()) {
+        output("[send] ERROR: peer '$peerName' not found. Use 'list' to see known peers.")
+        return
+    }
+    if (matching.size > 1) {
+        System.err.println("WARN: multiple peers named '$peerName', using first")
+    }
+    val peer = matching.first()
+
+    val clock = TimeSource.Monotonic
+    val started = clock.markNow()
+    var lastPrint = started
+    var lastBytes = 0L
+
+    val result = client.send(peer, file) { transferred, total ->
+        val now = clock.markNow()
+        if ((now - lastPrint) >= 500.milliseconds) {
+            val intervalSec = (now - lastPrint).inWholeMilliseconds / 1000.0
+            val speed = if (intervalSec > 0) (transferred - lastBytes) / intervalSec else 0.0
+            val totalStr = if (total > 0) " / ${formatBytes(total)}" else ""
+            print("\r[send] ${formatBytes(transferred)}$totalStr  (${formatBytes(speed.toLong())}/s)   ")
+            System.out.flush()
+            lastPrint = now
+            lastBytes = transferred
+        }
+    }
+
+    val elapsed = started.elapsedNow()
+    println() // end progress line
+    when (result) {
+        is SendResult.Success -> output("[send] OK — ${elapsed.inWholeMilliseconds} ms  →  ${result.savedPath}")
+        is SendResult.Failure -> output("[send] FAIL: ${result.reason}")
+    }
+}
+
+internal fun formatBytes(bytes: Long): String = when {
+    bytes < 0 -> "? B"
+    bytes < 1_024 -> "$bytes B"
+    bytes < 1_024 * 1_024 -> "%.1f KB".format(bytes / 1_024.0)
+    bytes < 1_024 * 1_024 * 1_024 -> "%.1f MB".format(bytes / (1_024.0 * 1_024))
+    else -> "%.2f GB".format(bytes / (1_024.0 * 1_024 * 1_024))
 }
 
 fun main(args: Array<String>) = TetherCommand().main(args)

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt
@@ -58,7 +58,7 @@ class TetherCommand :
         }
         echo("mDNS started → advertising '$deviceName' on port $actualPort\n")
 
-        launch {
+        val peersJob = launch {
             discovery.discoveredDevices.collect { peers ->
                 if (peers.isEmpty()) {
                     echo("[peers] none")
@@ -119,7 +119,10 @@ class TetherCommand :
                         rawPath = tokens[2],
                     )
                 }
-                "quit" -> running = false
+                "quit" -> {
+                    peersJob.cancel()
+                    running = false
+                }
                 else -> echo("unknown command: '${tokens[0]}'. Available: send, list, quit.")
             }
         }

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/CliSendTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/CliSendTest.kt
@@ -90,13 +90,14 @@ class CliSendTest {
     fun `send reports error when file does not exist`() {
         val (client, device) = setup()
         try {
+            val nonExistent = Files.createTempDirectory("cli-missing").resolve("no-such-file.bin")
             val messages = mutableListOf<String>()
             runBlocking {
                 handleSend(
                     client = client,
                     peers = listOf(device),
                     peerName = device.name,
-                    rawPath = "/tmp/no-such-file-tether-test.bin",
+                    rawPath = nonExistent.toString(),
                     output = messages::add,
                 )
             }

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/CliSendTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/CliSendTest.kt
@@ -1,0 +1,112 @@
+package com.tubetoast.tether
+
+import com.tubetoast.tether.network.FileClient
+import com.tubetoast.tether.network.FileServer
+import com.tubetoast.tether.protocol.Device
+import kotlinx.coroutines.runBlocking
+import java.nio.file.Files
+import kotlin.io.path.writeBytes
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CliSendTest {
+    private val tmpDir = Files.createTempDirectory("tether-cli-test").toFile()
+    private val server = FileServer(0, downloadsDir = tmpDir)
+
+    private fun setup(): Pair<FileClient, Device> {
+        val port = server.start()
+        val device = Device(id = "cli-test@127.0.0.1:$port", name = "cli-test", host = "127.0.0.1", port = port)
+        return FileClient() to device
+    }
+
+    private fun teardown(client: FileClient) {
+        client.close()
+        server.stop()
+        tmpDir.deleteRecursively()
+    }
+
+    @Test
+    fun `send happy path transfers file and reports OK`() {
+        val (client, device) = setup()
+        try {
+            val content = "hello from cli test".toByteArray()
+            val file = Files.createTempFile("cli-send", ".txt")
+            file.writeBytes(content)
+
+            val messages = mutableListOf<String>()
+            runBlocking {
+                handleSend(
+                    client = client,
+                    peers = listOf(device),
+                    peerName = device.name,
+                    rawPath = file.toString(),
+                    output = messages::add,
+                )
+            }
+
+            val ok = messages.firstOrNull { it.startsWith("[send] OK") }
+            assertTrue(ok != null, "Expected [send] OK but got: $messages")
+
+            val savedPath = ok.substringAfter("→").trim()
+            assertEquals(String(content), java.io.File(savedPath).readText())
+
+            Files.deleteIfExists(file)
+        } finally {
+            teardown(client)
+        }
+    }
+
+    @Test
+    fun `send reports error when peer not found`() {
+        val (client, _) = setup()
+        try {
+            val file = Files.createTempFile("cli-no-peer", ".txt")
+            file.writeBytes("data".toByteArray())
+
+            val messages = mutableListOf<String>()
+            runBlocking {
+                handleSend(
+                    client = client,
+                    peers = emptyList(),
+                    peerName = "nonexistent",
+                    rawPath = file.toString(),
+                    output = messages::add,
+                )
+            }
+
+            assertTrue(
+                messages.any { it.contains("peer 'nonexistent' not found") },
+                "Expected peer-not-found error but got: $messages",
+            )
+
+            Files.deleteIfExists(file)
+        } finally {
+            teardown(client)
+        }
+    }
+
+    @Test
+    fun `send reports error when file does not exist`() {
+        val (client, device) = setup()
+        try {
+            val messages = mutableListOf<String>()
+            runBlocking {
+                handleSend(
+                    client = client,
+                    peers = listOf(device),
+                    peerName = device.name,
+                    rawPath = "/tmp/no-such-file-tether-test.bin",
+                    output = messages::add,
+                )
+            }
+
+            assertTrue(
+                messages.any { it.contains("file not found") },
+                "Expected file-not-found error but got: $messages",
+            )
+        } finally {
+            teardown(client)
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/CliSendTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/CliSendTest.kt
@@ -8,6 +8,7 @@ import java.nio.file.Files
 import kotlin.io.path.writeBytes
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class CliSendTest {
@@ -40,7 +41,7 @@ class CliSendTest {
                     client = client,
                     peers = listOf(device),
                     peerName = device.name,
-                    rawPath = file.toString(),
+                    file = file,
                     output = messages::add,
                 )
             }
@@ -70,7 +71,7 @@ class CliSendTest {
                     client = client,
                     peers = emptyList(),
                     peerName = "nonexistent",
-                    rawPath = file.toString(),
+                    file = file,
                     output = messages::add,
                 )
             }
@@ -79,6 +80,38 @@ class CliSendTest {
                 messages.any { it.contains("peer 'nonexistent' not found") },
                 "Expected peer-not-found error but got: $messages",
             )
+
+            Files.deleteIfExists(file)
+        } finally {
+            teardown(client)
+        }
+    }
+
+    @Test
+    fun `send warns and uses first when multiple peers share name`() {
+        val (client, device) = setup()
+        try {
+            val content = "dup-peer test".toByteArray()
+            val file = Files.createTempFile("cli-dup", ".txt")
+            file.writeBytes(content)
+
+            val duplicate = device.copy(id = "cli-test-2@127.0.0.1:${device.port}")
+            val errors = mutableListOf<String>()
+            val messages = mutableListOf<String>()
+            runBlocking {
+                handleSend(
+                    client = client,
+                    peers = listOf(device, duplicate),
+                    peerName = device.name,
+                    file = file,
+                    output = messages::add,
+                    errorOutput = errors::add,
+                )
+            }
+
+            assertTrue(errors.any { it.contains("multiple peers") }, "Expected WARN but got: $errors")
+            assertTrue(messages.any { it.startsWith("[send] OK") }, "Expected OK but got: $messages")
+            assertFalse(messages.any { it.startsWith("[send] FAIL") }, "Unexpected FAIL: $messages")
 
             Files.deleteIfExists(file)
         } finally {
@@ -97,7 +130,7 @@ class CliSendTest {
                     client = client,
                     peers = listOf(device),
                     peerName = device.name,
-                    rawPath = nonExistent.toString(),
+                    file = nonExistent,
                     output = messages::add,
                 )
             }

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/network/FileClientProgressTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/network/FileClientProgressTest.kt
@@ -1,0 +1,91 @@
+package com.tubetoast.tether.network
+
+import com.tubetoast.tether.protocol.Device
+import com.tubetoast.tether.protocol.SendResult
+import kotlinx.coroutines.runBlocking
+import java.nio.file.Files
+import kotlin.io.path.writeBytes
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class FileClientProgressTest {
+    private val tmpDir = Files.createTempDirectory("tether-progress-test").toFile()
+    private val server = FileServer(0, downloadsDir = tmpDir)
+
+    private fun setup(): Pair<FileClient, Int> {
+        val port = server.start()
+        return FileClient() to port
+    }
+
+    private fun teardown(client: FileClient) {
+        client.close()
+        server.stop()
+        tmpDir.deleteRecursively()
+    }
+
+    @Test
+    fun `send with onProgress reports monotonically increasing bytes`() {
+        val (client, port) = setup()
+        try {
+            val content = ByteArray(64 * 1024) { it.toByte() }
+            val file = Files.createTempFile("progress-test", ".bin")
+            file.writeBytes(content)
+            val device = Device(id = "test@127.0.0.1:$port", name = "test", host = "127.0.0.1", port = port)
+
+            val reports = mutableListOf<Long>()
+            runBlocking {
+                val result = client.send(device, file) { transferred, _ -> reports.add(transferred) }
+                assertIs<SendResult.Success>(result)
+            }
+
+            assertTrue(reports.isNotEmpty(), "onProgress was never called")
+            assertTrue(reports.last() == content.size.toLong(), "Last report must equal file size")
+            assertTrue(reports.zipWithNext().all { (a, b) -> b >= a }, "Progress must be non-decreasing")
+
+            Files.deleteIfExists(file)
+        } finally {
+            teardown(client)
+        }
+    }
+
+    @Test
+    fun `send with onProgress preserves file content`() {
+        val (client, port) = setup()
+        try {
+            val content = ByteArray(256) { it.toByte() }
+            val file = Files.createTempFile("progress-content-test", ".bin")
+            file.writeBytes(content)
+            val device = Device(id = "test@127.0.0.1:$port", name = "test", host = "127.0.0.1", port = port)
+
+            runBlocking {
+                val result = client.send(device, file) { _, _ -> } as SendResult.Success
+                val saved = java.io.File(result.savedPath).readBytes()
+                assertTrue(content.contentEquals(saved), "Saved content must match sent content")
+            }
+
+            Files.deleteIfExists(file)
+        } finally {
+            teardown(client)
+        }
+    }
+
+    @Test
+    fun `send without onProgress still works`() {
+        val (client, port) = setup()
+        try {
+            val file = Files.createTempFile("no-progress-test", ".txt")
+            file.writeBytes("hello".toByteArray())
+            val device = Device(id = "test@127.0.0.1:$port", name = "test", host = "127.0.0.1", port = port)
+
+            runBlocking {
+                val result = client.send(device, file)
+                assertIs<SendResult.Success>(result)
+            }
+
+            Files.deleteIfExists(file)
+        } finally {
+            teardown(client)
+        }
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/network/FileClientJvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/network/FileClientJvm.kt
@@ -12,7 +12,7 @@ import kotlin.io.path.inputStream
 suspend fun FileClient.send(
     device: Device,
     file: Path,
-    onProgress: ((bytesTransferred: Long, totalBytes: Long) -> Unit)? = null,
+    onProgress: ((bytesTransferred: Long, totalBytes: Long?) -> Unit)? = null,
 ): SendResult {
     if (!file.exists()) throw FileNotFoundException(file.toString())
     return send(

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/network/FileClientJvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/network/FileClientJvm.kt
@@ -4,11 +4,22 @@ import com.tubetoast.tether.protocol.Device
 import com.tubetoast.tether.protocol.SendResult
 import io.ktor.utils.io.jvm.javaio.toByteReadChannel
 import java.io.FileNotFoundException
+import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.exists
 import kotlin.io.path.inputStream
 
-suspend fun FileClient.send(device: Device, file: Path): SendResult {
+suspend fun FileClient.send(
+    device: Device,
+    file: Path,
+    onProgress: ((bytesTransferred: Long, totalBytes: Long) -> Unit)? = null,
+): SendResult {
     if (!file.exists()) throw FileNotFoundException(file.toString())
-    return send(device, file.inputStream().toByteReadChannel(), file.fileName.toString())
+    return send(
+        device = device,
+        channel = file.inputStream().toByteReadChannel(),
+        fileName = file.fileName.toString(),
+        totalBytes = Files.size(file),
+        onProgress = onProgress,
+    )
 }


### PR DESCRIPTION
Closes #52.

## Summary

- `FileClient.send()` in `commonMain` extended with optional `totalBytes` + `onProgress` callback — all platforms can use it without reimplementing progress tracking
- Progress copying runs in a sibling coroutine via `coroutineScope { launch { } }` so Ktor reads from the pipe concurrently with the fill; no in-memory buffering
- `FileClientJvm` extension passes `Files.size(path)` as `totalBytes`; callback optional, existing callers unaffected
- `Main.kt` replaces `awaitCancellation()` with a stdin command loop (`send <peer-name> <path>`, `list`, `quit`); `readLine()` wrapped in `Dispatchers.IO` so the peers subscription keeps updating
- `handleSend()` is `internal` and takes `List<Device>` + injectable `output` lambda — no dependency on `MdnsDiscovery` internals, easy to unit-test
- `CliSendTest`: happy path, peer-not-found, file-not-found
- `FileClientProgressTest`: progress monotonicity, byte correctness, no-callback compatibility
- `CLAUDE.md` updated with command reference table

## Test plan

- [ ] `./gradlew allTests -q` — green
- [ ] Start runner, type `list` — prints `[list] no peers found` while no peers visible
- [ ] Start second instance with a different `--name`, wait for `[peers]` line, type `list` — both peers shown
- [ ] `send <peer-name> <path>` to a small file — prints `[send] OK` line with path
- [ ] `send <peer-name> <path>` to a large file (>100 MB) — progress line updates ~every 500 ms
- [ ] `send nonexistent /tmp/file` — `peer 'nonexistent' not found`
- [ ] `send <peer> /tmp/no-such-file` — `file not found` before any network call
- [ ] Empty line and unknown command — no crash, correct message
- [ ] `quit` — clean shutdown, no hanging process
- [ ] Ctrl+C during idle — shutdown hook fires, clean exit
- [ ] Ctrl+C during active `send` — transfer cancelled, process exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)