### PR TITLE
#44: deduplicate JmDNS peers by name on port change

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
@@ -46,6 +46,7 @@ actual class MdnsDiscovery {
                 }
 
                 override fun serviceRemoved(event: ServiceEvent) {
+                    println("INFO: serviceRemoved '${event.name}'")
                     _discoveredDevices.value = _discoveredDevices.value
                         .filterNot { it.name == event.name }
                 }

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
@@ -46,7 +46,7 @@ actual class MdnsDiscovery {
                 }
 
                 override fun serviceRemoved(event: ServiceEvent) {
-                    println("INFO: serviceRemoved '${event.name}'")
+                    System.err.println("INFO: serviceRemoved '${event.name}'")
                     _discoveredDevices.value = _discoveredDevices.value
                         .filterNot { it.name == event.name }
                 }

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/discovery/MdnsDiscoveryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/discovery/MdnsDiscoveryTest.kt
@@ -171,6 +171,36 @@ class MdnsDiscoveryTest {
         }
     }
 
+    @Test
+    fun `peer re-resolved with new port replaces old entry`() = runBlocking {
+        val a = MdnsDiscovery()
+        val b = MdnsDiscovery()
+        try {
+            a.start("PortChangeA", 19060)
+            b.start("PortChangeB", 19061)
+
+            withTimeout(10_000) {
+                a.discoveredDevices.first { peers -> peers.any { it.name == "PortChangeB" && it.port == 19061 } }
+            }
+
+            b.stop()
+            b.start("PortChangeB", 19062)
+
+            val peersAfterRestart = withTimeout(15_000) {
+                a.discoveredDevices.first { peers ->
+                    peers.any { it.name == "PortChangeB" && it.port == 19062 }
+                }
+            }
+
+            val portChangeBPeers = peersAfterRestart.filter { it.name == "PortChangeB" }
+            assertEquals(1, portChangeBPeers.size, "expected exactly one entry for PortChangeB, got: $portChangeBPeers")
+            assertEquals(19062, portChangeBPeers[0].port)
+        } finally {
+            a.stop()
+            b.stop()
+        }
+    }
+
     // NOTE: the "JmDNS renames on conflict" test was removed because it tested JmDNS
     // internal conflict-probing behaviour rather than our own code. Our self-filter uses
     // IP+port (not name), so it is rename-proof by construction — no renaming scenario


### PR DESCRIPTION
Closes #44.

## Summary

- `serviceResolved` in `MdnsDiscovery.jvm.kt` already contained the deduplication logic (`filterNot { name } + device`) — landed earlier in PR #39. This PR completes the remaining DoD items.
- Added `println("INFO: serviceRemoved '${event.name}'")` to the `serviceRemoved` handler so it's visible in logs whether the event fires on peer shutdown.
- Added `peer re-resolved with new port replaces old entry` test in `MdnsDiscoveryTest`: starts peer B on port 19061, waits for discovery, restarts B on port 19062, asserts exactly one entry for B with the updated port.

## Test plan

- [x] `./gradlew allTests -q` — green
- [ ] Manual: start Desktop runner, restart Android app — `[peers]` shows one entry per peer after each restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)