### PR TITLE
#50: AppContainer composition root and Phase 1 manual DI

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -156,18 +156,19 @@ adb devices | awk '/device$/ && !/List/ {print $1}'
 
 1. **Install:** `./gradlew -q :composeApp:installDebug`
 2. **Logcat clear:** `adb logcat -c`
-3. **Start activity** (с замером времени для метрики cross-discovery):
+3. **Start activity:**
    ```bash
-   LAUNCH_MS=$(python3 -c "import time; print(int(time.time() * 1000))")
    adb shell am start -n com.tubetoast.tether/.MainActivity
    ```
-4. **Ждём `NSD service registered` как anchor готовности** (вместо слепого `sleep 8`):
+4. **Ждём `NSD service registered` как anchor готовности** (вместо слепого `sleep 8`).
+   Anchor для метрики cross-discovery ставится **после** того как Android-сторона опубликовалась — чтобы дельта мерила только пропагацию через сеть + JmDNS resolve, а не Android boot/init/наш wait-loop:
    ```bash
    DEADLINE=$(($(date +%s) + 12))
    while [ $(date +%s) -lt $DEADLINE ]; do
      adb logcat -d 2>/dev/null | grep -q "NSD service registered" && break
      sleep 1
    done
+   NSD_READY_MS=$(python3 -c "import time; print(int(time.time() * 1000))")
    ```
    Парсим:
    - `TetherFGService: FileServer started on port <N>` → `ANDROID_PORT`
@@ -178,18 +179,18 @@ adb devices | awk '/device$/ && !/List/ {print $1}'
    ```
    Если эмулятор и IP `10.0.2.x` — host-доступ через `adb forward tcp:18080 tcp:$ANDROID_PORT` и `localhost:18080`. Для физ. устройства — прямо `$ANDROID_IP:$ANDROID_PORT`.
 6. **`/health` sanity:** `curl -sf http://$ANDROID_IP:$ANDROID_PORT/health` → `Tether OK`. Это единственное место, где curl допустим — endpoint sanity, не пользовательский flow.
-7. **Cross-discovery с замером времени:** в stdin Desktop CLI поллим лог, ищем `Tether-<MODEL>` пока не появится. Записываем delta от `LAUNCH_MS`:
+7. **Cross-discovery с замером времени:** в stdin Desktop CLI поллим лог, ищем `Tether-<MODEL>` пока не появится. Дельта считается от `NSD_READY_MS` (момент когда Android уже опубликовался), не от `am start`:
    ```bash
    for i in $(seq 1 30); do
      sleep 1
      grep -E "\[peers\] .*Tether-" $LOG_A | grep -v "none" | tail -1 | grep -q . && break
    done
    NOW_MS=$(python3 -c "import time; print(int(time.time() * 1000))")
-   DELTA_MS=$((NOW_MS - LAUNCH_MS))
+   DELTA_MS=$((NOW_MS - NSD_READY_MS))
    ANDROID_NAME=$(grep -oE 'Tether-[A-Za-z0-9_]+' $LOG_A | head -1)
    echo "cross-discovery: ${DELTA_MS}ms, peer=$ANDROID_NAME"
    ```
-   В отчёт: `Android | cross-discovery | ✓ PASS | 2154 ms`. Это намного информативнее голого PASS.
+   В отчёт: `Android | cross-discovery | ✓ PASS | 250 ms`. Это чистое время network-propagation + JmDNS resolve, без Android-init и без slop'а 1-секундного `sleep`-loop'а.
 8. **Send Desktop → Android (через CLI):**
    ```bash
    if [ -z "$ANDROID_NAME" ]; then

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/TetherApp.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/TetherApp.kt
@@ -1,16 +1,14 @@
 package com.tubetoast.tether
 
 import android.app.Application
-import android.content.Context
+import com.tubetoast.tether.di.AndroidAppContainer
+import com.tubetoast.tether.di.AppContainerProvider
+import com.tubetoast.tether.di.TetherAppConfig
 
-class TetherApp : Application() {
-    override fun onCreate() {
-        super.onCreate()
-        context = applicationContext
-    }
-
-    companion object {
-        lateinit var context: Context
-            private set
+class TetherApp :
+    Application(),
+    AppContainerProvider {
+    override val container: AndroidAppContainer by lazy {
+        AndroidAppContainer(TetherAppConfig(application = this))
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/di/AndroidAppConfig.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/di/AndroidAppConfig.kt
@@ -1,0 +1,7 @@
+package com.tubetoast.tether.di
+
+import android.app.Application
+
+interface AndroidAppConfig : JvmAppConfig {
+    val application: Application
+}

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/di/AndroidAppContainer.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/di/AndroidAppContainer.kt
@@ -1,0 +1,10 @@
+package com.tubetoast.tether.di
+
+import com.tubetoast.tether.discovery.MdnsDiscovery
+
+class AndroidAppContainer(
+    config: AndroidAppConfig,
+) : JvmAppContainer(config) {
+    val application = config.application
+    override val mdnsDiscovery: MdnsDiscovery = MdnsDiscovery(application)
+}

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/di/AppContainerProvider.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/di/AppContainerProvider.kt
@@ -1,0 +1,12 @@
+package com.tubetoast.tether.di
+
+/**
+ * Implemented by the [android.app.Application] class so Android components with
+ * framework-managed empty constructors (Activity, Service, BroadcastReceiver) can
+ * reach the composition root without a service-locator global.
+ *
+ * Access pattern: `(application as AppContainerProvider).container`.
+ */
+interface AppContainerProvider {
+    val container: AndroidAppContainer
+}

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/di/TetherAppConfig.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/di/TetherAppConfig.kt
@@ -1,0 +1,14 @@
+package com.tubetoast.tether.di
+
+import android.app.Application
+import android.os.Build
+import java.io.File
+
+class TetherAppConfig(
+    override val application: Application,
+) : AndroidAppConfig {
+    override val deviceName: String = "Tether-${Build.MODEL}"
+    override val port: Int = 0
+    override val downloadsDir: File =
+        (application.getExternalFilesDir(null) ?: application.filesDir).resolve("Tether")
+}

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.android.kt
@@ -5,7 +5,6 @@ import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.os.Build
 import android.util.Log
-import com.tubetoast.tether.TetherApp
 import com.tubetoast.tether.protocol.Device
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -15,7 +14,9 @@ import java.util.concurrent.ConcurrentLinkedQueue
 private const val SERVICE_TYPE = "_tether._tcp."
 private const val TAG = "MdnsDiscovery"
 
-actual class MdnsDiscovery actual constructor() {
+actual class MdnsDiscovery(
+    private val context: Context,
+) {
     private val _discoveredDevices = MutableStateFlow<List<Device>>(emptyList())
     actual val discoveredDevices: StateFlow<List<Device>> = _discoveredDevices.asStateFlow()
 
@@ -146,7 +147,7 @@ actual class MdnsDiscovery actual constructor() {
         ownName = deviceName
         resolveQueue.clear()
         resolving = false
-        val nm = TetherApp.context.getSystemService(Context.NSD_SERVICE) as NsdManager
+        val nm = context.getSystemService(Context.NSD_SERVICE) as NsdManager
         nsdManager = nm
         val serviceInfo = NsdServiceInfo().apply {
             serviceName = deviceName

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/TetherForegroundService.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/TetherForegroundService.kt
@@ -14,6 +14,7 @@ import androidx.core.app.NotificationCompat
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
 import com.tubetoast.tether.R
+import com.tubetoast.tether.di.AppContainerProvider
 import com.tubetoast.tether.discovery.MdnsDiscovery
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -25,11 +26,13 @@ private const val CHANNEL_ID = "tether_foreground"
 internal const val ACTION_STOP = "com.tubetoast.tether.action.STOP"
 
 class TetherForegroundService : LifecycleService() {
+    // The "running" prefix marks these as the started, attached instances —
+    // distinct from the "candidate" locals fetched from the container before start().
     // @Volatile: written from IO coroutine (lifecycleScope.launch(Dispatchers.IO)),
     // read from main thread in onStartCommand / onDestroy.
-    @Volatile private var server: FileServer? = null
+    @Volatile private var runningFileServer: FileServer? = null
 
-    @Volatile private var discovery: MdnsDiscovery? = null
+    @Volatile private var runningMdnsDiscovery: MdnsDiscovery? = null
 
     // Binder returned from onBind so MainActivity can check if the service is running
     // via bindService(intent, connection, flags=0) without BIND_AUTO_CREATE.
@@ -39,15 +42,19 @@ class TetherForegroundService : LifecycleService() {
         super.onCreate()
         startForegroundCompat()
 
+        val container = (application as AppContainerProvider).container
+        val fileServer = container.fileServer
+        val mdnsDiscovery = container.mdnsDiscovery
+        val deviceName = container.deviceName
+        val downloadsDir = container.downloadsDir
+
         lifecycleScope.launch(Dispatchers.IO) {
-            val downloadsDir = (getExternalFilesDir(null) ?: filesDir).resolve("Tether")
-            val srv = FileServer(port = 0, downloadsDir = downloadsDir)
             val port = try {
-                srv.start()
+                fileServer.start()
             } catch (e: CancellationException) {
                 // Coroutine cancelled (e.g. user pressed Stop before server finished starting).
                 // Ensure the partially-started engine doesn't leak.
-                runCatching { srv.stop() }
+                runCatching { fileServer.stop() }
                 throw e
             } catch (e: Exception) {
                 Log.e(TAG, "FileServer failed to start: ${e.message}", e)
@@ -55,19 +62,17 @@ class TetherForegroundService : LifecycleService() {
                 stopSelf()
                 return@launch
             }
-            server = srv
+            runningFileServer = fileServer
             Log.i(TAG, "FileServer started on port $port, downloads → ${downloadsDir.absolutePath}")
 
-            val deviceName = "Tether-${Build.MODEL}"
-            val disc = MdnsDiscovery()
             try {
-                disc.start(deviceName, port)
-                discovery = disc
+                mdnsDiscovery.start(deviceName, port)
+                runningMdnsDiscovery = mdnsDiscovery
                 Log.i(TAG, "mDNS started: name=$deviceName port=$port")
             } catch (e: Exception) {
                 Log.e(TAG, "mDNS failed to start: ${e.message}", e)
-                srv.stop()
-                server = null
+                fileServer.stop()
+                runningFileServer = null
                 stopForeground(STOP_FOREGROUND_REMOVE)
                 stopSelf()
             }
@@ -91,24 +96,24 @@ class TetherForegroundService : LifecycleService() {
     }
 
     override fun onDestroy() {
-        discovery?.also { d ->
+        runningMdnsDiscovery?.let { mdnsDiscovery ->
             try {
-                d.stop()
+                mdnsDiscovery.stop()
                 Log.i(TAG, "mDNS stopped")
             } catch (e: Exception) {
                 Log.w(TAG, "mDNS stop failed: ${e.message}")
             }
         }
-        server?.also { s ->
+        runningFileServer?.let { fileServer ->
             try {
-                s.stop()
+                fileServer.stop()
                 Log.i(TAG, "FileServer stopped")
             } catch (e: Exception) {
                 Log.w(TAG, "FileServer stop failed: ${e.message}")
             }
         }
-        discovery = null
-        server = null
+        runningMdnsDiscovery = null
+        runningFileServer = null
         super.onDestroy()
     }
 

--- a/composeApp/src/androidUnitTest/kotlin/com/tubetoast/tether/network/TetherForegroundServiceTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/tubetoast/tether/network/TetherForegroundServiceTest.kt
@@ -2,6 +2,7 @@ package com.tubetoast.tether.network
 
 import android.app.Service
 import android.content.Intent
+import com.tubetoast.tether.TetherApp
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
@@ -12,7 +13,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [34])
+@Config(sdk = [34], application = TetherApp::class)
 class TetherForegroundServiceTest {
     @Test
     fun `onBind returns non-null binder so bindService check works`() {

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/di/AppleAppConfig.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/di/AppleAppConfig.kt
@@ -1,0 +1,3 @@
+package com.tubetoast.tether.di
+
+interface AppleAppConfig : AppConfig

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/di/AppleAppContainer.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/di/AppleAppContainer.kt
@@ -1,0 +1,11 @@
+package com.tubetoast.tether.di
+
+import com.tubetoast.tether.discovery.MdnsDiscovery
+import com.tubetoast.tether.network.FileServer
+
+open class AppleAppContainer(
+    config: AppleAppConfig,
+) : AppContainer(config) {
+    override val fileServer: FileServer = FileServer()
+    override val mdnsDiscovery: MdnsDiscovery = MdnsDiscovery()
+}

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.apple.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.apple.kt
@@ -20,7 +20,7 @@ private const val SERVICE_TYPE = "_tether._tcp."
 // from the same thread (main thread via DisposableEffect in Compose), all accesses to
 // mutable state are single-threaded — no @Synchronized or @Volatile needed.
 // @Synchronized is a JVM-only annotation and is not available in Kotlin/Native.
-actual class MdnsDiscovery actual constructor() {
+actual class MdnsDiscovery {
     private val _discoveredDevices = MutableStateFlow<List<Device>>(emptyList())
     actual val discoveredDevices: StateFlow<List<Device>> = _discoveredDevices.asStateFlow()
 

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/network/FileServer.apple.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/network/FileServer.apple.kt
@@ -1,0 +1,17 @@
+package com.tubetoast.tether.network
+
+/**
+ * Apple-target stub. Ktor's CIO server engine is JVM-only — a real Apple
+ * implementation will land when the iOS receive-side is built (likely on
+ * Ktor's `ktor-server-darwin` engine or a hand-rolled NSStream loop).
+ *
+ * Until then the stub keeps the common `AppContainer.fileServer` contract
+ * satisfied so common code can reference the type. Calling [start] throws
+ * loudly so any accidental wiring is caught immediately at runtime.
+ */
+actual class FileServer {
+    actual fun start(): Int =
+        error("FileServer is not yet implemented for Apple targets")
+
+    actual fun stop() = Unit
+}

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppConfig.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppConfig.kt
@@ -1,0 +1,5 @@
+package com.tubetoast.tether.di
+
+interface AppConfig {
+    val deviceName: String
+}

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
@@ -1,0 +1,12 @@
+package com.tubetoast.tether.di
+
+import com.tubetoast.tether.discovery.MdnsDiscovery
+import com.tubetoast.tether.network.FileServer
+
+abstract class AppContainer(
+    config: AppConfig,
+) {
+    val deviceName: String = config.deviceName
+    abstract val fileServer: FileServer
+    abstract val mdnsDiscovery: MdnsDiscovery
+}

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
@@ -1,6 +1,7 @@
 package com.tubetoast.tether.di
 
 import com.tubetoast.tether.discovery.MdnsDiscovery
+import com.tubetoast.tether.network.FileClient
 import com.tubetoast.tether.network.FileServer
 
 abstract class AppContainer(
@@ -9,4 +10,5 @@ abstract class AppContainer(
     val deviceName: String = config.deviceName
     abstract val fileServer: FileServer
     abstract val mdnsDiscovery: MdnsDiscovery
+    open val fileClient: FileClient = FileClient()
 }

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.kt
@@ -3,7 +3,7 @@ package com.tubetoast.tether.discovery
 import com.tubetoast.tether.protocol.Device
 import kotlinx.coroutines.flow.StateFlow
 
-expect class MdnsDiscovery() {
+expect class MdnsDiscovery {
     val discoveredDevices: StateFlow<List<Device>>
 
     fun start(deviceName: String, port: Int)

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
@@ -80,22 +80,22 @@ private const val COPY_BUFFER_SIZE = 8 * 1024
 
 private suspend fun copyWithProgress(
     source: ByteReadChannel,
-    dest: ByteChannel,
+    destination: ByteChannel,
     totalBytes: Long?,
     onProgress: (Long, Long?) -> Unit,
 ) {
-    val buf = ByteArray(COPY_BUFFER_SIZE)
+    val buffer = ByteArray(COPY_BUFFER_SIZE)
     var transferred = 0L
     try {
         while (!source.isClosedForRead) {
-            val read = source.readAvailable(buf)
-            if (read > 0) {
-                dest.writeFully(buf, 0, read)
-                transferred += read
+            val bytesRead = source.readAvailable(buffer)
+            if (bytesRead > 0) {
+                destination.writeFully(buffer, 0, bytesRead)
+                transferred += bytesRead
                 onProgress(transferred, totalBytes)
             }
         }
     } finally {
-        dest.close()
+        destination.close()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileServer.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileServer.kt
@@ -1,5 +1,12 @@
 package com.tubetoast.tether.network
 
+/**
+ * The expect declaration intentionally omits a constructor: JVM's `actual`
+ * takes `(port, downloadsDir)`, Apple's stub takes no args. KMP allows this
+ * — actuals are free to declare their own constructors when expect declares
+ * none. Common code never instantiates `FileServer` directly; only the
+ * platform-specific `*AppContainer` does, and it knows its own constructor.
+ */
 expect class FileServer {
     fun start(): Int
 

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileServer.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileServer.kt
@@ -1,0 +1,7 @@
+package com.tubetoast.tether.network
+
+expect class FileServer {
+    fun start(): Int
+
+    fun stop()
+}

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt
@@ -5,9 +5,9 @@ import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.int
-import com.tubetoast.tether.discovery.MdnsDiscovery
+import com.tubetoast.tether.di.DefaultDesktopAppConfig
+import com.tubetoast.tether.di.DesktopAppContainer
 import com.tubetoast.tether.network.FileClient
-import com.tubetoast.tether.network.FileServer
 import com.tubetoast.tether.network.send
 import com.tubetoast.tether.protocol.Device
 import com.tubetoast.tether.protocol.SendResult
@@ -39,7 +39,10 @@ class TetherCommand :
         echo("=== Tether debug runner ===")
         echo("device : $deviceName")
 
-        val server = FileServer(port)
+        val container = DesktopAppContainer(
+            DefaultDesktopAppConfig(deviceName = deviceName, port = port),
+        )
+        val server = container.fileServer
         val actualPort = try {
             server.start()
         } catch (e: IOException) {
@@ -50,7 +53,7 @@ class TetherCommand :
         echo("port   : $actualPort")
         echo("FileServer started  →  http://localhost:$actualPort/health")
 
-        val discovery = MdnsDiscovery()
+        val discovery = container.mdnsDiscovery
         try {
             discovery.start(deviceName, actualPort)
         } catch (e: Exception) {

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt
@@ -77,14 +77,14 @@ class TetherCommand :
             }
         }
 
-        val fileClient = FileClient()
+        val fileClient = container.fileClient
 
         // Shutdown hook runs cleanup in a thread with a 2 s timeout so JmDNS
         // can send goodbye packets but never blocks the JVM exit indefinitely.
         // After all hooks finish the JVM halts and kills any remaining threads.
         Runtime.getRuntime().addShutdownHook(
             Thread {
-                val t = Thread {
+                val cleanupThread = Thread {
                     try {
                         discovery.stop()
                     } catch (e: Exception) {
@@ -101,9 +101,9 @@ class TetherCommand :
                         System.err.println("WARN: FileClient close failed — ${e.message}")
                     }
                 }
-                t.isDaemon = true
-                t.start()
-                t.join(2_000)
+                cleanupThread.isDaemon = true
+                cleanupThread.start()
+                cleanupThread.join(2_000)
             },
         )
 
@@ -154,8 +154,8 @@ internal suspend fun handleSend(
     file: Path,
     output: (String) -> Unit = ::println,
     errorOutput: (String) -> Unit = System.err::println,
-    progressOutput: (String) -> Unit = { s ->
-        print(s)
+    progressOutput: (String) -> Unit = { text ->
+        print(text)
         System.out.flush()
     },
 ) {
@@ -184,8 +184,8 @@ internal suspend fun handleSend(
         if ((now - lastPrint) >= 500.milliseconds) {
             val intervalSec = (now - lastPrint).inWholeMilliseconds / 1000.0
             val speed = if (intervalSec > 0) (transferred - lastBytes) / intervalSec else 0.0
-            val totalStr = total?.let { " / ${formatBytes(it)}" } ?: ""
-            progressOutput("\r[send] ${formatBytes(transferred)}$totalStr  (${formatBytes(speed.toLong())}/s)   ")
+            val formattedTotal = total?.let { " / ${formatBytes(it)}" } ?: ""
+            progressOutput("\r[send] ${formatBytes(transferred)}$formattedTotal  (${formatBytes(speed.toLong())}/s)   ")
             lastPrint = now
             lastBytes = transferred
         }

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/di/DesktopAppConfig.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/di/DesktopAppConfig.kt
@@ -1,0 +1,11 @@
+package com.tubetoast.tether.di
+
+import java.io.File
+
+interface DesktopAppConfig : JvmAppConfig
+
+class DefaultDesktopAppConfig(
+    override val deviceName: String,
+    override val port: Int,
+    override val downloadsDir: File = File(System.getProperty("user.home"), "Downloads/Tether"),
+) : DesktopAppConfig

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/di/DesktopAppContainer.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/di/DesktopAppContainer.kt
@@ -1,0 +1,9 @@
+package com.tubetoast.tether.di
+
+import com.tubetoast.tether.discovery.MdnsDiscovery
+
+class DesktopAppContainer(
+    config: DesktopAppConfig,
+) : JvmAppContainer(config) {
+    override val mdnsDiscovery: MdnsDiscovery = MdnsDiscovery()
+}

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
@@ -62,8 +62,12 @@ actual class MdnsDiscovery {
 
                         val ipv4 = info.getHostAddresses().firstOrNull { IPV4_REGEX.matches(it) }
                         if (ipv4 == null) {
+                            // JmDNS resolves A/AAAA records in stages — first callback can carry only
+                            // IPv6, IPv4 arrives on a later callback. Skip quietly and wait for the
+                            // next event. A persistent IPv6-only state across the peer's lifetime
+                            // is a separate concern (see follow-up logger issue).
                             System.err.println(
-                                "WARN: serviceResolved — no IPv4 for '${event.name}', skipping",
+                                "DEBUG: serviceResolved — no IPv4 yet for '${event.name}', skipping",
                             )
                             return
                         }

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
@@ -12,7 +12,7 @@ import javax.jmdns.ServiceListener
 private const val SERVICE_TYPE = "_tether._tcp.local."
 private val IPV4_REGEX = Regex("""\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}""")
 
-actual class MdnsDiscovery actual constructor() {
+actual class MdnsDiscovery {
     private val _discoveredDevices = MutableStateFlow<List<Device>>(emptyList())
     actual val discoveredDevices: StateFlow<List<Device>> = _discoveredDevices.asStateFlow()
 

--- a/composeApp/src/iosMain/kotlin/com/tubetoast/tether/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/com/tubetoast/tether/MainViewController.kt
@@ -1,19 +1,22 @@
 package com.tubetoast.tether
 
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.window.ComposeUIViewController
-import com.tubetoast.tether.discovery.MdnsDiscovery
+import com.tubetoast.tether.di.DefaultIosAppConfig
+import com.tubetoast.tether.di.IosAppContainer
 import platform.UIKit.UIDevice
 
 @Suppress("ktlint:standard:function-naming")
-fun MainViewController() = ComposeUIViewController {
-    val discovery = remember { MdnsDiscovery() }
-    DisposableEffect(Unit) {
-        val deviceName = UIDevice.currentDevice.name
-        // TODO: replace with actual FileServer port once server is available on iOS
-        discovery.start(deviceName, port = 8080)
-        onDispose { discovery.stop() }
+fun MainViewController() = run {
+    val container = IosAppContainer(
+        DefaultIosAppConfig(deviceName = UIDevice.currentDevice.name),
+    )
+    ComposeUIViewController {
+        DisposableEffect(Unit) {
+            // TODO: replace with actual FileServer port once server is available on iOS
+            container.mdnsDiscovery.start(container.deviceName, port = 8080)
+            onDispose { container.mdnsDiscovery.stop() }
+        }
+        App()
     }
-    App()
 }

--- a/composeApp/src/iosMain/kotlin/com/tubetoast/tether/di/IosAppConfig.kt
+++ b/composeApp/src/iosMain/kotlin/com/tubetoast/tether/di/IosAppConfig.kt
@@ -1,0 +1,7 @@
+package com.tubetoast.tether.di
+
+interface IosAppConfig : AppleAppConfig
+
+class DefaultIosAppConfig(
+    override val deviceName: String,
+) : IosAppConfig

--- a/composeApp/src/iosMain/kotlin/com/tubetoast/tether/di/IosAppContainer.kt
+++ b/composeApp/src/iosMain/kotlin/com/tubetoast/tether/di/IosAppContainer.kt
@@ -1,0 +1,5 @@
+package com.tubetoast.tether.di
+
+class IosAppContainer(
+    config: IosAppConfig,
+) : AppleAppContainer(config)

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/di/JvmAppConfig.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/di/JvmAppConfig.kt
@@ -1,0 +1,8 @@
+package com.tubetoast.tether.di
+
+import java.io.File
+
+interface JvmAppConfig : AppConfig {
+    val port: Int
+    val downloadsDir: File
+}

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/di/JvmAppContainer.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/di/JvmAppContainer.kt
@@ -1,0 +1,11 @@
+package com.tubetoast.tether.di
+
+import com.tubetoast.tether.network.FileServer
+import java.io.File
+
+abstract class JvmAppContainer(
+    config: JvmAppConfig,
+) : AppContainer(config) {
+    val downloadsDir: File = config.downloadsDir
+    override val fileServer: FileServer = FileServer(config.port, downloadsDir)
+}

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/network/FileServer.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/network/FileServer.kt
@@ -18,13 +18,13 @@ import java.io.File
 
 private const val BUFFER_SIZE = 64 * 1024
 
-class FileServer(
+actual class FileServer(
     private val port: Int,
     private val downloadsDir: File = File(System.getProperty("user.home"), "Downloads/Tether"),
 ) {
     private var server: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
 
-    fun start(): Int {
+    actual fun start(): Int {
         check(server == null) { "FileServer is already running" }
         downloadsDir.mkdirs()
         val srv = embeddedServer(CIO, port = port) {
@@ -75,7 +75,7 @@ class FileServer(
         return runBlocking { srv.engine.resolvedConnectors() }.first().port
     }
 
-    fun stop() {
+    actual fun stop() {
         server?.stop(gracePeriodMillis = 500, timeoutMillis = 1_000)
         server = null
     }

--- a/composeApp/src/macosMain/kotlin/com/tubetoast/tether/di/MacosAppConfig.kt
+++ b/composeApp/src/macosMain/kotlin/com/tubetoast/tether/di/MacosAppConfig.kt
@@ -1,0 +1,7 @@
+package com.tubetoast.tether.di
+
+interface MacosAppConfig : AppleAppConfig
+
+class DefaultMacosAppConfig(
+    override val deviceName: String,
+) : MacosAppConfig

--- a/composeApp/src/macosMain/kotlin/com/tubetoast/tether/di/MacosAppContainer.kt
+++ b/composeApp/src/macosMain/kotlin/com/tubetoast/tether/di/MacosAppContainer.kt
@@ -1,0 +1,5 @@
+package com.tubetoast.tether.di
+
+class MacosAppContainer(
+    config: MacosAppConfig,
+) : AppleAppContainer(config)

--- a/docs/engineering/adr/adr-presentation-and-navigation.md
+++ b/docs/engineering/adr/adr-presentation-and-navigation.md
@@ -23,7 +23,7 @@ Each of those tasks would otherwise have to answer the same architectural questi
 - **Single UI codebase.** Compose-MP is the rendering layer everywhere; we will not maintain a parallel SwiftUI tree.
 - **Android config-change survival** is required.
 - **iOS UIKit integration** is plausible — share sheet, file pickers, document camera. The presentation layer must let a UIKit entry point drive the same state holder a Compose screen drives.
-- **Existing DI shape.** Composition happens in `AppGraph` (see [dependency-injection.md](../dependency-injection.md)). Components receive collaborators via constructor; presentation must keep that style.
+- **Existing DI shape.** Composition happens in `AppContainer` (see [dependency-injection.md](../dependency-injection.md)). Components receive collaborators via constructor; presentation must keep that style.
 
 ## Decision drivers
 
@@ -34,7 +34,7 @@ Each of those tasks would otherwise have to answer the same architectural questi
 | Android config-change survival | Required (rotation, dark/light theme, locale). |
 | UIKit interop | Some iOS flows enter from native UI (share sheet) and must drive the same state holder. |
 | Testability without Compose | Presentation logic should be testable as plain Kotlin in `commonTest`. |
-| Fit with `AppGraph` constructor DI | Components must take dependencies via constructor, not look them up. |
+| Fit with `AppContainer` constructor DI | Components must take dependencies via constructor, not look them up. |
 | Maturity | This is a load-bearing choice; replacing it later is expensive. |
 
 ### Validation scenarios
@@ -66,9 +66,9 @@ Each option below is judged against the same five scenarios:
 **How it handles the scenarios:**
 
 1. Device list — `coroutineScope()` extension binds the discovery `collect` to component lifetime; cancelled on destroy.
-2. Send + progress — transfer state lives in an `AppGraph` repository, not in the Component. The send Component observes the repository; rotation rebuilds the Component, the transfer keeps running.
+2. Send + progress — transfer state lives in an `AppContainer` repository, not in the Component. The send Component observes the repository; rotation rebuilds the Component, the transfer keeps running.
 3. Pairing dialog — `ChildSlot` overlay; its own back handler closes the slot before the screen.
-4. Back from transfer — Component reads "is anything in progress?" from the AppGraph repository and registers a `BackHandler` accordingly to show a confirmation.
+4. Back from transfer — Component reads "is anything in progress?" from the AppContainer repository and registers a `BackHandler` accordingly to show a confirmation.
 5. iOS share sheet — `RootComponent.onSharedFile(uri)` is called from the UIViewController code path.
 
 ### 2. Voyager
@@ -80,7 +80,7 @@ Each option below is judged against the same five scenarios:
 - **Config-change survival:** ScreenModels are retained; `SavedStateHandle` integration on Android.
 - **UIKit interop:** limited to what Compose-MP gives you (a single root `UIViewController`). A UIKit-side entry point cannot drive a Voyager Screen without going through Compose first.
 - **Testability:** ScreenModels are testable, but their lifecycle is owned by the hosting Composable, which couples test setup to Compose fixtures.
-- **DI fit:** acceptable — `getScreenModel { ... }` accepts constructor args, but the canonical pattern leans on a service-locator, fighting `AppGraph`'s "no global lookups" rule.
+- **DI fit:** acceptable — `getScreenModel { ... }` accepts constructor args, but the canonical pattern leans on a service-locator, fighting `AppContainer`'s "no global lookups" rule.
 - **Maturity:** stable, popular, smaller maintainer team and slower release cadence than Decompose.
 
 **Why not chosen:** the UIKit blind spot is decisive. The native iOS pickers / share sheet path is plausible from day one (see `docs/product/features/file-transfer.md` and `pairing.md`). With Voyager, that path forces a parallel non-Voyager state holder for the native side — exactly the fork the ADR is meant to prevent.
@@ -121,7 +121,7 @@ The AndroidX Navigation Compose library, recently extended to non-Android KMP ta
 - **Config-change survival + process-death restoration:** persistence is a first-class feature — PMs serialise via `PmStateHandler` and restore after process recreation. Stronger out-of-the-box than Decompose's default.
 - **UIKit interop:** PMs are pure Kotlin; native UIKit code can drive them directly. Same property as Decompose.
 - **Testability:** dedicated `premo-test` module with `runPmTest`. No Compose runtime needed.
-- **DI fit:** PMs accept `PmArgs` (serializable) and a parent reference via constructor. Compatible with `AppGraph`.
+- **DI fit:** PMs accept `PmArgs` (serializable) and a parent reference via constructor. Compatible with `AppContainer`.
 - **Maturity:** v1.0.0-alpha.15 (May 2024), no commits since May 2024, single maintainer, ~200 stars. README explicitly warns: *"the library is in the pre-release alpha version. Stable work and backward compatibility are not guaranteed."* No stable release in five years.
 
 **Why not chosen:** two blocking issues. (1) **macOS native is not supported** by the library's KMP configuration — and macOS native is one of our four required targets. (2) **Pre-release alpha + ~2 years of no commits + single maintainer** make this a risky bet for a load-bearing layer. The good ideas in Premo — process-death persistence as a first-class concern, parent-intercepts-navigation messaging — are noted as inspiration when extending the Decompose-based layer.
@@ -170,11 +170,11 @@ Shape rules:
 - **Components are plain Kotlin** — they take their dependencies and a `ComponentContext` via constructor. No globals, no service locators.
 - **Naming follows Decompose** — classes are `XxxComponent`, not `XxxViewModel`. They are not Android `ViewModel`s; the difference matters for tests, lifecycle, and KMP.
 - **CoroutineScope is a default constructor argument** wired to the library's `coroutineScope()` extension on `ComponentContext`. Lifecycle-bound by default; tests pass an injected `TestScope` instead.
-- **`AppGraph` builds the root Component**; child Components are created by their parents (or by a `ChildStack` configuration).
+- **`AppContainer` builds the root Component**; child Components are created by their parents (or by a `ChildStack` configuration).
 - **Compose subscribes via `subscribeAsState`** and forwards events as method calls. No `LaunchedEffect`-driven business logic.
 - **Start with a single root Component and `ChildSlot` for modal overlays** (pairing dialog, confirmations). Add **`ChildStack`** when the first explicit back-press flow lands (likely send + progress).
 - **One Component per logical screen / dialog.** Sub-state inside a screen stays inside the Component; we don't split presentation into ceremonial layers.
-- **Long-lived domain state stays out of Components.** Active transfers, peer state, and other state that must outlive a screen live in repositories owned by `AppGraph`. Components observe these repositories; they never own such state and do not use `InstanceKeeper` for it.
+- **Long-lived domain state stays out of Components.** Active transfers, peer state, and other state that must outlive a screen live in repositories owned by `AppContainer`. Components observe these repositories; they never own such state and do not use `InstanceKeeper` for it.
 
 ## Consequences
 
@@ -183,8 +183,8 @@ Shape rules:
 - Presentation logic is testable as plain Kotlin in `commonTest` — no Compose runtime, no Robolectric.
 - Back stack, lifecycle, and state restoration come from a maintained library instead of from us.
 - iOS UIKit integration is on the table from day one; share-sheet / native pickers don't force a rewrite.
-- DI shape (`AppGraph` + constructor injection) generalises naturally — Components are constructor-injected like everything else.
-- Per-screen scope question from [dependency-injection.md](../dependency-injection.md) is answered: long-lived domain state stays in `AppGraph` repositories; Components own only screen-local view state (and only for as long as the screen lives). `AppGraph` stays singleton.
+- DI shape (`AppContainer` + constructor injection) generalises naturally — Components are constructor-injected like everything else.
+- Per-screen scope question from [dependency-injection.md](../dependency-injection.md) is answered: long-lived domain state stays in `AppContainer` repositories; Components own only screen-local view state (and only for as long as the screen lives). `AppContainer` stays singleton.
 
 **Negative / cost:**
 

--- a/docs/engineering/architecture-principles.md
+++ b/docs/engineering/architecture-principles.md
@@ -28,6 +28,25 @@ Clean Architecture and adjacent patterns are full of ceremony that doesn't pay r
 - **Triple-layer DTO ↔ domain ↔ presentation mapping when there's no real divergence yet.** This one is nuanced: as the project matures, layers *do* legitimately need different shapes (DTO has serialization quirks, domain has invariants, presentation has display fields). The rule is not "never map" — it's "don't force three types up front." Start with one. Split when the second shape *actually* diverges (e.g. a UI list state with `selected`, `lastSeen`, `signal` is genuinely not the same as a network `Device`). Don't fight that growth in the name of brevity, and don't pre-empt it in the name of layering.
 - **Interfaces for things with one implementation.** An interface earns its place when there are at least two implementations, or it's a seam for testing. Otherwise the concrete class is the contract.
 
+## Named classes over anonymous objects
+
+When you need to implement an interface — even with a trivial body that's just data (e.g. a config interface filled with constants) — **prefer a named class in its own file** over `object : Interface { ... }` inline.
+
+Why:
+- Anonymous objects sprout duplicates. The next call site copies the literal, drifts on a field, and the divergence is invisible at review.
+- A named class has a place in the file tree and a name in stack traces and test reports.
+- Refactoring (rename a config field, add a new one) updates one file instead of N inline objects.
+
+The exception is one-shot test fakes for a single test method, where extracting would obscure the test. If the same anonymous object would be useful in a second test — extract.
+
+## Naming: spell properties out, no abbreviations
+
+Don't shorten property or local-variable names to save keystrokes (`srv`, `disc`, `cfg`, `mgr`). Names should describe what the value is, not approximate it.
+
+When two values represent the same conceptual entity in different roles (e.g. a candidate held in a local before being published to a field), don't disambiguate by abbreviating one of them. Pick names that describe each role: a "freshly fetched" instance vs a "started/attached" one, an "incoming" vs a "current" instance. The reader should learn from the name why both exist.
+
+Reason: abbreviated names hide intent and merge with each other (`svc`, `srv`, `srvc` all blur together). Descriptive names also surface duplication that abbreviations let slide — if two variables would have the same long name, that's a design signal, not a styling problem.
+
 ## Heuristics for new code
 
 When deciding whether to add a layer, an interface, or a use case, ask:
@@ -42,7 +61,7 @@ When refactoring existing code, the same questions apply in reverse: a layer tha
 
 - Components that create their own collaborators (`HttpClient()` inside `FileClient`). Breaks testability and lifecycle. Fixed by constructor injection — see [dependency-injection.md](dependency-injection.md).
 - Platform context (`TetherApp.context`) reached for from inside discovery/network code. Pushes platform details across layers. Fixed by passing what's needed explicitly into the platform-specific `actual`.
-- UI directly orchestrating discovery + networking. Drag-bottom layer concerns into the most volatile one. Fixed by an `AppGraph` composition root that wires lifecycle, and a thin Component surface for UI (see [presentation-layer.md](presentation-layer.md)).
+- UI directly orchestrating discovery + networking. Drag-bottom layer concerns into the most volatile one. Fixed by an `AppContainer` composition root that wires lifecycle, and a thin Component surface for UI (see [presentation-layer.md](presentation-layer.md)).
 
 ## Decisions
 

--- a/docs/engineering/dependency-injection.md
+++ b/docs/engineering/dependency-injection.md
@@ -2,33 +2,55 @@
 
 How Tether wires its components — today, and where this is headed. This is also the **"does my code fit?" checklist** for new code.
 
-## Today: no DI
+## Phase 1 (current): Manual DI via composition root
 
-There is no DI framework. Components construct their own collaborators:
+A container — `AppContainer` — is the single place where shared components are constructed. Each platform's entry point creates the right container leaf, hands components to whoever needs them, and owns their lifecycle. No reflection, no DSL, no annotations. Components themselves never call `new` on their collaborators.
 
-```kotlin
-class FileClient { private val http = HttpClient { ... } }     // FileClient owns its http client
-class FileServer { private val server = embeddedServer(...) }  // FileServer owns its server
+### Container hierarchy
+
+The container hierarchy mirrors the source set hierarchy. Every layer adds only what its source set can actually see:
+
+```
+AppContainer            (commonMain)        — abstract: fileServer, mdnsDiscovery
+├── JvmAppContainer     (jvmMain)           — provides FileServer(port, downloadsDir)
+│   ├── AndroidAppContainer  (androidMain)  — provides MdnsDiscovery(context)
+│   └── DesktopAppContainer  (desktopMain)  — provides MdnsDiscovery() no-arg
+└── AppleAppContainer   (appleMain)         — provides FileServer() stub + MdnsDiscovery() no-arg
+    ├── IosAppContainer     (iosMain)
+    └── MacosAppContainer   (macosMain)
 ```
 
-This is fine while the project is tiny. It is also already starting to bite — see anti-patterns below.
+`AppContainer` is `abstract` and declares both `fileServer` and `mdnsDiscovery` abstractly — construction lives in the platform leaves because the `MdnsDiscovery` constructor needs `Context` on Android but no args on Desktop/Apple, and `FileServer` is JVM-implementation-only with an Apple stub. `JvmAppContainer` is also `abstract`: it provides `FileServer` (sharing the construction across Android + Desktop) but cannot construct `MdnsDiscovery`.
 
-## Decision
+`FileServer` itself is declared in `commonMain` as an `expect class` so common code can reference the type. The JVM `actual` ([`FileServer.kt`](../../composeApp/src/jvmMain/kotlin/com/tubetoast/tether/network/FileServer.kt)) holds the real Ktor implementation; the Apple `actual` ([`FileServer.apple.kt`](../../composeApp/src/appleMain/kotlin/com/tubetoast/tether/network/FileServer.apple.kt)) is a stub that throws on `start()` — a real Apple implementation will land when the iOS receive-side is built.
 
-We adopt DI in two phases.
+Every container takes an `AppConfig` interface in its constructor. `AppConfig` is the input — the values the entry point chooses (device name, port, downloads dir, Android `Application`). The hierarchy of `*AppConfig` interfaces tracks the container hierarchy: [`AppConfig`](../../composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppConfig.kt), [`JvmAppConfig`](../../composeApp/src/jvmMain/kotlin/com/tubetoast/tether/di/JvmAppConfig.kt), [`AndroidAppConfig`](../../composeApp/src/androidMain/kotlin/com/tubetoast/tether/di/AndroidAppConfig.kt), etc.
 
-### Phase 1 (now): Manual DI via composition root
+Concrete `*AppConfig` implementations are **named classes in their own files** (per [architecture-principles.md](architecture-principles.md) — "Named classes over anonymous objects"): [`TetherAppConfig`](../../composeApp/src/androidMain/kotlin/com/tubetoast/tether/di/TetherAppConfig.kt) for Android, [`DefaultDesktopAppConfig`](../../composeApp/src/desktopMain/kotlin/com/tubetoast/tether/di/DesktopAppConfig.kt), [`DefaultIosAppConfig`](../../composeApp/src/iosMain/kotlin/com/tubetoast/tether/di/IosAppConfig.kt), [`DefaultMacosAppConfig`](../../composeApp/src/macosMain/kotlin/com/tubetoast/tether/di/MacosAppConfig.kt). Anonymous `object : AppConfig { ... }` literals invite drift between call sites.
 
-A single object — call it `AppGraph` — assembles dependencies in each platform's entry point:
+### Entry points
 
-- JVM: `Main.kt` builds `AppGraph`, hands components to whoever needs them.
-- Android: `TetherApp.onCreate()` builds `AppGraph`, exposes it to `MainActivity`.
-- iOS: `MainViewController` builds `AppGraph`, passes it into Compose.
-- macOS: same shape as iOS.
+Each platform builds its container in its entry point and passes components down:
 
-Inside the graph, dependencies are wired by calling constructors. No reflection, no DSL, no annotations. Components themselves never call `new` on their collaborators.
+- **Desktop** ([`Main.kt`](../../composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt)): builds `DesktopAppContainer` from CLI args at the top of `runBlocking`.
+- **Android** ([`TetherApp`](../../composeApp/src/androidMain/kotlin/com/tubetoast/tether/TetherApp.kt)): builds `AndroidAppContainer` lazily in the `Application` subclass and exposes it via the [`AppContainerProvider`](../../composeApp/src/androidMain/kotlin/com/tubetoast/tether/di/AppContainerProvider.kt) interface. [`TetherForegroundService`](../../composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/TetherForegroundService.kt) reads it via `(application as AppContainerProvider).container`.
+- **iOS** ([`MainViewController`](../../composeApp/src/iosMain/kotlin/com/tubetoast/tether/MainViewController.kt)): builds `IosAppContainer` outside the `ComposeUIViewController { ... }` lambda so the composable does not act as a composition root (see rule 5 below).
+- **macOS**: container leaf and config exist; the entry point will follow the same shape as iOS once a macOS run target lands.
 
-### Phase 2 (later): Migrate to Metro
+### The Provider pattern (Android)
+
+Android's framework-managed components — `Activity`, `Service`, `BroadcastReceiver` — must have empty constructors. They cannot receive `AppContainer` through the constructor like normal components. The pattern that fits is:
+
+1. The `Application` subclass implements `AppContainerProvider` and owns the container.
+2. Framework components access it via `(application as AppContainerProvider).container`.
+
+This is **not** a service-locator: `AppContainerProvider` is an interface implemented by exactly one type (`TetherApp` in production, a test `Application` in tests), and access is scoped to Android-framework-managed classes. Pure Kotlin classes still receive their collaborators through the constructor.
+
+### Migration to Phase 2 stays cheap
+
+The container hierarchy and provider pattern map directly onto Metro's shape. When we migrate, `AppContainer` becomes a `@DependencyGraph`, the platform subclasses become Metro contributions, and the `*AppConfig` interfaces become `@Provides` methods on a config graph. Tests that override `open val`s become test graphs with `@Provides` overrides. No structural reshuffle.
+
+## Phase 2 (later): Migrate to Metro
 
 When manual DI becomes painful, we move to [Metro](https://github.com/ZacSweers/metro) — a Kotlin compiler-plugin DI framework by Zac Sweers (Anvil author). v1.0.0 stable, April 2026.
 
@@ -45,13 +67,13 @@ When manual DI becomes painful, we move to [Metro](https://github.com/ZacSweers/
 
 **Why not Hilt / Dagger:** not KMP. Dagger generates JVM bytecode, Hilt is Android-locked.
 
-### Migration trigger (when Phase 2 starts)
+## Migration trigger (when Phase 2 starts)
 
 We move to Metro when **any one** of these hits:
 
-- We split out a third Gradle module and wiring across module boundaries becomes tedious in `AppGraph`.
+- We split out a third Gradle module and wiring across module boundaries becomes tedious in the container.
 - We forget to register something for the first time and ship a crash to a platform.
-- The composition root grows past ~30 lines or starts branching by platform / build flavor.
+- A container leaf grows past ~30 lines or starts branching by build flavor.
 
 Until then, a compiler plugin is more apparatus than the problem deserves.
 
@@ -77,7 +99,7 @@ The composition root creates the `HttpClient` once and hands it to every compone
 
 ### 2. Constructor injection only
 
-No `lateinit var http: HttpClient` set after construction. No service-locator lookups inside methods (`AppGraph.http.send(...)`). Dependencies are explicit constructor arguments.
+No `lateinit var http: HttpClient` set after construction. No service-locator lookups inside methods (`AppContainer.http.send(...)`). Dependencies are explicit constructor arguments.
 
 Reason: a class's constructor signature is its honest dependency list. Anything reached through globals is invisible.
 
@@ -126,23 +148,25 @@ Two problems:
 1. `DisposableEffect(Unit)` runs once, capturing the instance from the first composition. On every recomposition, a new `MdnsDiscovery()` is created and immediately discarded — never started, never stopped. Memory leak.
 2. Even with `remember { MdnsDiscovery() }` to fix the leak, the composable still owns the lifecycle of a singleton — it shouldn't.
 
-✅ The correct shape (Phase 1): build `MdnsDiscovery` in the platform entry point, pass it into the composable.
+✅ The correct shape: build the container in the platform entry point, pass components into the composable.
 
 ```kotlin
 // iosMain — MainViewController.kt (platform entry point = composition root)
-fun MainViewController(): UIViewController {
-    val discovery = MdnsDiscovery()   // created here, owned here
-    return ComposeUIViewController {
+fun MainViewController() = run {
+    val container = IosAppContainer(
+        DefaultIosAppConfig(deviceName = UIDevice.currentDevice.name),
+    )
+    ComposeUIViewController {
         DisposableEffect(Unit) {
-            discovery.start(UIDevice.currentDevice.name, port = 8080)
-            onDispose { discovery.stop() }
+            container.mdnsDiscovery.start(container.deviceName, port = 8080)
+            onDispose { container.mdnsDiscovery.stop() }
         }
-        App(discovery = discovery)    // passed as parameter
+        App()
     }
 }
 ```
 
-When `AppGraph` lands, `MainViewController` will receive the graph and extract `discovery` from it. The composable itself never calls a constructor.
+The container is created **outside** the `ComposeUIViewController { ... }` lambda; the composable receives ready-made components, never calls a constructor.
 
 ### 6. Don't introduce an interface for one implementation
 
@@ -157,47 +181,48 @@ A `FileTransferRepository` interface with one `FileTransferRepositoryImpl` adds 
 
 When you do need to test a class that depends on `HttpClient`, prefer Ktor's `MockEngine` or a hand-rolled fake — don't introduce a `HttpClientWrapper` interface just to mock it. Same logic for `MdnsDiscovery`: fake the `Flow<List<Device>>` it exposes, don't abstract the platform API behind another layer.
 
-## Composition root sketch
+## Testability
 
-This is the rough shape `AppGraph` will take in Phase 1. Not yet implemented; reference it when wiring is added.
+The container is also the seam tests use to substitute fakes. Three levels of tests, three patterns:
+
+### 1. Unit tests of components (no container needed)
+
+Components like `FileServer` and `MdnsDiscovery` take their dependencies through the constructor and are tested directly. The container exists for production wiring only — tests construct what they need. See [`FileServerTest`](../../composeApp/src/jvmTest/kotlin/com/tubetoast/tether/network/FileServerTest.kt).
+
+### 2. Tests of consumers that depend on container components
+
+When a class (e.g. a future Decompose Component or `TrustedDeviceStore`) takes container components, the test builds a fake container by subclassing and overriding `open val`s — exactly what the `open val mdnsDiscovery` declarations are for:
 
 ```kotlin
-// commonMain
-class AppGraph(
-    val protocol: ProtocolModule,
-    val discovery: MdnsDiscovery,
-    val client: FileClient,
-)
-
-// jvmMain (Main.kt)
-fun main(args: Array<String>) {
-    val graph = AppGraph(
-        protocol = ProtocolModule(),
-        discovery = MdnsDiscovery(),
-        client = FileClient(HttpClient(CIO)),
-    )
-    val server = FileServer(/* ... */)
-    // ...
+class FakeAppContainer(deviceName: String = "test") : AppContainer(
+    object : AppConfig { override val deviceName = deviceName },
+) {
+    override val mdnsDiscovery: MdnsDiscovery = FakeMdnsDiscovery()
 }
-
-// androidMain (TetherApp.onCreate)
-appGraph = AppGraph(
-    protocol = ProtocolModule(),
-    discovery = MdnsDiscovery(applicationContext),
-    client = FileClient(HttpClient(CIO)),
-)
 ```
 
-Things to notice:
-- Different platforms build different graphs (Android passes `Context`, JVM also builds a `FileServer`).
-- No component in the graph reaches across to construct another.
-- `commonMain` defines the *shape* (`AppGraph` data class), platforms fill it in.
-- The platform entry point also builds the **root Component** (Decompose), passing `AppGraph` to it. The root creates its children with the dependencies they need. See [presentation-layer.md](presentation-layer.md).
+(For one-shot test fakes, an inline `object : AppConfig` literal is acceptable — the named-class rule has its exception there. Reused fakes get extracted to a named class.)
 
-### Per-screen scoping
+### 3. Tests of Android framework components
 
-`AppGraph` is a singleton. There is no separate per-screen DI scope and no `ViewModelStoreOwner` integration — per-screen state and lifecycle are owned by Decompose Components, not by an Android-style ViewModel container. Each Component receives the dependencies it needs from `AppGraph` (or from its parent Component) and constructs its children directly.
+`Service`/`Activity` tests under Robolectric need an `Application` that implements `AppContainerProvider`. The simplest path is `@Config(application = TetherApp::class)` — Robolectric instantiates the real `TetherApp`, the lazy container builds against the Robolectric-shadowed `getExternalFilesDir`, etc. See [`TetherForegroundServiceTest`](../../composeApp/src/androidUnitTest/kotlin/com/tubetoast/tether/network/TetherForegroundServiceTest.kt).
+
+When a test needs a fake container instead of the real one, define a `TestApplication : Application(), AppContainerProvider` that exposes a `FakeAndroidAppContainer`, and switch `@Config(application = TestApplication::class)`. This stays out of any global static — each test method gets a fresh instance through Robolectric.
+
+### Testability rules to keep this working
+
+1. **Container fields are `open val`.** Override is the substitution mechanism. No setters, no `lateinit var`.
+2. **`AppConfig` and its subtypes are interfaces.** Tests implement them with named classes (or, exceptionally, anonymous objects for one-shot test cases).
+3. **Common-logic tests don't reach for a platform container.** They construct a minimal `AppContainer` subclass in `commonTest`.
+4. **Don't mock components, fake them.** Mock frameworks force a layer of indirection that pollutes production code. If a fake is hard to write because the component is too coupled to its collaborators, fix the component.
+
+## Per-screen scoping
+
+`AppContainer` is a singleton. There is no separate per-screen DI scope and no `ViewModelStoreOwner` integration — per-screen state and lifecycle are owned by Decompose Components, not by an Android-style ViewModel container. Each Component receives the dependencies it needs from `AppContainer` (or from its parent Component) and constructs its children directly.
+
+The platform entry point also builds the **root Component** (Decompose), passing `AppContainer` to it. The root creates its children with the dependencies they need. See [presentation-layer.md](presentation-layer.md).
 
 ## Open questions
 
-- iOS receive-side: when a non-Ktor `FileServer` implementation lands, the graph branches per-platform more aggressively. May be the moment to flip to Metro.
+- iOS receive-side: when a non-Ktor `FileServer` implementation lands, the container branches per-platform more aggressively. May be the moment to flip to Metro.
+- Public/Internal container split (per the library DI pattern): not needed in a single-module app; revisit when the first lib module is extracted.

--- a/docs/engineering/presentation-layer.md
+++ b/docs/engineering/presentation-layer.md
@@ -10,14 +10,14 @@ A **Component** is a plain Kotlin class that holds the state and lifecycle of on
 
 ```
 +-------------------+      +-----------------+      +----------------+
-|  Composable       |      |  Component      |      |  AppGraph      |
+|  Composable       |      |  Component      |      |  AppContainer      |
 |  DeviceList(...)  +------> state: Value    +------> repositories,  |
 |  events as calls  |      |  fun onClick()  |      |  discovery,    |
 +-------------------+      +-----------------+      |  network       |
                                                     +----------------+
 ```
 
-Compose talks down to the Component. The Component talks down to `AppGraph` collaborators received via constructor — never the other way around.
+Compose talks down to the Component. The Component talks down to `AppContainer` collaborators received via constructor — never the other way around.
 
 ## Component anatomy
 
@@ -77,9 +77,9 @@ Events are plain method calls on the Component. No `LaunchedEffect` business log
 
 ## Long-lived state lives outside Components
 
-A Component's lifetime is bound to the screen (or flow) it represents. Anything that must outlive a screen — active file transfers, peer state, long-running connections — lives in repositories owned by `AppGraph`. Components observe these repositories via injected dependencies and never duplicate the state internally.
+A Component's lifetime is bound to the screen (or flow) it represents. Anything that must outlive a screen — active file transfers, peer state, long-running connections — lives in repositories owned by `AppContainer`. Components observe these repositories via injected dependencies and never duplicate the state internally.
 
-In particular: **we do not use `InstanceKeeper` to retain domain state across configuration changes.** The repository in `AppGraph` already outlives the Activity; the Component just rebuilds and re-subscribes on rotation.
+In particular: **we do not use `InstanceKeeper` to retain domain state across configuration changes.** The repository in `AppContainer` already outlives the Activity; the Component just rebuilds and re-subscribes on rotation.
 
 ## Navigation
 
@@ -94,7 +94,7 @@ See [Decompose: Navigation overview](https://arkivanov.github.io/Decompose/navig
 
 ## Configuration change (Android)
 
-Decompose hooks into `AppCompatActivity` via `defaultComponentContext(...)`. When the activity is recreated on rotation, the root Component is rebuilt, but `StateKeeper` restores serializable view state and the underlying `AppGraph` repositories are untouched. No work needed in individual Components beyond putting any session-local view state through `stateKeeper.consume(...)` / `register(...)`.
+Decompose hooks into `AppCompatActivity` via `defaultComponentContext(...)`. When the activity is recreated on rotation, the root Component is rebuilt, but `StateKeeper` restores serializable view state and the underlying `AppContainer` repositories are untouched. No work needed in individual Components beyond putting any session-local view state through `stateKeeper.consume(...)` / `register(...)`.
 
 Process-death state restoration is **not currently a goal** — Tether's flows are short-lived enough that a killed process means a fresh start. Revisit if persistence requirements emerge.
 

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -167,6 +167,92 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		36178BE111A19303B04BB4F7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 6ADF10981B49572313127913 /* Configuration */;
+			baseConfigurationReferenceRelativePath = Config.xcconfig;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		3D66038A4A0BDB3C101138C9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = arm64;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
+				DEVELOPMENT_TEAM = "${TEAM_ID}";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		C16259DCA30F49FB84F49570 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 6ADF10981B49572313127913 /* Configuration */;
@@ -232,64 +318,6 @@
 			};
 			name = Debug;
 		};
-		36178BE111A19303B04BB4F7 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReferenceAnchor = 6ADF10981B49572313127913 /* Configuration */;
-			baseConfigurationReferenceRelativePath = Config.xcconfig;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu17;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
-				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				MTL_FAST_MATH = YES;
-				SDKROOT = iphoneos;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
 		F9E0572260C25D7751C9A9CA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -299,7 +327,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
-				DEVELOPMENT_TEAM = "${TEAM_ID}";
+				DEVELOPMENT_TEAM = FWTP2CBJ2T;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iosApp/Info.plist;
@@ -318,51 +346,23 @@
 			};
 			name = Debug;
 		};
-		3D66038A4A0BDB3C101138C9 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = arm64;
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
-				DEVELOPMENT_TEAM = "${TEAM_ID}";
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = iosApp/Info.plist;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		62C6648B5BB37BB959DC12BE /* Build configuration list for PBXProject "iosApp" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				C16259DCA30F49FB84F49570 /* Debug */,
-				36178BE111A19303B04BB4F7 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		383E31F6AF6DFAD616B148CE /* Build configuration list for PBXNativeTarget "iosApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				F9E0572260C25D7751C9A9CA /* Debug */,
 				3D66038A4A0BDB3C101138C9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		62C6648B5BB37BB959DC12BE /* Build configuration list for PBXProject "iosApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C16259DCA30F49FB84F49570 /* Debug */,
+				36178BE111A19303B04BB4F7 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
## Summary

- **Container hierarchy** mirrors source set hierarchy: `AppContainer` (common) → `JvmAppContainer` → Android/Desktop leaves; parallel `AppleAppContainer` → iOS/macOS leaves. macOS leaf is wired in advance for the future entry point.
- `AppConfig` interface family describes the input each platform supplies (device name, port, downloads dir, Android `Application`). Concrete configs are named classes per the new "Named classes over anonymous objects" architecture principle.
- `AppContainerProvider` (androidMain) gives `Service`/`Activity` access to the container without a service-locator global.
- `MdnsDiscovery.android` now takes `Context` via constructor; `TetherApp.context` companion + its anti-pattern reference are gone.
- `TetherForegroundServiceTest` switched to `@Config(application = TetherApp::class)` so the FGS test runs against the real `AppContainerProvider`.
- [`docs/engineering/dependency-injection.md`](docs/engineering/dependency-injection.md) Phase 1 section rewritten in past tense with hierarchy diagram, Provider-pattern explanation, and a new testability section (3 levels, 4 rules). Phase 2/Metro decision deferred to documented triggers.

## Test plan

- [x] `./gradlew allTests` — green (Common + JVM + Apple)
- [x] `./gradlew :composeApp:assembleDebug` — APK builds
- [x] `./gradlew :composeApp:compileKotlinMacosArm64` — green
- [x] `./gradlew :composeApp:run --args="--name TestPlan --port 0"` — CLI starts, FileServer + mDNS announce
- [x] `rg "TetherApp\.context"` — no matches
- [x] `rg "FileServer\(|MdnsDiscovery\("` outside `di/` and tests — only class declaration lines, no instantiations
- [ ] Android device smoke test (PR reviewer): launch app, observe FGS notification, confirm Desktop discovers the peer
- [ ] iOS device/simulator smoke test (PR reviewer): launch app, confirm Desktop discovers the peer

🤖 Generated with [Claude Code](https://claude.com/claude-code)