### PR TITLE
#73: fix quoted token parsing in Desktop CLI send command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,15 @@ Before making commits, identify the relevant GitHub issue. If no issue exists fo
 curl http://localhost:{port}/health  # → "Tether OK"
 ```
 
+**Desktop CLI via uber JAR** (builds the packaged artifact and runs it — useful for testing the real jar)
+```bash
+# Build uber JAR + run (default args)
+./gradlew :composeApp:runJar
+
+# Custom name and port
+./gradlew :composeApp:runJar --args="--name MyMac --port 8080"
+```
+
 Once the runner is up, it reads commands from stdin:
 
 | Command | Description |

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -188,6 +188,27 @@ dependencies {
     debugImplementation(libs.compose.uiTooling)
 }
 
+// Builds the uber JAR and immediately launches it with `java -jar`.
+// Usage: ./gradlew :composeApp:runJar --args="--name MyMac --port 8080"
+tasks.register("runJar") {
+    group = "application"
+    description = "Packages the uber JAR for the current OS and runs it via java -jar"
+    dependsOn("packageUberJarForCurrentOS")
+    doLast {
+        val jarDir = layout.buildDirectory.dir("compose/jars").get().asFile
+        val jar = jarDir.listFiles()?.firstOrNull { it.extension == "jar" }
+            ?: error("Uber JAR not found in ${jarDir.absolutePath}")
+        val runArgs = (project.findProperty("args") as? String)
+            ?.split("\\s+".toRegex())
+            .orEmpty()
+        project.javaexec {
+            classpath(jar)
+            mainClass.set("com.tubetoast.tether.MainKt")
+            args(runArgs)
+        }
+    }
+}
+
 compose.desktop {
     application {
         mainClass = "com.tubetoast.tether.MainKt"

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -195,7 +195,10 @@ tasks.register("runJar") {
     description = "Packages the uber JAR for the current OS and runs it via java -jar"
     dependsOn("packageUberJarForCurrentOS")
     doLast {
-        val jarDir = layout.buildDirectory.dir("compose/jars").get().asFile
+        val jarDir = layout.buildDirectory
+            .dir("compose/jars")
+            .get()
+            .asFile
         val jar = jarDir.listFiles()?.firstOrNull { it.extension == "jar" }
             ?: error("Uber JAR not found in ${jarDir.absolutePath}")
         val runArgs = (project.findProperty("args") as? String)

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/Main.kt
@@ -105,6 +105,7 @@ class TetherCommand :
         )
 
         echo("Commands: send <peer-name> <path>, list, quit")
+        echo("  Tip: use quotes for names/paths with spaces — send \"My Peer\" \"/my path/file.txt\"")
 
         var running = true
         while (running) {
@@ -113,7 +114,7 @@ class TetherCommand :
             } catch (_: java.nio.charset.MalformedInputException) {
                 continue
             } ?: break
-            val tokens = line.trim().split("\\s+".toRegex(), limit = 3)
+            val tokens = parseTokens(line.trim())
             when (tokens.firstOrNull()?.lowercase()) {
                 "", null -> continue
                 "list" -> {
@@ -201,6 +202,38 @@ internal fun formatBytes(bytes: Long): String = when {
     bytes < 1_024 * 1_024 -> "%.1f KB".format(bytes / 1_024.0)
     bytes < 1_024 * 1_024 * 1_024 -> "%.1f MB".format(bytes / (1_024.0 * 1_024))
     else -> "%.2f GB".format(bytes / (1_024.0 * 1_024 * 1_024))
+}
+
+internal fun parseTokens(line: String): List<String> {
+    val tokens = mutableListOf<String>()
+    val current = StringBuilder()
+    var i = 0
+    while (i < line.length) {
+        when (val ch = line[i]) {
+            '"', '\'' -> {
+                i++
+                while (i < line.length && line[i] != ch) {
+                    if (line[i] == '\\' && i + 1 < line.length) {
+                        current.append(line[++i])
+                    } else {
+                        current.append(line[i])
+                    }
+                    i++
+                }
+            }
+            '\\' -> if (i + 1 < line.length) current.append(line[++i])
+            ' ', '\t' -> {
+                if (current.isNotEmpty()) {
+                    tokens.add(current.toString())
+                    current.clear()
+                }
+            }
+            else -> current.append(ch)
+        }
+        i++
+    }
+    if (current.isNotEmpty()) tokens.add(current.toString())
+    return tokens
 }
 
 fun main(args: Array<String>) = TetherCommand().main(args)

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/CliParseTokensTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/CliParseTokensTest.kt
@@ -1,0 +1,89 @@
+package com.tubetoast.tether
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CliParseTokensTest {
+    @Test
+    fun `plain tokens without quotes`() {
+        assertEquals(listOf("send", "peer", "/tmp/file.txt"), parseTokens("send peer /tmp/file.txt"))
+    }
+
+    @Test
+    fun `double-quoted peer name with space`() {
+        assertEquals(listOf("send", "Mac A", "/tmp/file.txt"), parseTokens("""send "Mac A" /tmp/file.txt"""))
+    }
+
+    @Test
+    fun `double-quoted file path with spaces`() {
+        assertEquals(
+            listOf("send", "peer", "/Downloads/A B C.txt"),
+            parseTokens("""send peer "/Downloads/A B C.txt""""),
+        )
+    }
+
+    @Test
+    fun `both peer and file in double quotes`() {
+        assertEquals(
+            listOf("send", "Mac A", "/Downloads/A B C.txt"),
+            parseTokens("""send "Mac A" "/Downloads/A B C.txt""""),
+        )
+    }
+
+    @Test
+    fun `single-quoted peer name with space`() {
+        assertEquals(listOf("send", "Mac A", "/tmp/file.txt"), parseTokens("send 'Mac A' /tmp/file.txt"))
+    }
+
+    @Test
+    fun `backslash-escaped space in peer name`() {
+        assertEquals(listOf("send", "Mac A", "/tmp/file.txt"), parseTokens("""send Mac\ A /tmp/file.txt"""))
+    }
+
+    @Test
+    fun `backslash-escaped space in file path`() {
+        assertEquals(
+            listOf("send", "peer", "/Downloads/A B C.txt"),
+            parseTokens("""send peer /Downloads/A\ B\ C.txt"""),
+        )
+    }
+
+    @Test
+    fun `empty string returns empty list`() {
+        assertEquals(emptyList(), parseTokens(""))
+    }
+
+    @Test
+    fun `extra whitespace between tokens`() {
+        assertEquals(listOf("send", "peer", "/tmp/file.txt"), parseTokens("send   peer   /tmp/file.txt"))
+    }
+
+    // Backslash inside double quotes is an escape sequence: `\ ` → ` ` (space), same as outside quotes.
+    @Test
+    fun `backslash-escaped space inside double quotes`() {
+        assertEquals(listOf("send", "Mac A", "/tmp/file.txt"), parseTokens("""send "Mac\ A" /tmp/file.txt"""))
+    }
+
+    // Unquoted spaces in a path produce multiple tokens — standard CLI behaviour.
+    // Users must quote paths with spaces: send peer "/path/A B C.txt"
+    @Test
+    fun `unquoted spaces in file path split into multiple tokens`() {
+        assertEquals(
+            listOf("send", "peer", "/Downloads/A", "B", "C.txt"),
+            parseTokens("send peer /Downloads/A B C.txt"),
+        )
+    }
+
+    // Unclosed quote: inner loop exits at end of string; accumulated content is returned as a token.
+    @Test
+    fun `unclosed double quote yields token up to end of string`() {
+        assertEquals(listOf("send", "Mac A /tmp/file.txt"), parseTokens("""send "Mac A /tmp/file.txt"""))
+    }
+
+    // Single quotes don't suppress backslash in this parser (unlike POSIX sh).
+    // `\ ` inside single quotes still produces a space, not a literal backslash-space pair.
+    @Test
+    fun `backslash inside single quotes acts as escape`() {
+        assertEquals(listOf("send", "Mac A", "/tmp/file.txt"), parseTokens("""send 'Mac\ A' /tmp/file.txt"""))
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces naive `split("\\s+")` with `parseTokens()` — a shell-like tokenizer that handles `"..."`, `'...'`, and `\`-escaped spaces
- `send "Mac A" "~/Downloads/A B C.txt"` now correctly resolves peer `Mac A` and file `~/Downloads/A B C.txt`

## Test plan
- [x] `CliParseTokensTest` — 10 unit tests covering all DoD scenarios (double quotes, single quotes, backslash-escape, mixed, edge cases)
- [x] `./gradlew allTests -q` passes

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)