### PR TITLE
#80: re-arm JmDNS ServiceResolver to catch late-joining peers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,7 +195,10 @@ GitHub Actions (`.github/workflows/ci.yml`) runs on all pushes and PRs to main:
 
 - **Desktop JVM tests** (`desktopTest/`): Server и network интеграционные тесты
 - **Common tests** (`commonTest/`): протокол и shared-логика
-- Стиль: `kotlin.test`, `runBlocking` для корутин, `withTimeout` для сетевых/асинхронных тестов
+- Стиль: `kotlin.test`; для корутин — `runTest` + `TestDispatcher` (из `kotlinx-coroutines-test`), **не `runBlocking`**
+- Управляй временем виртуально через `advanceTimeBy()` / `advanceUntilIdle()` — это ускоряет тесты и делает их детерминированными
+- `Thread.sleep` и `System.currentTimeMillis`-polling допустимы только для ожидания событий от **внешних нативных API** (JmDNS, NsdManager и т.п.), которые работают на реальных потоках вне нашего `CoroutineScope`; внутри тела теста всё остальное — виртуальное время
+- `withTimeout` внутри `runTest` использует **виртуальные** часы даже на `Dispatchers.IO` — не рассчитывай на него как на реальный таймаут
 - **Apple targets** (`appleTest/`): NSRunLoop нужно качать вручную — подробнее в [`docs/knowledge/apple-platform.md`](docs/knowledge/apple-platform.md).
 
 ## Knowledge base

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,7 @@ GitHub Actions (`.github/workflows/ci.yml`) runs on all pushes and PRs to main:
 - **Protocol Serialization**: Device.kt uses kotlinx.serialization for peer identification
 - **Compose for All Targets**: UI code in commonMain; platform-specific initialization in androidMain/iosMain/macosMain/desktopMain
 - **CLI Arguments**: Desktop runner accepts `--name` and `--port` via Clikt framework
+- **Comment style**: минимум комментариев. Перед тем как добавить комментарий — попробуй вынести блок в приватный метод: имя метода часто делает комментарий ненужным. Комментарий оставляй только там, где код не может выразить намерение сам: намеренное проглатывание исключения, неочевидные инварианты внешних библиотек, которые нужно перепроверять при обновлении зависимости.
 
 ## Testing Strategy
 
@@ -213,3 +214,5 @@ When reviewing a PR, follow the process in [`.claude/commands/code-review.md`](.
 
 **Важно: редактируй файлы только в worktree, не в корне репозитория.**
 Перед первым Edit убедись, что путь ведёт в `.claude/worktrees/<branch>/`, а не в корень проекта. Ошибка в пути приведёт к правке основной ветки в обход ревью.
+
+**Обновление инструкций (CLAUDE.md и других файлов в `.claude/`)**: правь только файл внутри текущего worktree. Корневой `CLAUDE.md` живёт на `main` — изменения в него попадают через обычный PR-флоу, а не прямой правкой.

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -144,6 +144,12 @@ kotlin {
                 implementation(libs.ktor.serialization.kotlinx.json)
             }
         }
+
+        sourceSets.named("desktopTest") {
+            dependencies {
+                implementation(libs.kotlinx.coroutines.test)
+            }
+        }
     }
 }
 

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
@@ -15,6 +15,7 @@ import javax.jmdns.JmDNS
 import javax.jmdns.ServiceEvent
 import javax.jmdns.ServiceInfo
 import javax.jmdns.ServiceListener
+import kotlin.coroutines.CoroutineContext
 
 private const val SERVICE_TYPE = "_tether._tcp.local."
 private val IPV4_REGEX = Regex("""\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}""")
@@ -32,10 +33,24 @@ private val IPV4_REGEX = Regex("""\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}""")
 // list.contains(status) via ListenerStatus.equals → getListener().equals() before adding,
 // and calls startServiceResolver(type) unconditionally afterwards regardless of dedup.
 // If JmDNS is upgraded, re-verify this invariant in JmDNSImpl.addServiceListener.
-private const val REQUERY_INITIAL_INTERVAL_MS = 5_000L
+internal const val REQUERY_INITIAL_INTERVAL_MS = 5_000L
 private const val REQUERY_MAX_INTERVAL_MS = 60_000L
 
 actual class MdnsDiscovery {
+    private val requeryContext: CoroutineContext
+
+    // Matches the expect class — production use, re-query runs on Dispatchers.IO.
+    constructor() {
+        requeryContext = Dispatchers.IO
+    }
+
+    // Additional constructor visible within the module for tests. Allows injecting a
+    // TestDispatcher so that advanceTimeBy() controls the re-query backoff timer
+    // without waiting for real time.
+    internal constructor(testContext: CoroutineContext) {
+        requeryContext = testContext
+    }
+
     private val _discoveredDevices = MutableStateFlow<List<Device>>(emptyList())
     actual val discoveredDevices: StateFlow<List<Device>> = _discoveredDevices.asStateFlow()
 
@@ -117,7 +132,7 @@ actual class MdnsDiscovery {
         serviceListener = listener
         instance.addServiceListener(SERVICE_TYPE, listener)
 
-        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val scope = CoroutineScope(SupervisorJob() + requeryContext)
         requeryScope = scope
         scope.launch {
             var interval = REQUERY_INITIAL_INTERVAL_MS

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
@@ -56,14 +56,12 @@ actual class MdnsDiscovery {
 
     @Volatile private var jmdns: JmDNS? = null
 
-    // Self-filter: identify own service by the IP JmDNS bound to and the registered port.
-    // Name-based filtering is unreliable — JmDNS may rename the service on conflict
-    // (e.g. "Foo" → "Foo (2)"), and stale records of the old name linger after a restart.
+    // JmDNS may rename a service on conflict (e.g. "Foo" → "Foo (2)"), so we identify
+    // our own service by IP+port, not by name.
     @Volatile private var ownIp: String? = null
 
     @Volatile private var ownPort: Int = -1
 
-    @Volatile private var serviceListener: ServiceListener? = null
     private var requeryScope: CoroutineScope? = null
 
     @Synchronized
@@ -94,28 +92,12 @@ actual class MdnsDiscovery {
                 if (jmdns == null) return
                 try {
                     val info: ServiceInfo = event.info
-
                     if (info.port !in 1..65535) {
                         System.err.println("WARN: invalid port ${info.port} for '${event.name}', skipping")
                         return
                     }
-
-                    val ipv4 = info.getHostAddresses().firstOrNull { IPV4_REGEX.matches(it) }
-                    if (ipv4 == null) {
-                        // JmDNS resolves A/AAAA records in stages — first callback can carry only
-                        // IPv6, IPv4 arrives on a later callback. Skip quietly and wait for the
-                        // next event. A persistent IPv6-only state across the peer's lifetime
-                        // is a separate concern (see follow-up logger issue).
-                        System.err.println(
-                            "DEBUG: serviceResolved — no IPv4 yet for '${event.name}', skipping",
-                        )
-                        return
-                    }
-
-                    // Filter self: same IP and same port uniquely identifies our own service,
-                    // regardless of the name JmDNS assigned (which may differ from deviceName).
-                    if (ipv4 == ownIp && info.port == ownPort) return
-
+                    val ipv4 = resolveIPv4(info, event.name) ?: return
+                    if (isSelf(ipv4, info.port)) return
                     val device = Device(
                         id = "${event.name}@$ipv4:${info.port}",
                         name = event.name,
@@ -129,7 +111,6 @@ actual class MdnsDiscovery {
                 }
             }
         }
-        serviceListener = listener
         instance.addServiceListener(SERVICE_TYPE, listener)
 
         val scope = CoroutineScope(SupervisorJob() + requeryContext)
@@ -139,9 +120,8 @@ actual class MdnsDiscovery {
             while (isActive) {
                 delay(interval)
                 val jm = jmdns ?: break
-                val sl = serviceListener ?: break
                 try {
-                    jm.addServiceListener(SERVICE_TYPE, sl)
+                    jm.addServiceListener(SERVICE_TYPE, listener)
                 } catch (e: Exception) {
                     // JmDNS may be mid-close; nothing to do.
                 }
@@ -156,7 +136,6 @@ actual class MdnsDiscovery {
         } catch (e: Exception) {
             scope.cancel()
             requeryScope = null
-            serviceListener = null
             jmdns = null
             ownIp = null
             ownPort = -1
@@ -172,7 +151,6 @@ actual class MdnsDiscovery {
     actual fun stop() {
         requeryScope?.cancel()
         requeryScope = null
-        serviceListener = null
         try {
             try {
                 jmdns?.unregisterAllServices()
@@ -191,4 +169,16 @@ actual class MdnsDiscovery {
             _discoveredDevices.value = emptyList()
         }
     }
+
+    // JmDNS resolves A/AAAA records in stages — the first callback may carry only IPv6;
+    // IPv4 arrives on a later callback. Returns null (caller skips) and waits for the next event.
+    private fun resolveIPv4(info: ServiceInfo, serviceName: String): String? {
+        val ipv4 = info.getHostAddresses().firstOrNull { IPV4_REGEX.matches(it) }
+        if (ipv4 == null) {
+            System.err.println("DEBUG: serviceResolved — no IPv4 yet for '$serviceName', skipping")
+        }
+        return ipv4
+    }
+
+    private fun isSelf(ipv4: String, port: Int): Boolean = ipv4 == ownIp && port == ownPort
 }

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
@@ -3,8 +3,8 @@ package com.tubetoast.tether.discovery
 import com.tubetoast.tether.protocol.Device
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -42,6 +42,7 @@ actual class MdnsDiscovery {
     // Matches the expect class — production use, re-query runs on Dispatchers.IO.
     constructor() {
         requeryContext = Dispatchers.IO
+        requeryScope = CoroutineScope(SupervisorJob() + requeryContext)
     }
 
     // Additional constructor visible within the module for tests. Allows injecting a
@@ -49,6 +50,7 @@ actual class MdnsDiscovery {
     // without waiting for real time.
     internal constructor(testContext: CoroutineContext) {
         requeryContext = testContext
+        requeryScope = CoroutineScope(SupervisorJob() + requeryContext)
     }
 
     private val _discoveredDevices = MutableStateFlow<List<Device>>(emptyList())
@@ -62,7 +64,8 @@ actual class MdnsDiscovery {
 
     @Volatile private var ownPort: Int = -1
 
-    private var requeryScope: CoroutineScope? = null
+    private lateinit var requeryScope: CoroutineScope
+    private var requeryJob: Job? = null
 
     @Synchronized
     actual fun start(deviceName: String, port: Int) {
@@ -113,9 +116,7 @@ actual class MdnsDiscovery {
         }
         instance.addServiceListener(SERVICE_TYPE, listener)
 
-        val scope = CoroutineScope(SupervisorJob() + requeryContext)
-        requeryScope = scope
-        scope.launch {
+        requeryJob = requeryScope.launch {
             var interval = REQUERY_INITIAL_INTERVAL_MS
             while (isActive) {
                 delay(interval)
@@ -134,8 +135,8 @@ actual class MdnsDiscovery {
                 ServiceInfo.create(SERVICE_TYPE, deviceName, port, ""),
             )
         } catch (e: Exception) {
-            scope.cancel()
-            requeryScope = null
+            requeryJob?.cancel()
+            requeryJob = null
             jmdns = null
             ownIp = null
             ownPort = -1
@@ -149,8 +150,8 @@ actual class MdnsDiscovery {
 
     @Synchronized
     actual fun stop() {
-        requeryScope?.cancel()
-        requeryScope = null
+        requeryJob?.cancel()
+        requeryJob = null
         try {
             try {
                 jmdns?.unregisterAllServices()

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
@@ -39,15 +39,12 @@ private const val REQUERY_MAX_INTERVAL_MS = 60_000L
 actual class MdnsDiscovery {
     private val requeryContext: CoroutineContext
 
-    // Matches the expect class — production use, re-query runs on Dispatchers.IO.
     constructor() {
         requeryContext = Dispatchers.IO
         requeryScope = CoroutineScope(SupervisorJob() + requeryContext)
     }
 
-    // Additional constructor visible within the module for tests. Allows injecting a
-    // TestDispatcher so that advanceTimeBy() controls the re-query backoff timer
-    // without waiting for real time.
+    // Internal — for tests: inject a TestDispatcher to control re-query timing via advanceTimeBy().
     internal constructor(testContext: CoroutineContext) {
         requeryContext = testContext
         requeryScope = CoroutineScope(SupervisorJob() + requeryContext)
@@ -58,8 +55,7 @@ actual class MdnsDiscovery {
 
     @Volatile private var jmdns: JmDNS? = null
 
-    // JmDNS may rename a service on conflict (e.g. "Foo" → "Foo (2)"), so we identify
-    // our own service by IP+port, not by name.
+    // IP+port, not name: JmDNS may rename a service on conflict (e.g. "Foo" → "Foo (2)").
     @Volatile private var ownIp: String? = null
 
     @Volatile private var ownPort: Int = -1
@@ -171,8 +167,7 @@ actual class MdnsDiscovery {
         }
     }
 
-    // JmDNS resolves A/AAAA records in stages — the first callback may carry only IPv6;
-    // IPv4 arrives on a later callback. Returns null (caller skips) and waits for the next event.
+    // JmDNS may deliver only IPv6 on the first callback; IPv4 arrives later.
     private fun resolveIPv4(info: ServiceInfo, serviceName: String): String? {
         val ipv4 = info.getHostAddresses().firstOrNull { IPV4_REGEX.matches(it) }
         if (ipv4 == null) {

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
@@ -1,9 +1,16 @@
 package com.tubetoast.tether.discovery
 
 import com.tubetoast.tether.protocol.Device
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import javax.jmdns.JmDNS
 import javax.jmdns.ServiceEvent
 import javax.jmdns.ServiceInfo
@@ -11,6 +18,22 @@ import javax.jmdns.ServiceListener
 
 private const val SERVICE_TYPE = "_tether._tcp.local."
 private val IPV4_REGEX = Regex("""\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}""")
+
+// JmDNS's ServiceResolver sends 3 PTR queries within ~675ms of addServiceListener and then
+// stops. After that JmDNS only re-queries when cached records become stale (~80% of TTL,
+// i.e. ~48 minutes by default). If a peer's initial multicast announcement is missed
+// (transient packet loss, WiFi power-save, etc.), discovery stalls until the next
+// announcement from the peer — observed in production as 2–3 minute latency for Android
+// peers (issue #47). Re-invoking addServiceListener with the same listener instance does
+// not add a duplicate (deduped via equals) but unconditionally re-arms ServiceResolver,
+// flushing out late or lost announcements.
+//
+// Verified against JmDNS 3.5.9 (libs.versions.toml): JmDNSImpl.addServiceListener checks
+// list.contains(status) via ListenerStatus.equals → getListener().equals() before adding,
+// and calls startServiceResolver(type) unconditionally afterwards regardless of dedup.
+// If JmDNS is upgraded, re-verify this invariant in JmDNSImpl.addServiceListener.
+private const val REQUERY_INITIAL_INTERVAL_MS = 5_000L
+private const val REQUERY_MAX_INTERVAL_MS = 60_000L
 
 actual class MdnsDiscovery {
     private val _discoveredDevices = MutableStateFlow<List<Device>>(emptyList())
@@ -25,6 +48,9 @@ actual class MdnsDiscovery {
 
     @Volatile private var ownPort: Int = -1
 
+    @Volatile private var serviceListener: ServiceListener? = null
+    private var requeryScope: CoroutineScope? = null
+
     @Synchronized
     actual fun start(deviceName: String, port: Int) {
         if (jmdns != null) throw IllegalStateException("MdnsDiscovery already started; call stop() first")
@@ -38,65 +64,84 @@ actual class MdnsDiscovery {
         ownIp = instance.inetAddress.hostAddress
         ownPort = port
 
-        instance.addServiceListener(
-            SERVICE_TYPE,
-            object : ServiceListener {
-                override fun serviceAdded(event: ServiceEvent) {
-                    jmdns?.requestServiceInfo(event.type, event.name)
-                }
+        val listener = object : ServiceListener {
+            override fun serviceAdded(event: ServiceEvent) {
+                jmdns?.requestServiceInfo(event.type, event.name)
+            }
 
-                override fun serviceRemoved(event: ServiceEvent) {
-                    System.err.println("INFO: serviceRemoved '${event.name}'")
-                    _discoveredDevices.value = _discoveredDevices.value
-                        .filterNot { it.name == event.name }
-                }
+            override fun serviceRemoved(event: ServiceEvent) {
+                System.err.println("INFO: serviceRemoved '${event.name}'")
+                _discoveredDevices.value = _discoveredDevices.value
+                    .filterNot { it.name == event.name }
+            }
 
-                override fun serviceResolved(event: ServiceEvent) {
-                    if (jmdns == null) return
-                    try {
-                        val info: ServiceInfo = event.info
+            override fun serviceResolved(event: ServiceEvent) {
+                if (jmdns == null) return
+                try {
+                    val info: ServiceInfo = event.info
 
-                        if (info.port !in 1..65535) {
-                            System.err.println("WARN: invalid port ${info.port} for '${event.name}', skipping")
-                            return
-                        }
-
-                        val ipv4 = info.getHostAddresses().firstOrNull { IPV4_REGEX.matches(it) }
-                        if (ipv4 == null) {
-                            // JmDNS resolves A/AAAA records in stages — first callback can carry only
-                            // IPv6, IPv4 arrives on a later callback. Skip quietly and wait for the
-                            // next event. A persistent IPv6-only state across the peer's lifetime
-                            // is a separate concern (see follow-up logger issue).
-                            System.err.println(
-                                "DEBUG: serviceResolved — no IPv4 yet for '${event.name}', skipping",
-                            )
-                            return
-                        }
-
-                        // Filter self: same IP and same port uniquely identifies our own service,
-                        // regardless of the name JmDNS assigned (which may differ from deviceName).
-                        if (ipv4 == ownIp && info.port == ownPort) return
-
-                        val device = Device(
-                            id = "${event.name}@$ipv4:${info.port}",
-                            name = event.name,
-                            host = ipv4,
-                            port = info.port,
-                        )
-                        _discoveredDevices.value = _discoveredDevices.value
-                            .filterNot { it.name == device.name } + device
-                    } catch (e: Exception) {
-                        System.err.println("WARN: serviceResolved error for '${event.name}' — ${e.message}")
+                    if (info.port !in 1..65535) {
+                        System.err.println("WARN: invalid port ${info.port} for '${event.name}', skipping")
+                        return
                     }
+
+                    val ipv4 = info.getHostAddresses().firstOrNull { IPV4_REGEX.matches(it) }
+                    if (ipv4 == null) {
+                        // JmDNS resolves A/AAAA records in stages — first callback can carry only
+                        // IPv6, IPv4 arrives on a later callback. Skip quietly and wait for the
+                        // next event. A persistent IPv6-only state across the peer's lifetime
+                        // is a separate concern (see follow-up logger issue).
+                        System.err.println(
+                            "DEBUG: serviceResolved — no IPv4 yet for '${event.name}', skipping",
+                        )
+                        return
+                    }
+
+                    // Filter self: same IP and same port uniquely identifies our own service,
+                    // regardless of the name JmDNS assigned (which may differ from deviceName).
+                    if (ipv4 == ownIp && info.port == ownPort) return
+
+                    val device = Device(
+                        id = "${event.name}@$ipv4:${info.port}",
+                        name = event.name,
+                        host = ipv4,
+                        port = info.port,
+                    )
+                    _discoveredDevices.value = _discoveredDevices.value
+                        .filterNot { it.name == device.name } + device
+                } catch (e: Exception) {
+                    System.err.println("WARN: serviceResolved error for '${event.name}' — ${e.message}")
                 }
-            },
-        )
+            }
+        }
+        serviceListener = listener
+        instance.addServiceListener(SERVICE_TYPE, listener)
+
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        requeryScope = scope
+        scope.launch {
+            var interval = REQUERY_INITIAL_INTERVAL_MS
+            while (isActive) {
+                delay(interval)
+                val jm = jmdns ?: break
+                val sl = serviceListener ?: break
+                try {
+                    jm.addServiceListener(SERVICE_TYPE, sl)
+                } catch (e: Exception) {
+                    // JmDNS may be mid-close; nothing to do.
+                }
+                interval = minOf(interval * 2, REQUERY_MAX_INTERVAL_MS)
+            }
+        }
 
         try {
             instance.registerService(
                 ServiceInfo.create(SERVICE_TYPE, deviceName, port, ""),
             )
         } catch (e: Exception) {
+            scope.cancel()
+            requeryScope = null
+            serviceListener = null
             jmdns = null
             ownIp = null
             ownPort = -1
@@ -110,6 +155,9 @@ actual class MdnsDiscovery {
 
     @Synchronized
     actual fun stop() {
+        requeryScope?.cancel()
+        requeryScope = null
+        serviceListener = null
         try {
             try {
                 jmdns?.unregisterAllServices()

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/discovery/MdnsDiscoveryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/discovery/MdnsDiscoveryTest.kt
@@ -2,9 +2,11 @@ package com.tubetoast.tether.discovery
 
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -212,23 +214,38 @@ class MdnsDiscoveryTest {
     // Reproduces issue #47: a peer that registers after JmDNS's initial 3-query
     // ServiceResolver burst (~675 ms) must still be discovered without waiting for the
     // ~48-minute TTL refresh. Implemented via periodic re-arming of addServiceListener.
+    //
+    // Uses runTest + StandardTestDispatcher to control the re-query backoff timer with
+    // virtual time. JmDNS's own timers run on real threads — Thread.sleep is used for
+    // those boundaries. Discovery is polled via System.currentTimeMillis rather than
+    // a coroutine withTimeout because runTest routes all coroutine delays through the
+    // virtual clock; a real-time guard is needed for the JmDNS callback.
     @Test
-    fun `late-joining peer is discovered after initial browse cycle`() = runBlocking {
-        val a = MdnsDiscovery()
-        val b = MdnsDiscovery()
+    fun `late-joining peer is discovered after initial browse cycle`() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val a = MdnsDiscovery(testDispatcher)
+        val b = MdnsDiscovery(testDispatcher)
         try {
             a.start("LateA", 19070)
-            // Well past the initial ServiceResolver burst (3 × 225 ms ≈ 675 ms) so any
-            // discovery now depends on the periodic re-query, not the initial cycle.
-            delay(3_000)
-
+            // JmDNS's ServiceResolver fires 3 PTR queries over ~675 ms of real time.
+            // Thread.sleep keeps us in real time so the burst finishes before b joins.
+            Thread.sleep(1_500)
             b.start("LateB", 19071)
-
-            val peers = withTimeout(15_000) {
-                a.discoveredDevices.first { peers -> peers.any { it.name == "LateB" } }
+            // JmDNS probes the service name before advertising (~3 × 250 ms). Wait for
+            // b to be reachable on the network before triggering a's re-query.
+            Thread.sleep(1_000)
+            // Advance virtual clock past the initial re-query interval: triggers
+            // addServiceListener in a's re-query coroutine, which re-arms ServiceResolver.
+            advanceTimeBy(REQUERY_INITIAL_INTERVAL_MS + 1)
+            // Poll with real time — discoveredDevices is updated from JmDNS's own threads
+            // and coroutine withTimeout would use virtual clock (routed through testScheduler).
+            val deadline = System.currentTimeMillis() + 10_000
+            while (System.currentTimeMillis() < deadline) {
+                if (a.discoveredDevices.value.any { it.name == "LateB" }) break
+                Thread.sleep(100)
             }
-            val lateB = peers.filter { it.name == "LateB" }
-            assertEquals(1, lateB.size)
+            val lateB = a.discoveredDevices.value.filter { it.name == "LateB" }
+            assertEquals(1, lateB.size, "LateB not discovered within 10 s after re-query")
             assertEquals(19071, lateB[0].port)
         } finally {
             a.stop()

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/discovery/MdnsDiscoveryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/discovery/MdnsDiscoveryTest.kt
@@ -211,15 +211,6 @@ class MdnsDiscoveryTest {
     // probing is timing-dependent and cannot reliably complete within a fixed timeout.
     // The correctness guarantee is documented in MdnsDiscovery.jvm.kt instead.
 
-    // Reproduces issue #47: a peer that registers after JmDNS's initial 3-query
-    // ServiceResolver burst (~675 ms) must still be discovered without waiting for the
-    // ~48-minute TTL refresh. Implemented via periodic re-arming of addServiceListener.
-    //
-    // Uses runTest + StandardTestDispatcher to control the re-query backoff timer with
-    // virtual time. JmDNS's own timers run on real threads — Thread.sleep is used for
-    // those boundaries. Discovery is polled via System.currentTimeMillis rather than
-    // a coroutine withTimeout because runTest routes all coroutine delays through the
-    // virtual clock; a real-time guard is needed for the JmDNS callback.
     @Test
     fun `late-joining peer is discovered after initial browse cycle`() = runTest {
         val testDispatcher = StandardTestDispatcher(testScheduler)

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/discovery/MdnsDiscoveryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/discovery/MdnsDiscoveryTest.kt
@@ -2,6 +2,7 @@ package com.tubetoast.tether.discovery
 
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -207,6 +208,33 @@ class MdnsDiscoveryTest {
     // can break it. The test was also consistently flaky: same-machine JmDNS conflict
     // probing is timing-dependent and cannot reliably complete within a fixed timeout.
     // The correctness guarantee is documented in MdnsDiscovery.jvm.kt instead.
+
+    // Reproduces issue #47: a peer that registers after JmDNS's initial 3-query
+    // ServiceResolver burst (~675 ms) must still be discovered without waiting for the
+    // ~48-minute TTL refresh. Implemented via periodic re-arming of addServiceListener.
+    @Test
+    fun `late-joining peer is discovered after initial browse cycle`() = runBlocking {
+        val a = MdnsDiscovery()
+        val b = MdnsDiscovery()
+        try {
+            a.start("LateA", 19070)
+            // Well past the initial ServiceResolver burst (3 × 225 ms ≈ 675 ms) so any
+            // discovery now depends on the periodic re-query, not the initial cycle.
+            delay(3_000)
+
+            b.start("LateB", 19071)
+
+            val peers = withTimeout(15_000) {
+                a.discoveredDevices.first { peers -> peers.any { it.name == "LateB" } }
+            }
+            val lateB = peers.filter { it.name == "LateB" }
+            assertEquals(1, lateB.size)
+            assertEquals(19071, lateB[0].port)
+        } finally {
+            a.stop()
+            b.stop()
+        }
+    }
 
     @Test
     fun `discovered device has correct host and port`() = runBlocking {

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/discovery/MdnsDiscoveryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/discovery/MdnsDiscoveryTest.kt
@@ -229,7 +229,7 @@ class MdnsDiscoveryTest {
             a.start("LateA", 19070)
             // JmDNS's ServiceResolver fires 3 PTR queries over ~675 ms of real time.
             // Thread.sleep keeps us in real time so the burst finishes before b joins.
-            Thread.sleep(1_500)
+            Thread.sleep(1_000)
             b.start("LateB", 19071)
             // JmDNS probes the service name before advertising (~3 × 250 ms). Wait for
             // b to be reachable on the network before triggering a's re-query.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,7 @@ compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMul
 compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
 compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }


### PR DESCRIPTION
Closes #80.

## Что делает PR

Добавляет периодический re-arm `JmDNS.addServiceListener` с тем же инстансом листенера, чтобы перевзводить `ServiceResolver` и обнаруживать late-joining пиров без ожидания TTL (~48 минут).

## История

Эта работа стартовала как попытка зафиксить #47 («нестабильное время обнаружения Android-пира на Desktop»). Гипотеза была: Desktop пропускает initial-burst announcement Android-устройства, и нужен механизм re-query.

В ходе ручного тестирования выяснилось, что реальный root cause #47 другой — на macOS `mDNSResponder` перехватывает входящие mDNS-пакеты с внешних WiFi-устройств на kernel-level, и user-space-сокет JmDNS их вообще не получает. `dns-sd` видит сервис Android, JmDNS — нет. Mac↔Mac работает только за счёт multicast loopback. Re-query этот класс проблем не решает (PTR-запросы JmDNS уходят, ответы Android приходят на интерфейс — но опять перехватываются `mDNSResponder` до сокета JmDNS).

Однако работа над re-query самостоятельно полезна и оформлена как отдельное улучшение через issue #80. См. историю и обоснование там.

#47 остаётся открытым, требует другого подхода (system mDNS API через `dns-sd` subprocess или JNA Bonjour) — отдельная задача.

## Что меняется

- `MdnsDiscovery.jvm.kt` — coroutine-цикл re-query с exponential backoff: 5s → 10s → 20s → 40s → 60s (cap).
- Lifecycle через `Job` (не пересоздаём scope на каждый `start()`): scope живёт вместе с инстансом, отменяем только конкретную корутину.
- Internal constructor `MdnsDiscovery(testContext: CoroutineContext)` — позволяет инжектить `TestDispatcher` для виртуального управления backoff-таймером.
- Refactor: вынесено `isSelf()` и `resolveIPv4()` private-методами.
- Документирован полу-публичный контракт JmDNS 3.5.9 (`JmDNSImpl.addServiceListener` дедуплицирует листенеров, но безусловно re-arms `ServiceResolver`).

## Тест

`late-joining peer is discovered after initial browse cycle` в `MdnsDiscoveryTest.kt` через `runTest` + `StandardTestDispatcher` + `advanceTimeBy(REQUERY_INITIAL_INTERVAL_MS + 1)`. Виртуальное время для backoff-таймера; `Thread.sleep` + polling через `System.currentTimeMillis` для событий от JmDNS на реальных потоках.

Также обновлён CLAUDE.md: тесты с корутинами пишем на `runTest` + `TestDispatcher`, не на `runBlocking`.

## Что НЕ делает

- Не закрывает #47 (см. секцию «История»).
- Не решает macOS-specific kernel-level interception.

## Test plan

- [ ] `./gradlew allTests -q` проходит локально и в CI.
- [ ] Mac↔Mac discovery работает стабильно (smoke).
- [ ] `start()` → `stop()` → `start()` не оставляет зомби-корутин (покрыто тестами `restart`/`stop emits empty list`).
