### PR TITLE
Скилл smoke-test для базовой проверки сборки и обнаружения по таргетам

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -1,0 +1,290 @@
+---
+name: smoke-test
+description: Прогон базового smoke-теста (happy-path) по платформам Tether — Desktop CLI (uber jar + /health + mDNS + stdin commands), Android (если adb-устройство подключено) с upload host→Android, нативная компиляция macosArm64 и iosSimulatorArm64. Используй этот скилл, когда пользователь просит «прогони smoke», «прогони smoke-тест», «basic smoke», «проверь сборку по платформам перед merge», «дымовой тест». Не путать с unit-тестами (`./gradlew allTests`) — smoke это рантайм-проверка стартует ли всё и видят ли друг друга, не корректность логики.
+---
+
+# Smoke-test skill
+
+Прогоняет базовые smoke-сценарии по таргетам Tether и выдаёт human-readable отчёт.
+
+**Это smoke, не регресс.** Цель — за 1-3 минуты увидеть, что ничего фундаментально не сломано (CLI стартует, FileServer отвечает, mDNS публикуется, stdin-команды работают, upload roundtrip OK, нативные таргеты компилируются). Корректность бизнес-логики — задача `./gradlew allTests`.
+
+## Чего скилл НЕ проверяет (вне скоупа автоматизации)
+
+В начале прогона **проговори это пользователю** — границы покрытия:
+
+- **Физический iPhone** — нет, требует ручной подписи и доверия сертификата.
+- **macOS run** — у `macosArm64` нет entry point, только sanity-компиляция.
+- **iOS receive/upload** — `FileServer.apple` это stub, на `start()` бросает `error()`. Только sanity-компиляция `iosSimulatorArm64`.
+- **iOS simulator runtime** — в текущей версии скилла не запускаем (требует Xcode-проекта и времени), только compile.
+- **Тап по Notification «Stop»** — заменяется на `am force-stop` или broadcast. Что *кнопка нарисована и работает* — проверить вручную.
+- **Sleep/wake реального девайса** — `adb shell input keyevent SLEEP/WAKEUP` это аппроксимация, не настоящий power state.
+- **Rotation effects на FGS-выживаемость** — на эмуляторе ≠ на реальном устройстве.
+
+В отчёте все эти позиции должны быть в секции **«Manual verification required»**.
+
+## Ключевое решение: uber jar, не gradle run
+
+**Не используй `./gradlew :composeApp:run` для авто-запуска CLI.** Compose Desktop's `run` task в non-TTY среде (когда скилл запускается агентом без терминала) не пробрасывает `System.in` корректно — `readLine()` сразу возвращает null, CLI выходит до того как FileServer успеет связаться с портом.
+
+Вместо этого собирай uber jar и запускай через `java -jar`:
+
+```bash
+./gradlew :composeApp:packageUberJarForCurrentOS -q
+java -jar composeApp/build/compose/jars/com.tubetoast.tether-macos-arm64-1.0.0.jar --name SmokeMac --port 0
+```
+
+При прямом запуске `java -jar` процесс наследует stdin от bash, и FIFO-подачу команд в stdin (`list`, `quit`) можно делать напрямую.
+
+Имя jar для других ОС/архитектур: подставь `linux-amd64`, `windows-x64` и т.п. — но скилл рассчитан на macOS-агента.
+
+## План прогона
+
+Скилл выполняет блоки последовательно. Падение блока не блокирует следующие. Cleanup выполняется **всегда**, даже если ранее были FAIL.
+
+### Блок 0: Подготовка
+
+1. Убедись, что нет работающих инстансов CLI (память: внешние mDNS-сервисы могут глючить тесты):
+   ```bash
+   pgrep -fl 'com.tubetoast.tether-.*\.jar|composeApp:run' || echo "clean"
+   ```
+   Если есть — `kill` их.
+2. Собрать uber jar:
+   ```bash
+   ./gradlew :composeApp:packageUberJarForCurrentOS -q
+   ls composeApp/build/compose/jars/
+   ```
+   Запомни имя файла. Для macosArm64 это `com.tubetoast.tether-macos-arm64-1.0.0.jar`.
+
+Если build падает — все остальные блоки SKIP с причиной «uber jar build failed».
+
+### Блок 1: Desktop CLI
+
+Запуск через FIFO (stdin keeper):
+
+```bash
+JAR=composeApp/build/compose/jars/com.tubetoast.tether-macos-arm64-1.0.0.jar
+LOG=/tmp/smoke-cli.log
+mkfifo /tmp/smoke-cli-in
+sleep 600 > /tmp/smoke-cli-in &              # keeper holds writer fd open
+KEEPER=$!; disown $KEEPER
+echo $KEEPER > /tmp/smoke-cli-keeper.pid
+
+nohup java -jar $JAR --name SmokeMac --port 0 < /tmp/smoke-cli-in > $LOG 2>&1 &
+JPID=$!; disown $JPID
+echo $JPID > /tmp/smoke-cli.pid
+```
+
+Wait до 30 сек:
+```bash
+for i in $(seq 1 30); do grep -q 'FileServer started' $LOG && break; sleep 1; done
+PORT=$(grep -oE 'port[[:space:]]*:[[:space:]]*[0-9]+' $LOG | grep -oE '[0-9]+' | head -1)
+```
+
+Сценарии:
+1. **Startup** — port распарсен, java pid жив (`ps -p $JPID`). PASS если оба условия.
+2. **`/health`** — `curl -sf --max-time 5 http://localhost:$PORT/health` → должно вернуть `Tether OK`.
+3. **Port LISTEN** — `lsof -nP -iTCP:$PORT | head -3` показывает java listener.
+4. **mDNS publish** — `( dns-sd -B _tether._tcp. local. 2>&1 & DNSSD_PID=$!; sleep 8; kill $DNSSD_PID 2>/dev/null ) | grep SmokeMac` — найти SmokeMac в browse output.
+5. **stdin `list`** — `echo "list" > /tmp/smoke-cli-in &; sleep 1; tail $LOG` — должен напечатать `[list]` или `[peers]` строку.
+6. **stdin `quit` graceful** — `echo "quit" > /tmp/smoke-cli-in &`, ждать до 8 сек, проверить `ps -p $JPID` — процесс должен умереть. Если не умер — FAIL «не graceful», `kill -9` и идти дальше.
+
+### Блок 2: Desktop ↔ Desktop send (через CLI)
+
+**Важно:** upload должен идти через **CLI команду `send`**, а не через `curl POST /upload`. Это смоук-тест пользовательского сценария, а не endpoint'а.
+
+Поднимаешь второй CLI-инстанс параллельно с первым (на другом FIFO/log/jar-args), ждёшь, пока mDNS даст обоим увидеть друг друга, и шлёшь команду `send <peer> <path>` в stdin первого.
+
+```bash
+JAR=composeApp/build/compose/jars/com.tubetoast.tether-macos-arm64-1.0.0.jar
+
+# Второй инстанс (первый уже запущен из блока 1, имя SmokeMacA)
+mkfifo /tmp/smoke-cliB-in
+sleep 600 > /tmp/smoke-cliB-in & KEEPER_B=$!; disown $KEEPER_B
+echo $KEEPER_B > /tmp/smoke-cliB-keeper.pid
+nohup java -jar $JAR --name SmokeMacB --port 0 < /tmp/smoke-cliB-in > /tmp/smoke-cliB.log 2>&1 &
+JPID_B=$!; disown $JPID_B
+echo $JPID_B > /tmp/smoke-cliB.pid
+
+# Wait until BOTH see each other
+for i in $(seq 1 30); do
+  grep -q 'SmokeMacA' /tmp/smoke-cliB.log 2>/dev/null && \
+  grep -q 'SmokeMacB' /tmp/smoke-cli.log 2>/dev/null && break
+  sleep 1
+done
+
+# Send file через stdin первого CLI
+echo "send-via-cli-$(date +%s)" > /tmp/smoke-send.txt
+echo "send SmokeMacB /tmp/smoke-send.txt" > /tmp/smoke-cli-in &
+sleep 4
+
+# Проверить что в логе первого CLI: "[send] OK"
+grep -E "^\[send\] (OK|FAIL)" /tmp/smoke-cli.log | tail -3
+
+# Проверить что файл реально landed в SmokeMacB's downloads
+diff /tmp/smoke-send.txt "$HOME/Downloads/Tether/smoke-send.txt" && echo PASS || echo FAIL
+```
+
+PASS если:
+1. в логе первого CLI есть `[send] OK — <ms> ms → <savedPath>`
+2. содержимое файла идентично оригиналу
+
+Bonus: можно проверить что `[send] FAIL: peer 'NonExistent' not found` корректно обрабатывается — но это уже за рамки smoke.
+
+### Блок 3: Android (условно)
+
+Сначала проверка устройства:
+```bash
+adb devices | awk '/device$/ && !/List/ {print $1}'
+```
+
+Если пусто — весь блок SKIP с причиной «no adb device connected».
+
+Если есть устройство:
+
+1. **Install:** `./gradlew -q :composeApp:installDebug`
+2. **Logcat clear:** `adb logcat -c`
+3. **Start activity:** `adb shell am start -n com.tubetoast.tether/.MainActivity`
+4. **Wait + grep logs (8 сек):**
+   ```bash
+   sleep 8
+   adb logcat -d 2>&1 | grep -E "TetherFGService|MdnsDiscovery|FileServer started|NSD service registered" | head -20
+   ```
+   Ищем строки:
+   - `TetherFGService: FileServer started on port <N>` → парсим `<N>` как `ANDROID_PORT`
+   - `mDNS started: name=Tether-...` → PASS «Android FGS+mDNS up»
+5. **Получить IP:**
+   ```bash
+   ANDROID_IP=$(adb shell ip route 2>&1 | awk '/wlan0.*src/ {print $9}' | head -1)
+   ```
+   Если эмулятор и IP `10.0.2.x` — это NAT, host достучится через `adb forward tcp:18080 tcp:$ANDROID_PORT` и localhost:18080. Для физ. устройства — прямо `$ANDROID_IP:$ANDROID_PORT`.
+6. **`/health` sanity:** `curl -sf http://$ANDROID_IP:$ANDROID_PORT/health` → `Tether OK`. Это единственное место, где curl допустим — endpoint sanity, не пользовательский flow.
+7. **Cross-discovery:** в stdin Desktop CLI послать `list`, проверить что в логе появилось имя `Tether-<MODEL>` (только для физ. устройства в одной WiFi; эмулятор в NAT — обычно не виден).
+8. **Send host → Android (через CLI):**
+   ```bash
+   ANDROID_NAME=$(grep -oE 'Tether-[A-Za-z0-9_]+' /tmp/smoke-cli.log | head -1)
+   echo "send-to-android-$(date +%s)" > /tmp/smoke-android.txt
+   echo "send $ANDROID_NAME /tmp/smoke-android.txt" > /tmp/smoke-cli-in &
+   sleep 5
+   grep -E "^\[send\] (OK|FAIL)" /tmp/smoke-cli.log | tail -3
+   adb shell cat /sdcard/Android/data/com.tubetoast.tether/files/Tether/smoke-android.txt | diff - /tmp/smoke-android.txt
+   ```
+   PASS если в логе Desktop CLI `[send] OK — <ms> ms → <savedPath>` И файл на Android идентичен.
+9. **Stop service:** `adb shell am force-stop com.tubetoast.tether`. PASS если приложение умерло.
+
+Помечай каждый под-сценарий отдельно: install, FGS+mDNS up, /health sanity, cross-discovery, send-to-android, stop.
+
+### Блок 4: Native compile sanity
+
+```bash
+./gradlew -q :composeApp:compileKotlinMacosArm64
+./gradlew -q :composeApp:compileKotlinIosSimulatorArm64
+```
+
+PASS если exit=0. FAIL — приложить последние ~30 строк stderr.
+
+### Блок 5: Cleanup
+
+Выполняется **всегда**:
+- `kill $(cat /tmp/smoke-cli.pid /tmp/smoke-cliB.pid /tmp/smoke-cli-keeper.pid /tmp/smoke-cliB-keeper.pid 2>/dev/null) 2>/dev/null`
+- `pkill -f 'com.tubetoast.tether.*\.jar'` (страховка)
+- `rm -f /tmp/smoke-cli*-in /tmp/smoke-cli*.log /tmp/smoke-cli*.pid /tmp/smoke-cli*-keeper.pid /tmp/smoke-port.txt /tmp/smoke-send.txt /tmp/smoke-android.txt`
+- `rm -f $HOME/Downloads/Tether/smoke-send.txt` (сами создали — сами убираем)
+- `adb shell rm -f /sdcard/Android/data/com.tubetoast.tether/files/Tether/smoke-android.txt`
+- `adb shell am force-stop com.tubetoast.tether`
+
+## Формат отчёта
+
+В конце прогона печатаешь markdown-отчёт ровно по этой структуре:
+
+```markdown
+# Smoke test report
+
+**Дата:** YYYY-MM-DD HH:MM
+**Branch:** <git branch>
+**Commit:** <short sha>
+**Jar:** com.tubetoast.tether-macos-arm64-1.0.0.jar (built in Ns)
+
+## Summary
+
+- **PASS:** N
+- **FAIL:** M
+- **SKIP:** K
+- **Total:** N+M+K
+- **Verdict:** 🟢 GREEN | 🟡 YELLOW (есть SKIP, FAIL=0) | 🔴 RED (есть FAIL)
+
+## Results
+
+| Block | Scenario | Result | Details |
+|---|---|---|---|
+| Desktop CLI | uber jar build | ✓ PASS | 8s |
+| Desktop CLI | startup + port parse | ✓ PASS | port=49507, pid=83952 |
+| Desktop CLI | /health | ✓ PASS | "Tether OK" |
+| Desktop CLI | port LISTEN | ✓ PASS | java *:49507 |
+| Desktop CLI | mDNS publish | ✓ PASS | SmokeMac в dns-sd -B |
+| Desktop CLI | stdin `list` | ✓ PASS | peer printed |
+| Desktop CLI | graceful `quit` | ✓ PASS | exit in 3s |
+| Desktop↔Desktop | upload roundtrip | ✓ PASS | diff empty |
+| Android | adb device | ✓ PASS | <serial>, model, API |
+| Android | installDebug | ✓ PASS | 4s |
+| Android | FGS + FileServer up | ✓ PASS | port=42367 |
+| Android | mDNS publish | ✓ PASS | Tether-<MODEL> |
+| Android | /health (over WiFi) | ✓ PASS | "Tether OK" |
+| Android | upload host→Android | ✓ PASS | content match |
+| Android | cross-discovery (Desktop sees Android) | ~ PARTIAL | seen в browse, deepening |
+| Android | force-stop | ✓ PASS | process killed |
+| Native | compileKotlinMacosArm64 | ✓ PASS | 1s |
+| Native | compileKotlinIosSimulatorArm64 | ✓ PASS | 2s |
+
+## Failures
+
+(подробности FAIL: команда, stderr tail, гипотеза причины)
+
+## Manual verification required (не покрыто smoke)
+
+- iOS simulator runtime — запустить `iosApp/iosApp.xcodeproj` в Xcode, проверить mDNS publish.
+- Физический iPhone — установить через Xcode, проверить кросс-обнаружение с Desktop.
+- macOS run — нет entry point, не запускается.
+- iOS receive (FileServer.apple — stub) — пропускаем.
+- Notification «Stop» button on Android — проверить тап вручную; smoke использует `am force-stop`.
+- Sleep/wake real device — `adb shell input keyevent` ≠ реальный power state.
+- Rotation persistence — на реальном устройстве, эмулятор недостаточен.
+
+## Environment
+
+- OS: Darwin <version> arm64
+- Java: <java -version>
+- adb device: <serial / model / API> или "none"
+- Xcode: <xcodebuild -version | head -1>
+- dns-sd: <path>
+```
+
+## Как вызывать
+
+Когда пользователь просит «прогони smoke»:
+
+1. Печатаешь короткий план (1-2 строки): «прогоню Desktop CLI через uber jar, Desktop↔Desktop upload, Android если есть устройство, native compile. Что не проверяю — см. отчёт».
+2. Запускаешь блоки.
+3. Печатаешь отчёт.
+4. Если verdict 🔴 — даёшь recommend: какой блок упал и куда смотреть.
+
+Не уточняй у пользователя — скилл должен быть «zero-question»: всё, что неавтоматизируемо, идёт в Manual verification.
+
+## Edge cases при прогоне
+
+- **Gradle daemon занят** — не убивай его, он переиспользуется.
+- **Uber jar старый (изменился код)** — `packageUberJarForCurrentOS` сам пересоберёт что нужно. Не делай `clean`.
+- **`dns-sd` не на macOS** — Linux нет; в этом случае mDNS browse SKIP с причиной «dns-sd not available».
+- **`timeout` на macOS отсутствует** — используй pattern `( cmd & PID=$!; sleep N; kill $PID )` вместо `timeout`.
+- **FIFO writer keeper умер раньше времени** — readLine() вернёт null, CLI выйдет; проверяй `ps -p $KEEPER`.
+- **Эмулятор Android в NAT (10.0.2.x)** — `adb forward` обязателен, прямой доступ host→android не работает.
+- **Несколько adb-устройств** — выбирай первое или fail с уточнением. Не вешай скилл на специфичный serial.
+
+## Что НЕ делать
+
+- **Не используй `./gradlew :composeApp:run`** — баг со stdin (см. выше).
+- **Не запускай `allTests`** — это другой инструмент. Smoke ≤3 минуты.
+- **Не модифицируй код приложения** даже если видишь проблему. Сообщай в отчёте, заводи issue отдельно.
+- **Не лезь в `~/Downloads`** ничего кроме `Tether/smoke.txt` — там пользовательский контент.
+- **Не запускай `./gradlew clean`** — съест кеш и замедлит следующий прогон.
+- **Не отправляй ничего в сеть** кроме localhost и `$ANDROID_IP` (последний — только если adb-устройство подключено).

--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: smoke-test
-description: Прогон базового smoke-теста (happy-path) по платформам Tether — Desktop CLI (uber jar + /health + mDNS + stdin commands), Android (если adb-устройство подключено) с upload host→Android, нативная компиляция macosArm64 и iosSimulatorArm64. Используй этот скилл, когда пользователь просит «прогони smoke», «прогони smoke-тест», «basic smoke», «проверь сборку по платформам перед merge», «дымовой тест». Не путать с unit-тестами (`./gradlew allTests`) — smoke это рантайм-проверка стартует ли всё и видят ли друг друга, не корректность логики.
+description: Прогон базового smoke-теста (happy-path) по платформам Tether — Desktop CLI (uber jar + /health + mDNS + stdin commands), Desktop↔Desktop send через CLI, Android (если adb-устройство подключено) с send-from-Desktop, нативная компиляция macosArm64 и iosSimulatorArm64. Используй этот скилл, когда пользователь просит «прогони smoke», «прогони smoke-тест», «basic smoke», «basic regression», «проверь сборку по платформам перед merge», «дымовой тест». Не путать с unit-тестами (`./gradlew allTests`) — smoke это рантайм-проверка стартует ли всё и видят ли друг друга, не корректность логики.
 ---
 
 # Smoke-test skill
 
 Прогоняет базовые smoke-сценарии по таргетам Tether и выдаёт human-readable отчёт.
 
-**Это smoke, не регресс.** Цель — за 1-3 минуты увидеть, что ничего фундаментально не сломано (CLI стартует, FileServer отвечает, mDNS публикуется, stdin-команды работают, upload roundtrip OK, нативные таргеты компилируются). Корректность бизнес-логики — задача `./gradlew allTests`.
+**Это smoke, не регресс.** Цель — за 1-3 минуты увидеть, что ничего фундаментально не сломано (CLI стартует, FileServer отвечает, mDNS публикуется, stdin-команды работают, send roundtrip OK, нативные таргеты компилируются). Корректность бизнес-логики — задача `./gradlew allTests`.
 
 ## Чего скилл НЕ проверяет (вне скоупа автоматизации)
 
@@ -15,8 +15,9 @@ description: Прогон базового smoke-теста (happy-path) по п
 
 - **Физический iPhone** — нет, требует ручной подписи и доверия сертификата.
 - **macOS run** — у `macosArm64` нет entry point, только sanity-компиляция.
-- **iOS receive/upload** — `FileServer.apple` это stub, на `start()` бросает `error()`. Только sanity-компиляция `iosSimulatorArm64`.
+- **iOS receive/send** — `FileServer.apple` это stub, на `start()` бросает `error()`. Только sanity-компиляция `iosSimulatorArm64`.
 - **iOS simulator runtime** — в текущей версии скилла не запускаем (требует Xcode-проекта и времени), только compile.
+- **Android-инициированный send (Android → Desktop)** — у Android нет CLI-входа: `send` живёт только в Desktop runner'е. Скилл проверяет обратное направление: **Desktop → Android** через CLI `send`. Это **deviation от issue #69** (там было «upload Android→Desktop»), но другого автоматизируемого пути нет до тех пор, пока на Android не появится способ инициировать transfer программно (UI-кнопка, intent, broadcast). Если такой механизм заведут — добавить отдельный шаг в Блок 3.
 - **Тап по Notification «Stop»** — заменяется на `am force-stop` или broadcast. Что *кнопка нарисована и работает* — проверить вручную.
 - **Sleep/wake реального девайса** — `adb shell input keyevent SLEEP/WAKEUP` это аппроксимация, не настоящий power state.
 - **Rotation effects на FGS-выживаемость** — на эмуляторе ≠ на реальном устройстве.
@@ -25,18 +26,20 @@ description: Прогон базового smoke-теста (happy-path) по п
 
 ## Ключевое решение: uber jar, не gradle run
 
-**Не используй `./gradlew :composeApp:run` для авто-запуска CLI.** Compose Desktop's `run` task в non-TTY среде (когда скилл запускается агентом без терминала) не пробрасывает `System.in` корректно — `readLine()` сразу возвращает null, CLI выходит до того как FileServer успеет связаться с портом.
+**Не используй `./gradlew :composeApp:run` для авто-запуска CLI.** Compose Desktop's `run` task в non-TTY среде не пробрасывает `System.in` корректно — `readLine()` сразу возвращает null, CLI выходит до того как FileServer успеет связаться с портом.
 
-Вместо этого собирай uber jar и запускай через `java -jar`:
+Вместо этого собирай uber jar и запускай через `java -jar`. Имя jar определяй динамически (версия в имени может меняться):
 
 ```bash
 ./gradlew :composeApp:packageUberJarForCurrentOS -q
-java -jar composeApp/build/compose/jars/com.tubetoast.tether-macos-arm64-1.0.0.jar --name SmokeMac --port 0
+JAR=$(ls composeApp/build/compose/jars/*.jar 2>/dev/null | head -1)
+[ -z "$JAR" ] && { echo "uber jar not found"; exit 1; }
+java -jar "$JAR" --name SmokeMacA --port 0
 ```
 
-При прямом запуске `java -jar` процесс наследует stdin от bash, и FIFO-подачу команд в stdin (`list`, `quit`) можно делать напрямую.
+При прямом запуске `java -jar` процесс наследует stdin от bash, и FIFO-подачу команд в stdin (`list`, `send`, `quit`) можно делать напрямую.
 
-Имя jar для других ОС/архитектур: подставь `linux-amd64`, `windows-x64` и т.п. — но скилл рассчитан на macOS-агента.
+Скилл рассчитан на macOS-агента (имя jar содержит `macos-arm64`). Под другими ОС/архитектурами имя файла будет другим — динамический `ls` это снимает.
 
 ## План прогона
 
@@ -44,92 +47,101 @@ java -jar composeApp/build/compose/jars/com.tubetoast.tether-macos-arm64-1.0.0.j
 
 ### Блок 0: Подготовка
 
-1. Убедись, что нет работающих инстансов CLI (память: внешние mDNS-сервисы могут глючить тесты):
+1. Убедись, что нет работающих инстансов CLI:
    ```bash
    pgrep -fl 'com.tubetoast.tether-.*\.jar|composeApp:run' || echo "clean"
    ```
-   Если есть — `kill` их.
+   Если есть — `kill` их (память: внешние mDNS-сервисы могут глючить тесты).
 2. Собрать uber jar:
    ```bash
    ./gradlew :composeApp:packageUberJarForCurrentOS -q
-   ls composeApp/build/compose/jars/
+   JAR=$(ls composeApp/build/compose/jars/*.jar 2>/dev/null | head -1)
    ```
-   Запомни имя файла. Для macosArm64 это `com.tubetoast.tether-macos-arm64-1.0.0.jar`.
+   Запомни путь.
 
-Если build падает — все остальные блоки SKIP с причиной «uber jar build failed».
+Если build падает или JAR не найден — все остальные блоки SKIP с причиной «uber jar build failed».
 
-### Блок 1: Desktop CLI
+### Блок 1: Desktop CLI (инстанс A)
 
-Запуск через FIFO (stdin keeper):
+Запуск через FIFO (stdin keeper). Имя — `SmokeMacA` (важно: должно совпасть с тем, что Блок 2 ищет в логе инстанса B):
 
 ```bash
-JAR=composeApp/build/compose/jars/com.tubetoast.tether-macos-arm64-1.0.0.jar
-LOG=/tmp/smoke-cli.log
-mkfifo /tmp/smoke-cli-in
-sleep 600 > /tmp/smoke-cli-in &              # keeper holds writer fd open
-KEEPER=$!; disown $KEEPER
-echo $KEEPER > /tmp/smoke-cli-keeper.pid
+LOG_A=/tmp/smoke-cliA.log
+mkfifo /tmp/smoke-cliA-in
+sleep 600 > /tmp/smoke-cliA-in &              # keeper holds writer fd open
+KEEPER_A=$!; disown $KEEPER_A
+echo $KEEPER_A > /tmp/smoke-cliA-keeper.pid
 
-nohup java -jar $JAR --name SmokeMac --port 0 < /tmp/smoke-cli-in > $LOG 2>&1 &
-JPID=$!; disown $JPID
-echo $JPID > /tmp/smoke-cli.pid
+nohup java -jar "$JAR" --name SmokeMacA --port 0 < /tmp/smoke-cliA-in > $LOG_A 2>&1 &
+JPID_A=$!; disown $JPID_A
+echo $JPID_A > /tmp/smoke-cliA.pid
 ```
 
-Wait до 30 сек:
+Wait до 30 сек (поллинг лога надёжнее, чем `sleep` на удачу):
 ```bash
-for i in $(seq 1 30); do grep -q 'FileServer started' $LOG && break; sleep 1; done
-PORT=$(grep -oE 'port[[:space:]]*:[[:space:]]*[0-9]+' $LOG | grep -oE '[0-9]+' | head -1)
+for i in $(seq 1 30); do grep -q 'FileServer started' $LOG_A && break; sleep 1; done
+PORT_A=$(grep -oE 'port[[:space:]]*:[[:space:]]*[0-9]+' $LOG_A | grep -oE '[0-9]+' | head -1)
 ```
 
 Сценарии:
-1. **Startup** — port распарсен, java pid жив (`ps -p $JPID`). PASS если оба условия.
-2. **`/health`** — `curl -sf --max-time 5 http://localhost:$PORT/health` → должно вернуть `Tether OK`.
-3. **Port LISTEN** — `lsof -nP -iTCP:$PORT | head -3` показывает java listener.
-4. **mDNS publish** — `( dns-sd -B _tether._tcp. local. 2>&1 & DNSSD_PID=$!; sleep 8; kill $DNSSD_PID 2>/dev/null ) | grep SmokeMac` — найти SmokeMac в browse output.
-5. **stdin `list`** — `echo "list" > /tmp/smoke-cli-in &; sleep 1; tail $LOG` — должен напечатать `[list]` или `[peers]` строку.
-6. **stdin `quit` graceful** — `echo "quit" > /tmp/smoke-cli-in &`, ждать до 8 сек, проверить `ps -p $JPID` — процесс должен умереть. Если не умер — FAIL «не graceful», `kill -9` и идти дальше.
+1. **Startup** — port распарсен, java pid жив (`ps -p $JPID_A`). PASS если оба условия.
+2. **`/health`** — `curl -sf --max-time 5 http://localhost:$PORT_A/health` → должно вернуть `Tether OK`.
+3. **Port LISTEN** — `lsof -nP -iTCP:$PORT_A | head -3` показывает java listener.
+4. **mDNS publish (primary)** — поллим CLI-лог, ищем `mDNS started → advertising 'SmokeMacA' on port`. Это уже подтверждение публикации (CLI сам пишет это после успешного `discovery.start()`).
+5. **mDNS publish (secondary, опционально)** — `( dns-sd -B _tether._tcp. local. 2>&1 & DNSSD_PID=$!; sleep 8; kill $DNSSD_PID 2>/dev/null ) | grep SmokeMacA`. Если `dns-sd` нет (Linux) — этот шаг SKIP, общий результат всё равно PASS по primary.
+6. **stdin `list`** — `echo "list" > /tmp/smoke-cliA-in &; sleep 1; tail $LOG_A` — должен напечатать `[list]` или `[peers]` строку.
+7. **stdin `quit` graceful** — `echo "quit" > /tmp/smoke-cliA-in &`, ждать до 8 сек, проверить `ps -p $JPID_A` — процесс должен умереть. Если не умер — FAIL «не graceful», `kill -9` и идти дальше.
+
+**Замечание для Блока 2:** инстанс A держим живым до конца Блока 2, `quit` шлём только после успешного send. Иначе придётся перезапускать.
 
 ### Блок 2: Desktop ↔ Desktop send (через CLI)
 
-**Важно:** upload должен идти через **CLI команду `send`**, а не через `curl POST /upload`. Это смоук-тест пользовательского сценария, а не endpoint'а.
+**Важно:** send должен идти через **CLI команду `send`**, а не через `curl POST /upload`. Это смоук-тест пользовательского сценария, а не endpoint'а.
 
-Поднимаешь второй CLI-инстанс параллельно с первым (на другом FIFO/log/jar-args), ждёшь, пока mDNS даст обоим увидеть друг друга, и шлёшь команду `send <peer> <path>` в stdin первого.
+Поднимаешь второй CLI-инстанс (`SmokeMacB`) параллельно с A, ждёшь, пока mDNS даст обоим увидеть друг друга, шлёшь `send SmokeMacB <path>` в stdin A.
 
 ```bash
-JAR=composeApp/build/compose/jars/com.tubetoast.tether-macos-arm64-1.0.0.jar
-
-# Второй инстанс (первый уже запущен из блока 1, имя SmokeMacA)
+LOG_B=/tmp/smoke-cliB.log
 mkfifo /tmp/smoke-cliB-in
 sleep 600 > /tmp/smoke-cliB-in & KEEPER_B=$!; disown $KEEPER_B
 echo $KEEPER_B > /tmp/smoke-cliB-keeper.pid
-nohup java -jar $JAR --name SmokeMacB --port 0 < /tmp/smoke-cliB-in > /tmp/smoke-cliB.log 2>&1 &
+nohup java -jar "$JAR" --name SmokeMacB --port 0 < /tmp/smoke-cliB-in > $LOG_B 2>&1 &
 JPID_B=$!; disown $JPID_B
 echo $JPID_B > /tmp/smoke-cliB.pid
 
-# Wait until BOTH see each other
+# Wait until BOTH see each other (имена должны точно совпадать с --name выше)
 for i in $(seq 1 30); do
-  grep -q 'SmokeMacA' /tmp/smoke-cliB.log 2>/dev/null && \
-  grep -q 'SmokeMacB' /tmp/smoke-cli.log 2>/dev/null && break
+  grep -q 'SmokeMacA' $LOG_B 2>/dev/null && \
+  grep -q 'SmokeMacB' $LOG_A 2>/dev/null && break
   sleep 1
 done
 
-# Send file через stdin первого CLI
+# Send через stdin A
 echo "send-via-cli-$(date +%s)" > /tmp/smoke-send.txt
-echo "send SmokeMacB /tmp/smoke-send.txt" > /tmp/smoke-cli-in &
-sleep 4
+echo "send SmokeMacB /tmp/smoke-send.txt" > /tmp/smoke-cliA-in &
 
-# Проверить что в логе первого CLI: "[send] OK"
-grep -E "^\[send\] (OK|FAIL)" /tmp/smoke-cli.log | tail -3
+# Поллим лог A на финальную строку send (не на удачу через sleep N)
+for i in $(seq 1 15); do
+  grep -qE "^\[send\] (OK|FAIL)" $LOG_A && break
+  sleep 1
+done
+SEND_LINE=$(grep -E "^\[send\] (OK|FAIL)" $LOG_A | tail -1)
+echo "$SEND_LINE"
 
-# Проверить что файл реально landed в SmokeMacB's downloads
-diff /tmp/smoke-send.txt "$HOME/Downloads/Tether/smoke-send.txt" && echo PASS || echo FAIL
+# Парсим savedPath из строки "[send] OK — <ms> ms  →  <savedPath>" — не угадываем директорию
+SAVED_B=$(echo "$SEND_LINE" | sed -nE 's/.*→[[:space:]]+(.+)$/\1/p')
+if [ -n "$SAVED_B" ] && [ -f "$SAVED_B" ]; then
+  diff /tmp/smoke-send.txt "$SAVED_B" && echo PASS || echo FAIL
+else
+  echo "FAIL: savedPath not parsed or file missing"
+fi
 ```
 
 PASS если:
-1. в логе первого CLI есть `[send] OK — <ms> ms → <savedPath>`
-2. содержимое файла идентично оригиналу
+1. в логе A есть `[send] OK — <ms> ms → <savedPath>`
+2. файл по `savedPath` идентичен оригиналу
 
-Bonus: можно проверить что `[send] FAIL: peer 'NonExistent' not found` корректно обрабатывается — но это уже за рамки smoke.
+Cleanup инстанса B и квит A — в Блоке 5.
 
 ### Блок 3: Android (условно)
 
@@ -144,35 +156,63 @@ adb devices | awk '/device$/ && !/List/ {print $1}'
 
 1. **Install:** `./gradlew -q :composeApp:installDebug`
 2. **Logcat clear:** `adb logcat -c`
-3. **Start activity:** `adb shell am start -n com.tubetoast.tether/.MainActivity`
-4. **Wait + grep logs (8 сек):**
+3. **Start activity** (с замером времени для метрики cross-discovery):
    ```bash
-   sleep 8
-   adb logcat -d 2>&1 | grep -E "TetherFGService|MdnsDiscovery|FileServer started|NSD service registered" | head -20
+   LAUNCH_MS=$(python3 -c "import time; print(int(time.time() * 1000))")
+   adb shell am start -n com.tubetoast.tether/.MainActivity
    ```
-   Ищем строки:
-   - `TetherFGService: FileServer started on port <N>` → парсим `<N>` как `ANDROID_PORT`
-   - `mDNS started: name=Tether-...` → PASS «Android FGS+mDNS up»
-5. **Получить IP:**
+4. **Ждём `NSD service registered` как anchor готовности** (вместо слепого `sleep 8`):
    ```bash
-   ANDROID_IP=$(adb shell ip route 2>&1 | awk '/wlan0.*src/ {print $9}' | head -1)
+   DEADLINE=$(($(date +%s) + 12))
+   while [ $(date +%s) -lt $DEADLINE ]; do
+     adb logcat -d 2>/dev/null | grep -q "NSD service registered" && break
+     sleep 1
+   done
    ```
-   Если эмулятор и IP `10.0.2.x` — это NAT, host достучится через `adb forward tcp:18080 tcp:$ANDROID_PORT` и localhost:18080. Для физ. устройства — прямо `$ANDROID_IP:$ANDROID_PORT`.
+   Парсим:
+   - `TetherFGService: FileServer started on port <N>` → `ANDROID_PORT`
+   - `Starting NSD: name=Tether-...` и `NSD service registered: ...` — разница времён = NSD probing latency, выводим в Details.
+5. **Получить IP** (надёжный вариант через `ip addr`, не `ip route` — формат у некоторых вендоров отличается):
+   ```bash
+   ANDROID_IP=$(adb shell ip addr show wlan0 2>&1 | grep "inet " | awk '{print $2}' | cut -d/ -f1 | head -1)
+   ```
+   Если эмулятор и IP `10.0.2.x` — host-доступ через `adb forward tcp:18080 tcp:$ANDROID_PORT` и `localhost:18080`. Для физ. устройства — прямо `$ANDROID_IP:$ANDROID_PORT`.
 6. **`/health` sanity:** `curl -sf http://$ANDROID_IP:$ANDROID_PORT/health` → `Tether OK`. Это единственное место, где curl допустим — endpoint sanity, не пользовательский flow.
-7. **Cross-discovery:** в stdin Desktop CLI послать `list`, проверить что в логе появилось имя `Tether-<MODEL>` (только для физ. устройства в одной WiFi; эмулятор в NAT — обычно не виден).
-8. **Send host → Android (через CLI):**
+7. **Cross-discovery с замером времени:** в stdin Desktop CLI поллим лог, ищем `Tether-<MODEL>` пока не появится. Записываем delta от `LAUNCH_MS`:
    ```bash
-   ANDROID_NAME=$(grep -oE 'Tether-[A-Za-z0-9_]+' /tmp/smoke-cli.log | head -1)
-   echo "send-to-android-$(date +%s)" > /tmp/smoke-android.txt
-   echo "send $ANDROID_NAME /tmp/smoke-android.txt" > /tmp/smoke-cli-in &
-   sleep 5
-   grep -E "^\[send\] (OK|FAIL)" /tmp/smoke-cli.log | tail -3
-   adb shell cat /sdcard/Android/data/com.tubetoast.tether/files/Tether/smoke-android.txt | diff - /tmp/smoke-android.txt
+   for i in $(seq 1 30); do
+     sleep 1
+     grep -E "\[peers\] .*Tether-" $LOG_A | grep -v "none" | tail -1 | grep -q . && break
+   done
+   NOW_MS=$(python3 -c "import time; print(int(time.time() * 1000))")
+   DELTA_MS=$((NOW_MS - LAUNCH_MS))
+   ANDROID_NAME=$(grep -oE 'Tether-[A-Za-z0-9_]+' $LOG_A | head -1)
+   echo "cross-discovery: ${DELTA_MS}ms, peer=$ANDROID_NAME"
    ```
-   PASS если в логе Desktop CLI `[send] OK — <ms> ms → <savedPath>` И файл на Android идентичен.
-9. **Stop service:** `adb shell am force-stop com.tubetoast.tether`. PASS если приложение умерло.
+   В отчёт: `Android | cross-discovery | ✓ PASS | 2154 ms`. Это намного информативнее голого PASS.
+8. **Send Desktop → Android (через CLI):**
+   ```bash
+   if [ -z "$ANDROID_NAME" ]; then
+     echo "SKIP: cross-discovery did not surface Android peer (likely emulator NAT)"
+   else
+     echo "send-to-android-$(date +%s)" > /tmp/smoke-android.txt
+     echo "send $ANDROID_NAME /tmp/smoke-android.txt" > /tmp/smoke-cliA-in &
+     for i in $(seq 1 15); do
+       grep -qE "^\[send\] (OK|FAIL)" $LOG_A && break
+       sleep 1
+     done
+     SEND_LINE=$(grep -E "^\[send\] (OK|FAIL)" $LOG_A | tail -1)
+     # На Android savedPath абсолютный — `cat` его напрямую через adb shell
+     SAVED_PATH=$(echo "$SEND_LINE" | sed -nE 's/.*→[[:space:]]+(.+)$/\1/p')
+     adb shell cat "$SAVED_PATH" 2>/dev/null | diff - /tmp/smoke-android.txt && echo PASS || echo FAIL
+   fi
+   ```
+   PASS если в логе Desktop CLI `[send] OK` И файл на Android по распарсенному savedPath идентичен. Если ANDROID_NAME пустой — это **SKIP, не FAIL** (явная причина: cross-discovery недоступен).
+9. **Stop service:** `adb shell am force-stop com.tubetoast.tether`. PASS если приложение умерло. (Тап Notification «Stop» — manual.)
 
-Помечай каждый под-сценарий отдельно: install, FGS+mDNS up, /health sanity, cross-discovery, send-to-android, stop.
+**Direction note:** этот блок проверяет Desktop → Android. Обратное направление (Android → Desktop) автоматизировать нельзя — см. секцию «Чего скилл НЕ проверяет».
+
+Помечай каждый под-сценарий отдельно: install, FGS+mDNS up (с NSD probing latency), /health sanity, cross-discovery (с ms), send-desktop-to-android, stop.
 
 ### Блок 4: Native compile sanity
 
@@ -186,16 +226,16 @@ PASS если exit=0. FAIL — приложить последние ~30 стр�
 ### Блок 5: Cleanup
 
 Выполняется **всегда**:
-- `kill $(cat /tmp/smoke-cli.pid /tmp/smoke-cliB.pid /tmp/smoke-cli-keeper.pid /tmp/smoke-cliB-keeper.pid 2>/dev/null) 2>/dev/null`
+- `kill $(cat /tmp/smoke-cliA.pid /tmp/smoke-cliB.pid /tmp/smoke-cliA-keeper.pid /tmp/smoke-cliB-keeper.pid 2>/dev/null) 2>/dev/null`
 - `pkill -f 'com.tubetoast.tether.*\.jar'` (страховка)
-- `rm -f /tmp/smoke-cli*-in /tmp/smoke-cli*.log /tmp/smoke-cli*.pid /tmp/smoke-cli*-keeper.pid /tmp/smoke-port.txt /tmp/smoke-send.txt /tmp/smoke-android.txt`
-- `rm -f $HOME/Downloads/Tether/smoke-send.txt` (сами создали — сами убираем)
-- `adb shell rm -f /sdcard/Android/data/com.tubetoast.tether/files/Tether/smoke-android.txt`
+- `rm -f /tmp/smoke-cli*-in /tmp/smoke-cli*.log /tmp/smoke-cli*.pid /tmp/smoke-cli*-keeper.pid /tmp/smoke-send.txt /tmp/smoke-android.txt`
+- Файлы в `~/Downloads/Tether/`, которые сами создали — убираем по `savedPath` из лога A (не по угаданному пути).
+- `adb shell rm -f /sdcard/Android/data/com.tubetoast.tether/files/Tether/smoke-android.txt` (или по `SAVED_PATH` если парсили)
 - `adb shell am force-stop com.tubetoast.tether`
 
 ## Формат отчёта
 
-В конце прогона печатаешь markdown-отчёт ровно по этой структуре:
+В конце прогона печатаешь markdown-отчёт:
 
 ```markdown
 # Smoke test report
@@ -203,7 +243,7 @@ PASS если exit=0. FAIL — приложить последние ~30 стр�
 **Дата:** YYYY-MM-DD HH:MM
 **Branch:** <git branch>
 **Commit:** <short sha>
-**Jar:** com.tubetoast.tether-macos-arm64-1.0.0.jar (built in Ns)
+**Jar:** <auto-detected name> (built in Ns)
 
 ## Summary
 
@@ -217,21 +257,23 @@ PASS если exit=0. FAIL — приложить последние ~30 стр�
 
 | Block | Scenario | Result | Details |
 |---|---|---|---|
-| Desktop CLI | uber jar build | ✓ PASS | 8s |
-| Desktop CLI | startup + port parse | ✓ PASS | port=49507, pid=83952 |
-| Desktop CLI | /health | ✓ PASS | "Tether OK" |
-| Desktop CLI | port LISTEN | ✓ PASS | java *:49507 |
-| Desktop CLI | mDNS publish | ✓ PASS | SmokeMac в dns-sd -B |
-| Desktop CLI | stdin `list` | ✓ PASS | peer printed |
-| Desktop CLI | graceful `quit` | ✓ PASS | exit in 3s |
-| Desktop↔Desktop | upload roundtrip | ✓ PASS | diff empty |
+| Build | uber jar | ✓ PASS | <Ns>, jar=<name> |
+| Desktop CLI A | startup + port | ✓ PASS | port=49507, pid=83952 |
+| Desktop CLI A | /health | ✓ PASS | "Tether OK" |
+| Desktop CLI A | port LISTEN | ✓ PASS | java *:49507 |
+| Desktop CLI A | mDNS publish (log) | ✓ PASS | advertising 'SmokeMacA' |
+| Desktop CLI A | mDNS publish (dns-sd) | ✓ PASS | SmokeMacA в browse |
+| Desktop CLI A | stdin `list` | ✓ PASS | peer printed |
+| Desktop↔Desktop | send via CLI | ✓ PASS | savedPath parsed, diff empty |
+| Desktop CLI A | graceful `quit` | ✓ PASS | exit in 3s |
 | Android | adb device | ✓ PASS | <serial>, model, API |
 | Android | installDebug | ✓ PASS | 4s |
-| Android | FGS + FileServer up | ✓ PASS | port=42367 |
+| Android | FGS + FileServer | ✓ PASS | port=42367 |
+| Android | NSD probing latency | ✓ PASS | 950ms (start→registered) |
 | Android | mDNS publish | ✓ PASS | Tether-<MODEL> |
 | Android | /health (over WiFi) | ✓ PASS | "Tether OK" |
-| Android | upload host→Android | ✓ PASS | content match |
-| Android | cross-discovery (Desktop sees Android) | ~ PARTIAL | seen в browse, deepening |
+| Android | cross-discovery | ✓ PASS | 2154ms (launch→peer-on-Desktop) |
+| Android | send Desktop→Android | ✓ PASS | savedPath parsed, diff empty |
 | Android | force-stop | ✓ PASS | process killed |
 | Native | compileKotlinMacosArm64 | ✓ PASS | 1s |
 | Native | compileKotlinIosSimulatorArm64 | ✓ PASS | 2s |
@@ -244,10 +286,11 @@ PASS если exit=0. FAIL — приложить последние ~30 стр�
 
 - iOS simulator runtime — запустить `iosApp/iosApp.xcodeproj` в Xcode, проверить mDNS publish.
 - Физический iPhone — установить через Xcode, проверить кросс-обнаружение с Desktop.
-- macOS run — нет entry point, не запускается.
-- iOS receive (FileServer.apple — stub) — пропускаем.
+- macOS run — нет entry point.
+- iOS receive (FileServer.apple — stub) — пропускаем по дизайну.
+- **Android-инициированный send (Android → Desktop)** — нет CLI на Android, скилл проверяет обратное направление.
 - Notification «Stop» button on Android — проверить тап вручную; smoke использует `am force-stop`.
-- Sleep/wake real device — `adb shell input keyevent` ≠ реальный power state.
+- Sleep/wake real device — `adb input keyevent` ≠ реальный power state.
 - Rotation persistence — на реальном устройстве, эмулятор недостаточен.
 
 ## Environment
@@ -256,14 +299,14 @@ PASS если exit=0. FAIL — приложить последние ~30 стр�
 - Java: <java -version>
 - adb device: <serial / model / API> или "none"
 - Xcode: <xcodebuild -version | head -1>
-- dns-sd: <path>
+- dns-sd: <path> или "not available"
 ```
 
 ## Как вызывать
 
 Когда пользователь просит «прогони smoke»:
 
-1. Печатаешь короткий план (1-2 строки): «прогоню Desktop CLI через uber jar, Desktop↔Desktop upload, Android если есть устройство, native compile. Что не проверяю — см. отчёт».
+1. Печатаешь короткий план (1-2 строки): «прогоню Desktop CLI через uber jar, Desktop↔Desktop send, Android если есть устройство, native compile. Что не проверяю — см. отчёт».
 2. Запускаешь блоки.
 3. Печатаешь отчёт.
 4. Если verdict 🔴 — даёшь recommend: какой блок упал и куда смотреть.
@@ -272,19 +315,23 @@ PASS если exit=0. FAIL — приложить последние ~30 стр�
 
 ## Edge cases при прогоне
 
-- **Gradle daemon занят** — не убивай его, он переиспользуется.
+- **Gradle daemon занят** — не убивай его, переиспользуется.
 - **Uber jar старый (изменился код)** — `packageUberJarForCurrentOS` сам пересоберёт что нужно. Не делай `clean`.
-- **`dns-sd` не на macOS** — Linux нет; в этом случае mDNS browse SKIP с причиной «dns-sd not available».
-- **`timeout` на macOS отсутствует** — используй pattern `( cmd & PID=$!; sleep N; kill $PID )` вместо `timeout`.
+- **Имя jar содержит версию** — определяй динамически через `ls composeApp/build/compose/jars/*.jar | head -1`. Не хардкодь `1.0.0`.
+- **`dns-sd` не на macOS** — Linux нет; secondary mDNS check SKIP с причиной «dns-sd not available». Primary check (grep CLI лога на `mDNS started`) всё равно работает.
+- **`timeout` на macOS отсутствует** — pattern `( cmd & PID=$!; sleep N; kill $PID )` вместо `timeout`.
 - **FIFO writer keeper умер раньше времени** — readLine() вернёт null, CLI выйдет; проверяй `ps -p $KEEPER`.
-- **Эмулятор Android в NAT (10.0.2.x)** — `adb forward` обязателен, прямой доступ host→android не работает.
+- **Эмулятор Android в NAT (10.0.2.x)** — cross-discovery не работает (multicast в NAT блокируется), `ANDROID_NAME` пустой → send-блок SKIP с понятной причиной, не FAIL. Health доступен через `adb forward`.
+- **`ip route` ненадёжен на части вендоров** (ColorOS, MIUI отдают подсеть вместо src) — используй `ip addr show wlan0`.
 - **Несколько adb-устройств** — выбирай первое или fail с уточнением. Не вешай скилл на специфичный serial.
+- **`savedPath` всегда парсить из лога**, не угадывать `$HOME/Downloads/Tether/...`. Пользователь может изменить директорию загрузок.
 
 ## Что НЕ делать
 
 - **Не используй `./gradlew :composeApp:run`** — баг со stdin (см. выше).
 - **Не запускай `allTests`** — это другой инструмент. Smoke ≤3 минуты.
 - **Не модифицируй код приложения** даже если видишь проблему. Сообщай в отчёте, заводи issue отдельно.
-- **Не лезь в `~/Downloads`** ничего кроме `Tether/smoke.txt` — там пользовательский контент.
+- **Не лезь в `~/Downloads`** дальше своих файлов — там пользовательский контент.
 - **Не запускай `./gradlew clean`** — съест кеш и замедлит следующий прогон.
 - **Не отправляй ничего в сеть** кроме localhost и `$ANDROID_IP` (последний — только если adb-устройство подключено).
+- **Не угадывай пути назначения файлов** — всегда парси из `[send] OK — ... → <savedPath>`.


### PR DESCRIPTION
## Summary

- Добавлен скилл `.claude/skills/smoke-test/SKILL.md` для базовой happy-path проверки по таргетам перед merge/релизом.
- Запуск Desktop CLI идёт через uber jar (`packageUberJarForCurrentOS` + `java -jar`), потому что `:composeApp:run` в non-TTY не пробрасывает `System.in`.
- File transfer проверяется через CLI команду `send` (как пользователь), `curl` оставлен только для `/health` sanity.
- Покрытие: Desktop CLI (startup, `/health`, mDNS publish, stdin `list`/`quit`), Desktop↔Desktop send (через два параллельных CLI), Android (FGS + FileServer + mDNS + cross-discovery с замером ms + Desktop→Android send), native compile macosArm64 / iosSimulatorArm64.
- Out of scope (manual): физический iPhone, macOS run, iOS receive (FileServer.apple — stub), тап Notification «Stop», sleep/wake реального девайса.

## ⚠️ Deviation от DoD #69 — направление Android transfer

В issue #69 описан сценарий **Android → Desktop** (Android инициирует upload). На сегодня в коде Android **нет программного входа для отправки файла** — `send` живёт только в Desktop CLI runner'е, а на Android FGS работает в receive-only режиме, и UI-кнопки «Send» пока нет.

Поэтому скилл проверяет **обратное направление: Desktop → Android** (Desktop инициирует, Android принимает). Это всё ещё валидный smoke для FileServer на Android (он реально получает и сохраняет файл), но сетевой код-пас отправки с Android **не покрыт автоматически и не будет покрыт этим скиллом**.

- В SKILL.md это явно зафиксировано в трёх местах: «Чего скилл НЕ проверяет», Блок 3 («Direction note»), шаблон отчёта («Manual verification required»).
- Когда на Android появится UI-кнопка отправки (фичевая задача, не часть smoke) — добавим отдельный шаг в Блок 3, инициируемый через `am broadcast`/`uiautomator`. Отдельного issue под это пока не заводим.

## Test plan

- [ ] Прогнать `/smoke-test` на чистой машине, убедиться что отчёт зелёный (Desktop blocks PASS).
- [ ] Прогнать с подключённым физическим Android — все блоки (install, FGS up, mDNS publish с probing latency, /health, cross-discovery с ms, Desktop→Android send, force-stop) должны быть PASS.
- [ ] Проверить что отчёт содержит секцию «Manual verification required» с явным перечислением неавтоматизируемого, включая Android-инициированный send.
- [ ] Без подключённого adb — Android-блок должен быть SKIP, не FAIL.
- [ ] При эмуляторе в NAT — Android-send-step должен быть SKIP с понятной причиной (multicast не проходит → cross-discovery недоступен), не FAIL.

Closes #69 (с deviation, см. выше)

🤖 Generated with [Claude Code](https://claude.com/claude-code)