### PR TITLE
#63: ADR for macOS Native vs Desktop JVM target choice

### DIFF
--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -10,6 +10,12 @@ Product-side docs (vision, audience, features) live in [`docs/product/`](../prod
 - [Modules](modules.md) — current monolith, target module split, and the triggers that move a piece of code into its own module.
 - [Dependency Injection](dependency-injection.md) — DI strategy now (manual composition root) and later (Metro). Concrete rules for new code.
 
+## Architecture Decision Records
+
+ADRs in [`adr/`](adr/) capture the *why* behind one-time architectural choices. Living docs above; ADRs are append-only history.
+
+- [macOS target — Native over Desktop JVM](adr/adr-macos-native-vs-jvm.md) — chose `macosArm64` Kotlin/Native to share `appleMain` with iOS.
+
 ## For the AI agent / contributor
 
 Before writing code, read [dependency-injection.md](dependency-injection.md) — it has the concrete "does my code fit" checklist.

--- a/docs/engineering/adr/adr-macos-native-vs-jvm.md
+++ b/docs/engineering/adr/adr-macos-native-vs-jvm.md
@@ -1,0 +1,53 @@
+# macOS Target — Native (`macosArm64`) over Desktop JVM
+
+**Status:** Accepted — 2026-05-07 (de facto since project init; this ADR records the rationale)
+**Issue:** #63
+
+## Context
+
+Tether ships macOS as part of the MVP — the canonical user described in [audience.md](../../product/audience.md) is "Android phone + macOS laptop." The KMP setup configures `macosArm64()` in `composeApp/build.gradle.kts`. The alternative would be to ship macOS via the Desktop JVM target, the same way Windows and Linux are planned to ship.
+
+Until now the choice was implicit: it lived in `build.gradle.kts` and a couple of paragraphs in [tech-stack.md](../../product/tech-stack.md). This ADR makes the trade-off explicit.
+
+## Decision drivers
+
+| | macOS Native (`macosArm64`) | macOS Desktop JVM |
+|---|---|---|
+| `appleMain` shared with iOS | ✅ same source set, same NSNetService discovery, same future receiver-server | ❌ macOS would need JmDNS, leaving NSNetService for iOS alone — two Apple-side stacks |
+| Ktor server | ❌ JVM-only — needs platform-side impl (Network.framework / GCDWebServer) | ✅ runs out of the box |
+| Compose-MP maturity | ⚠️ experimental | ✅ mature on JVM |
+| Distribution | ✅ native binary, small | ⚠️ `.app` with bundled JRE (~50–80 MB) |
+| Standalone `run` task | ❌ launches via IDE / Xcode | ✅ `./gradlew :composeApp:run` works |
+
+## Decision
+
+**macOS ships as a Kotlin/Native target (`macosArm64`).** Apple Silicon only; `macosX64` is deferred until a real user reports it (per tech-stack.md).
+
+### Why Native over JVM
+
+1. **`appleMain` source-set sharing with iOS.** mDNS discovery is already implemented once in `appleMain/MdnsDiscovery.apple.kt` and used by both iOS and macOS. The future iOS receiver-server (Network.framework / GCDWebServer / similar) will live in the same source set. Switching macOS to JVM breaks that share — discovery would have to be reimplemented in JmDNS for macOS, leaving NSNetService for iOS alone. We'd carry two Apple-side stacks instead of one.
+2. **Smaller distribution.** A native binary vs. a `.app` with a bundled JRE (50–80 MB). For a file-transfer utility the install footprint is part of the perceived product quality.
+
+### Costs accepted
+
+1. **Compose-MP on macOS native is experimental.** Acceptable for MVP scope; flagged in build configuration.
+2. **Ktor server doesn't run on Kotlin/Native.** macOS receiver needs a platform-side implementation. The work is required for iOS regardless; macOS Native gets it as part of that effort, not as extra scope.
+3. **No standalone `run` task.** `macosArm64` compiles, but launching is via IDE / Xcode. Less ergonomic than `./gradlew :composeApp:run` on Desktop JVM, but the JVM CLI fills the dev-iteration gap when needed.
+4. **Extra build target.** Marginal: a bit more compile time, an extra release artifact, separate test cycle.
+
+## Considered alternatives
+
+- **macOS via Desktop JVM.** Compose-MP is mature on JVM, Ktor runs out of the box, and the path to MVP is shorter. Lose `appleMain` sharing — doubled Apple-side mDNS stack — and `.app` distribution is heavier. Becomes attractive only if Compose-MP macOS native materially blocks UX (see revisit triggers).
+- **Drop macOS from MVP.** Conflicts with the canonical user described in [audience.md](../../product/audience.md).
+
+## Revisit if
+
+- **Compose-MP macOS native materially breaks UX** in the skeleton or first product screens — temporarily fall back to macOS JVM and restore Native when Compose stabilises.
+- **iOS receiver work is deferred indefinitely (>3 sprints).** The `appleMain` sharing argument weakens if the share is hypothetical for a long time; the Native-only justification then rests on distribution size, which alone may not be enough.
+- **An Intel Mac user surfaces** — add `macosX64()` (one line + a small permanent build/test/release tax). Independent of the Native-vs-JVM choice but closely related.
+
+## References
+
+- [tech-stack.md](../../product/tech-stack.md) — current macOS configuration notes
+- [audience.md](../../product/audience.md) — canonical user
+- [roadmap.md](../../product/roadmap.md) — MVP scope


### PR DESCRIPTION
## Summary

- New ADR [`docs/engineering/adr/adr-macos-native-vs-jvm.md`](docs/engineering/adr/adr-macos-native-vs-jvm.md) — documents why macOS ships as a Kotlin/Native target (`macosArm64`) rather than via Desktop JVM. The decision was already implicit in `composeApp/build.gradle.kts` and a few lines of `tech-stack.md`; this ADR makes the trade-off explicit.
- Engineering [`README.md`](docs/engineering/README.md) gains an **Architecture Decision Records** section pointing at `adr/`.

**Decision drivers:** `appleMain` source-set sharing with iOS (NSNetService discovery now, receiver-server later) and smaller distribution (native binary vs `.app` with bundled JRE).

**Costs accepted:** Compose-MP on macOS native is experimental, Ktor server is JVM-only (Apple-side server is required for iOS regardless), no standalone `run` task.

**Revisit triggers** documented for the cases where the choice should be re-evaluated.

> Note: PR [#61](https://github.com/khmelevartem/tether/pull/61) also introduces an *Architecture Decision Records* section in `docs/engineering/README.md`. Whichever lands second will need a small README rebase to merge the two ADR entries.

Closes #63.

## Test plan

- [x] Docs-only change, no code touched.
- [x] `./gradlew allTests -q` — green via pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)