### PR TITLE
#7: Android UI — device list screen with Decompose

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -102,14 +102,19 @@ kotlin {
             implementation(libs.ktor.server.core)
             implementation(libs.ktor.server.cio)
             implementation(libs.ktor.server.content.negotiation)
+            implementation(libs.decompose.core)
+            implementation(libs.decompose.extensions.compose)
+            implementation(libs.essenty.lifecycle.coroutines)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
         }
 
         androidMain.dependencies {
             implementation(libs.compose.uiToolingPreview)
             implementation(libs.androidx.activity.compose)
+            implementation(libs.androidx.appcompat)
             implementation(libs.androidx.lifecycle.service)
         }
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -114,7 +114,6 @@ kotlin {
         androidMain.dependencies {
             implementation(libs.compose.uiToolingPreview)
             implementation(libs.androidx.activity.compose)
-            implementation(libs.androidx.appcompat)
             implementation(libs.androidx.lifecycle.service)
         }
 

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/MainActivity.kt
@@ -6,18 +6,19 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import com.arkivanov.decompose.defaultComponentContext
+import com.tubetoast.tether.di.AppContainerProvider
 import com.tubetoast.tether.network.TetherForegroundService
+import com.tubetoast.tether.presentation.DeviceListComponent
 
 private const val TAG = "MainActivity"
 
-class MainActivity : ComponentActivity() {
+class MainActivity : AppCompatActivity() {
     private val notificationPermissionRequest = registerForActivityResult(
         ActivityResultContracts.RequestPermission(),
     ) { granted ->
@@ -42,8 +43,13 @@ class MainActivity : ComponentActivity() {
 
         startService()
 
+        val container = (application as AppContainerProvider).container
+        val component = DeviceListComponent(
+            componentContext = defaultComponentContext(),
+            discovery = container.mdnsDiscovery,
+        )
         setContent {
-            App()
+            App(component)
         }
     }
 
@@ -67,10 +73,4 @@ class MainActivity : ComponentActivity() {
             Intent(this, TetherForegroundService::class.java),
         )
     }
-}
-
-@Preview
-@Composable
-private fun AppAndroidPreview() {
-    App()
 }

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/MainActivity.kt
@@ -6,10 +6,10 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import com.arkivanov.decompose.defaultComponentContext
 import com.tubetoast.tether.di.AppContainerProvider
@@ -18,7 +18,7 @@ import com.tubetoast.tether.presentation.DeviceListComponent
 
 private const val TAG = "MainActivity"
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : ComponentActivity() {
     private val notificationPermissionRequest = registerForActivityResult(
         ActivityResultContracts.RequestPermission(),
     ) { granted ->

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/MainActivity.kt
@@ -11,7 +11,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
-import com.arkivanov.decompose.defaultComponentContext
+import com.arkivanov.decompose.retainedComponent
 import com.tubetoast.tether.di.AppContainerProvider
 import com.tubetoast.tether.network.TetherForegroundService
 import com.tubetoast.tether.presentation.DeviceListComponent
@@ -44,10 +44,13 @@ class MainActivity : ComponentActivity() {
         startService()
 
         val container = (application as AppContainerProvider).container
-        val component = DeviceListComponent(
-            componentContext = defaultComponentContext(),
-            discovery = container.mdnsDiscovery,
-        )
+        // retainedComponent: survives configuration changes (rotation) via the Activity's ViewModelStore.
+        val component = retainedComponent { componentContext ->
+            DeviceListComponent(
+                componentContext = componentContext,
+                discovery = container.mdnsDiscovery,
+            )
+        }
         setContent {
             App(component)
         }

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/MainActivity.kt
@@ -44,7 +44,6 @@ class MainActivity : ComponentActivity() {
         startService()
 
         val container = (application as AppContainerProvider).container
-        // retainedComponent: survives configuration changes (rotation) via the Activity's ViewModelStore.
         val component = retainedComponent { componentContext ->
             DeviceListComponent(
                 componentContext = componentContext,

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.android.kt
@@ -16,9 +16,9 @@ private const val TAG = "MdnsDiscovery"
 
 actual class MdnsDiscovery(
     private val context: Context,
-) {
+) : DeviceDiscovery {
     private val _discoveredDevices = MutableStateFlow<List<Device>>(emptyList())
-    actual val discoveredDevices: StateFlow<List<Device>> = _discoveredDevices.asStateFlow()
+    actual override val discoveredDevices: StateFlow<List<Device>> = _discoveredDevices.asStateFlow()
 
     @Volatile private var nsdManager: NsdManager? = null
 
@@ -142,7 +142,7 @@ actual class MdnsDiscovery(
     }
 
     @Synchronized
-    actual fun start(deviceName: String, port: Int) {
+    actual override fun start(deviceName: String, port: Int) {
         if (nsdManager != null) throw IllegalStateException("MdnsDiscovery already started; call stop() first")
         ownName = deviceName
         resolveQueue.clear()
@@ -160,7 +160,7 @@ actual class MdnsDiscovery(
     }
 
     @Synchronized
-    actual fun stop() {
+    actual override fun stop() {
         val nm = nsdManager ?: return
         Log.d(TAG, "Stopping NSD")
         try {

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.apple.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.apple.kt
@@ -20,9 +20,9 @@ private const val SERVICE_TYPE = "_tether._tcp."
 // from the same thread (main thread via DisposableEffect in Compose), all accesses to
 // mutable state are single-threaded — no @Synchronized or @Volatile needed.
 // @Synchronized is a JVM-only annotation and is not available in Kotlin/Native.
-actual class MdnsDiscovery {
+actual class MdnsDiscovery : DeviceDiscovery {
     private val _discoveredDevices = MutableStateFlow<List<Device>>(emptyList())
-    actual val discoveredDevices: StateFlow<List<Device>> = _discoveredDevices.asStateFlow()
+    actual override val discoveredDevices: StateFlow<List<Device>> = _discoveredDevices.asStateFlow()
 
     private var netService: NSNetService? = null
     private var browser: NSNetServiceBrowser? = null
@@ -34,7 +34,7 @@ actual class MdnsDiscovery {
     private var browserDelegate: BrowserDelegate? = null
     private val resolutionDelegates = mutableListOf<ResolutionDelegate>()
 
-    actual fun start(deviceName: String, port: Int) {
+    actual override fun start(deviceName: String, port: Int) {
         if (netService != null || browser != null) {
             throw IllegalStateException("MdnsDiscovery already started; call stop() first")
         }
@@ -67,7 +67,7 @@ actual class MdnsDiscovery {
         NSLog("mDNS: started discovery for %s", SERVICE_TYPE)
     }
 
-    actual fun stop() {
+    actual override fun stop() {
         try {
             netService?.stop()
         } catch (e: Exception) {

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/App.kt
@@ -1,50 +1,23 @@
 package com.tubetoast.tether
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.safeContentPadding
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import org.jetbrains.compose.resources.painterResource
-import tether.composeapp.generated.resources.Res
-import tether.composeapp.generated.resources.compose_multiplatform
+import com.tubetoast.tether.presentation.DeviceListComponent
+import com.tubetoast.tether.presentation.DeviceListScreen
 
 @Composable
-fun App(modifier: Modifier = Modifier) {
+fun App(component: DeviceListComponent, modifier: Modifier = Modifier) {
     MaterialTheme {
-        var showContent by remember { mutableStateOf(false) }
-        Column(
+        Surface(
             modifier = modifier
-                .background(MaterialTheme.colorScheme.primaryContainer)
-                .safeContentPadding()
-                .fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
+                .fillMaxSize()
+                .safeContentPadding(),
         ) {
-            Button(onClick = { showContent = !showContent }) {
-                Text("Click me!")
-            }
-            AnimatedVisibility(showContent) {
-                val greeting = remember { Greeting().greet() }
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Image(painterResource(Res.drawable.compose_multiplatform), null)
-                    Text("Compose: $greeting")
-                }
-            }
+            DeviceListScreen(component)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/discovery/DeviceDiscovery.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/discovery/DeviceDiscovery.kt
@@ -1,0 +1,12 @@
+package com.tubetoast.tether.discovery
+
+import com.tubetoast.tether.protocol.Device
+import kotlinx.coroutines.flow.StateFlow
+
+interface DeviceDiscovery {
+    val discoveredDevices: StateFlow<List<Device>>
+
+    fun start(deviceName: String, port: Int)
+
+    fun stop()
+}

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.kt
@@ -3,10 +3,10 @@ package com.tubetoast.tether.discovery
 import com.tubetoast.tether.protocol.Device
 import kotlinx.coroutines.flow.StateFlow
 
-expect class MdnsDiscovery {
-    val discoveredDevices: StateFlow<List<Device>>
+expect class MdnsDiscovery : DeviceDiscovery {
+    override val discoveredDevices: StateFlow<List<Device>>
 
-    fun start(deviceName: String, port: Int)
+    override fun start(deviceName: String, port: Int)
 
-    fun stop()
+    override fun stop()
 }

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/DeviceListComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/DeviceListComponent.kt
@@ -3,6 +3,7 @@ package com.tubetoast.tether.presentation
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.value.MutableValue
 import com.arkivanov.decompose.value.Value
+import com.arkivanov.decompose.value.update
 import com.arkivanov.essenty.lifecycle.coroutines.coroutineScope
 import com.tubetoast.tether.discovery.DeviceDiscovery
 import kotlinx.coroutines.CoroutineScope
@@ -19,7 +20,7 @@ class DeviceListComponent(
     init {
         coroutineScope.launch {
             discovery.discoveredDevices.collect { devices ->
-                _state.value = DeviceListState(devices)
+                _state.update { DeviceListState(devices) }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/DeviceListComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/DeviceListComponent.kt
@@ -1,0 +1,26 @@
+package com.tubetoast.tether.presentation
+
+import com.arkivanov.decompose.ComponentContext
+import com.arkivanov.decompose.value.MutableValue
+import com.arkivanov.decompose.value.Value
+import com.arkivanov.essenty.lifecycle.coroutines.coroutineScope
+import com.tubetoast.tether.discovery.DeviceDiscovery
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+class DeviceListComponent(
+    componentContext: ComponentContext,
+    private val discovery: DeviceDiscovery,
+    coroutineScope: CoroutineScope = componentContext.coroutineScope(),
+) : ComponentContext by componentContext {
+    private val _state = MutableValue(DeviceListState.empty())
+    val state: Value<DeviceListState> = _state
+
+    init {
+        coroutineScope.launch {
+            discovery.discoveredDevices.collect { devices ->
+                _state.value = DeviceListState(devices)
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/DeviceListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/DeviceListScreen.kt
@@ -1,6 +1,7 @@
 package com.tubetoast.tether.presentation
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -22,15 +23,16 @@ fun DeviceListScreen(component: DeviceListComponent, modifier: Modifier = Modifi
     val state by component.state.subscribeAsState()
 
     if (state.devices.isEmpty()) {
-        Box(
+        Column(
             modifier = modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
         ) {
             CircularProgressIndicator()
             Text(
                 text = "Ищем устройства в сети…",
                 style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.padding(top = 72.dp),
+                modifier = Modifier.padding(top = 16.dp),
             )
         }
     } else {

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/DeviceListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/DeviceListScreen.kt
@@ -1,0 +1,53 @@
+package com.tubetoast.tether.presentation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.arkivanov.decompose.extensions.compose.subscribeAsState
+
+@Composable
+fun DeviceListScreen(component: DeviceListComponent, modifier: Modifier = Modifier) {
+    val state by component.state.subscribeAsState()
+
+    if (state.devices.isEmpty()) {
+        Box(
+            modifier = modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            CircularProgressIndicator()
+            Text(
+                text = "Ищем устройства в сети…",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(top = 72.dp),
+            )
+        }
+    } else {
+        LazyColumn(modifier = modifier.fillMaxSize()) {
+            items(state.devices, key = { it.id }) { device ->
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                ) {
+                    Text(
+                        text = device.name,
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.padding(16.dp),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/DeviceListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/DeviceListScreen.kt
@@ -46,7 +46,12 @@ fun DeviceListScreen(component: DeviceListComponent, modifier: Modifier = Modifi
                     Text(
                         text = device.name,
                         style = MaterialTheme.typography.titleMedium,
-                        modifier = Modifier.padding(16.dp),
+                        modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp),
+                    )
+                    Text(
+                        text = "${device.host}:${device.port}",
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
                     )
                 }
             }

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/DeviceListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/DeviceListScreen.kt
@@ -29,7 +29,7 @@ fun DeviceListScreen(component: DeviceListComponent, modifier: Modifier = Modifi
             verticalArrangement = Arrangement.Center,
         ) {
             CircularProgressIndicator()
-            // TODO: move to resources after i18n approach is picked — #100
+            // TODO: move to resources after an approach is picked — #100
             Text(
                 text = "Ищем устройства в сети…",
                 style = MaterialTheme.typography.bodyMedium,

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/DeviceListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/DeviceListScreen.kt
@@ -29,6 +29,7 @@ fun DeviceListScreen(component: DeviceListComponent, modifier: Modifier = Modifi
             verticalArrangement = Arrangement.Center,
         ) {
             CircularProgressIndicator()
+            // TODO: move to resources after i18n approach is picked — #100
             Text(
                 text = "Ищем устройства в сети…",
                 style = MaterialTheme.typography.bodyMedium,

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/DeviceListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/DeviceListScreen.kt
@@ -39,6 +39,7 @@ fun DeviceListScreen(component: DeviceListComponent, modifier: Modifier = Modifi
         LazyColumn(modifier = modifier.fillMaxSize()) {
             items(state.devices, key = { it.id }) { device ->
                 Card(
+                    onClick = { /* TODO: navigate to file selection — #4b */ },
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp, vertical = 8.dp),

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/DeviceListState.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/DeviceListState.kt
@@ -1,0 +1,11 @@
+package com.tubetoast.tether.presentation
+
+import com.tubetoast.tether.protocol.Device
+
+data class DeviceListState(
+    val devices: List<Device>,
+) {
+    companion object {
+        fun empty() = DeviceListState(emptyList())
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/discovery/FakeDeviceDiscovery.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/discovery/FakeDeviceDiscovery.kt
@@ -1,0 +1,15 @@
+package com.tubetoast.tether.discovery
+
+import com.tubetoast.tether.protocol.Device
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class FakeDeviceDiscovery(
+    private val flow: StateFlow<List<Device>> = MutableStateFlow(emptyList()),
+) : DeviceDiscovery {
+    override val discoveredDevices: StateFlow<List<Device>> = flow
+
+    override fun start(deviceName: String, port: Int) = Unit
+
+    override fun stop() = Unit
+}

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/DeviceListComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/DeviceListComponentTest.kt
@@ -1,0 +1,70 @@
+package com.tubetoast.tether.presentation
+
+import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.tubetoast.tether.discovery.DeviceDiscovery
+import com.tubetoast.tether.protocol.Device
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DeviceListComponentTest {
+    private val deviceA = Device(id = "a", name = "DeviceA", host = "192.168.1.1", port = 8080)
+    private val deviceB = Device(id = "b", name = "DeviceB", host = "192.168.1.2", port = 8080)
+
+    @Test
+    fun `empty state when no devices discovered`() = runTest {
+        val component = buildComponent(emptyList())
+        assertEquals(emptyList(), component.state.value.devices)
+    }
+
+    @Test
+    fun `emits devices from discovery`() = runTest {
+        val flow = MutableStateFlow<List<Device>>(emptyList())
+        val component = buildComponent(flow = flow)
+
+        flow.value = listOf(deviceA, deviceB)
+        runCurrent()
+
+        assertEquals(listOf(deviceA, deviceB), component.state.value.devices)
+    }
+
+    @Test
+    fun `updates state when device disappears`() = runTest {
+        val flow = MutableStateFlow(listOf(deviceA, deviceB))
+        val component = buildComponent(flow = flow)
+        runCurrent()
+        assertEquals(2, component.state.value.devices.size)
+
+        flow.value = listOf(deviceA)
+        runCurrent()
+
+        assertEquals(listOf(deviceA), component.state.value.devices)
+    }
+
+    private fun buildComponent(
+        initial: List<Device> = emptyList(),
+        flow: MutableStateFlow<List<Device>> = MutableStateFlow(initial),
+    ): DeviceListComponent {
+        val lifecycle = LifecycleRegistry()
+        val context = DefaultComponentContext(lifecycle)
+        lifecycle.resume()
+        return DeviceListComponent(
+            componentContext = context,
+            discovery = FakeDeviceDiscovery(flow),
+            coroutineScope = backgroundScope,
+        )
+    }
+}
+
+private class FakeDeviceDiscovery(
+    private val flow: StateFlow<List<Device>>,
+) : DeviceDiscovery {
+    override val discoveredDevices: StateFlow<List<Device>> = flow
+
+    override fun start(deviceName: String, port: Int) = Unit
+
+    override fun stop() = Unit
+}

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/DeviceListComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/DeviceListComponentTest.kt
@@ -2,10 +2,13 @@ package com.tubetoast.tether.presentation
 
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.arkivanov.essenty.lifecycle.resume
 import com.tubetoast.tether.discovery.DeviceDiscovery
 import com.tubetoast.tether.protocol.Device
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -16,14 +19,14 @@ class DeviceListComponentTest {
 
     @Test
     fun `empty state when no devices discovered`() = runTest {
-        val component = buildComponent(emptyList())
+        val component = buildComponent(emptyList(), coroutineScope = backgroundScope)
         assertEquals(emptyList(), component.state.value.devices)
     }
 
     @Test
     fun `emits devices from discovery`() = runTest {
         val flow = MutableStateFlow<List<Device>>(emptyList())
-        val component = buildComponent(flow = flow)
+        val component = buildComponent(flow = flow, coroutineScope = backgroundScope)
 
         flow.value = listOf(deviceA, deviceB)
         runCurrent()
@@ -34,7 +37,7 @@ class DeviceListComponentTest {
     @Test
     fun `updates state when device disappears`() = runTest {
         val flow = MutableStateFlow(listOf(deviceA, deviceB))
-        val component = buildComponent(flow = flow)
+        val component = buildComponent(flow = flow, coroutineScope = backgroundScope)
         runCurrent()
         assertEquals(2, component.state.value.devices.size)
 
@@ -47,6 +50,7 @@ class DeviceListComponentTest {
     private fun buildComponent(
         initial: List<Device> = emptyList(),
         flow: MutableStateFlow<List<Device>> = MutableStateFlow(initial),
+        coroutineScope: CoroutineScope,
     ): DeviceListComponent {
         val lifecycle = LifecycleRegistry()
         val context = DefaultComponentContext(lifecycle)
@@ -54,7 +58,7 @@ class DeviceListComponentTest {
         return DeviceListComponent(
             componentContext = context,
             discovery = FakeDeviceDiscovery(flow),
-            coroutineScope = backgroundScope,
+            coroutineScope = coroutineScope,
         )
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/DeviceListComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/DeviceListComponentTest.kt
@@ -6,12 +6,14 @@ import com.arkivanov.essenty.lifecycle.resume
 import com.tubetoast.tether.discovery.FakeDeviceDiscovery
 import com.tubetoast.tether.protocol.Device
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class DeviceListComponentTest {
     private val deviceA = Device(id = "a", name = "DeviceA", host = "192.168.1.1", port = 8080)
     private val deviceB = Device(id = "b", name = "DeviceB", host = "192.168.1.2", port = 8080)

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/DeviceListComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/DeviceListComponentTest.kt
@@ -3,11 +3,10 @@ package com.tubetoast.tether.presentation
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
-import com.tubetoast.tether.discovery.DeviceDiscovery
+import com.tubetoast.tether.discovery.FakeDeviceDiscovery
 import com.tubetoast.tether.protocol.Device
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -61,14 +60,4 @@ class DeviceListComponentTest {
             coroutineScope = coroutineScope,
         )
     }
-}
-
-private class FakeDeviceDiscovery(
-    private val flow: StateFlow<List<Device>>,
-) : DeviceDiscovery {
-    override val discoveredDevices: StateFlow<List<Device>> = flow
-
-    override fun start(deviceName: String, port: Int) = Unit
-
-    override fun stop() = Unit
 }

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
@@ -18,15 +18,15 @@ internal interface MdnsDiscoveryDelegate {
  *
  * [stop] may block up to ~200 ms on macOS; invoke from a background dispatcher in UI code.
  */
-actual class MdnsDiscovery {
+actual class MdnsDiscovery : DeviceDiscovery {
     private val delegate: MdnsDiscoveryDelegate =
         if (isMacOsHost()) MdnsDiscoveryBonjour() else MdnsDiscoveryJmdns()
 
-    actual val discoveredDevices: StateFlow<List<Device>> get() = delegate.discoveredDevices
+    actual override val discoveredDevices: StateFlow<List<Device>> get() = delegate.discoveredDevices
 
-    actual fun start(deviceName: String, port: Int) = delegate.start(deviceName, port)
+    actual override fun start(deviceName: String, port: Int) = delegate.start(deviceName, port)
 
-    actual fun stop() = delegate.stop()
+    actual override fun stop() = delegate.stop()
 }
 
 private fun isMacOsHost(): Boolean =

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt
@@ -4,14 +4,6 @@ import com.tubetoast.tether.discovery.bonjour.MdnsDiscoveryBonjour
 import com.tubetoast.tether.protocol.Device
 import kotlinx.coroutines.flow.StateFlow
 
-internal interface MdnsDiscoveryDelegate {
-    val discoveredDevices: StateFlow<List<Device>>
-
-    fun start(deviceName: String, port: Int)
-
-    fun stop()
-}
-
 /**
  * macOS → [MdnsDiscoveryBonjour] (DNS-SD IPC; JmDNS can't see external WiFi peers on macOS).
  * Linux/Windows → [MdnsDiscoveryJmdns].
@@ -19,7 +11,7 @@ internal interface MdnsDiscoveryDelegate {
  * [stop] may block up to ~200 ms on macOS; invoke from a background dispatcher in UI code.
  */
 actual class MdnsDiscovery : DeviceDiscovery {
-    private val delegate: MdnsDiscoveryDelegate =
+    private val delegate: DeviceDiscovery =
         if (isMacOsHost()) MdnsDiscoveryBonjour() else MdnsDiscoveryJmdns()
 
     actual override val discoveredDevices: StateFlow<List<Device>> get() = delegate.discoveredDevices

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscoveryJmdns.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscoveryJmdns.kt
@@ -31,7 +31,7 @@ private const val REQUERY_MAX_INTERVAL_MS = 60_000L
  * re-arms `ServiceResolver` — re-verified in JmDNS 3.5.9 `JmDNSImpl`.
  * Re-verify if JmDNS is upgraded.
  */
-internal class MdnsDiscoveryJmdns : MdnsDiscoveryDelegate {
+internal class MdnsDiscoveryJmdns : DeviceDiscovery {
     private val requeryContext: CoroutineContext
 
     constructor() {

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/bonjour/MdnsDiscoveryBonjour.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/bonjour/MdnsDiscoveryBonjour.kt
@@ -3,7 +3,7 @@ package com.tubetoast.tether.discovery.bonjour
 import com.sun.jna.Memory
 import com.sun.jna.Pointer
 import com.sun.jna.ptr.PointerByReference
-import com.tubetoast.tether.discovery.MdnsDiscoveryDelegate
+import com.tubetoast.tether.discovery.DeviceDiscovery
 import com.tubetoast.tether.protocol.Device
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -33,7 +33,7 @@ import java.util.concurrent.CopyOnWriteArrayList
  * `DNSServiceRefDeallocate` in its own `finally` block — the pattern required
  * by `dns_sd.h` to avoid a concurrent-deallocate race.
  */
-internal class MdnsDiscoveryBonjour : MdnsDiscoveryDelegate {
+internal class MdnsDiscoveryBonjour : DeviceDiscovery {
     private val _discoveredDevices = MutableStateFlow<List<Device>>(emptyList())
     override val discoveredDevices: StateFlow<List<Device>> = _discoveredDevices.asStateFlow()
 

--- a/composeApp/src/iosMain/kotlin/com/tubetoast/tether/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/com/tubetoast/tether/MainViewController.kt
@@ -2,8 +2,14 @@ package com.tubetoast.tether
 
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.window.ComposeUIViewController
+import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.arkivanov.essenty.lifecycle.destroy
+import com.arkivanov.essenty.lifecycle.resume
+import com.arkivanov.essenty.lifecycle.stop
 import com.tubetoast.tether.di.DefaultIosAppConfig
 import com.tubetoast.tether.di.IosAppContainer
+import com.tubetoast.tether.presentation.DeviceListComponent
 import platform.UIKit.UIDevice
 
 @Suppress("ktlint:standard:function-naming")
@@ -11,15 +17,24 @@ fun MainViewController() = run {
     val container = IosAppContainer(
         DefaultIosAppConfig(deviceName = UIDevice.currentDevice.name),
     )
+    val lifecycle = LifecycleRegistry()
+    val context = DefaultComponentContext(lifecycle)
+    val component = DeviceListComponent(
+        componentContext = context,
+        discovery = container.mdnsDiscovery,
+    )
     ComposeUIViewController {
         DisposableEffect(Unit) {
+            lifecycle.resume()
             val port = container.fileServer.start()
             container.mdnsDiscovery.start(container.deviceName, port = port)
             onDispose {
                 container.mdnsDiscovery.stop()
                 container.fileServer.stop()
+                lifecycle.stop()
+                lifecycle.destroy()
             }
         }
-        App()
+        App(component)
     }
 }

--- a/docs/engineering/dependency-injection.md
+++ b/docs/engineering/dependency-injection.md
@@ -218,9 +218,9 @@ When a test needs a fake container instead of the real one, define a `TestApplic
 
 ## Per-screen scoping
 
-`AppContainer` is a singleton. There is no separate per-screen DI scope and no `ViewModelStoreOwner` integration — per-screen state and lifecycle are owned by Decompose Components, not by an Android-style ViewModel container. Each Component receives the dependencies it needs from `AppContainer` (or from its parent Component) and constructs its children directly.
+`AppContainer` is a singleton. There is no separate per-screen DI scope — per-screen state and lifecycle are owned by Decompose Components, not by an Android-style ViewModel container. Each Component receives the dependencies it needs from `AppContainer` (or from its parent Component) and constructs its children directly.
 
-The platform entry point also builds the **root Component** (Decompose), passing `AppContainer` to it. The root creates its children with the dependencies they need. See [presentation-layer.md](presentation-layer.md).
+The platform entry point builds the **root Component** (Decompose), passing `AppContainer` to it. The root creates its children with the dependencies they need. On Android we use Decompose's `retainedComponent { ... }`, which stores the Component in the Activity's `ViewModelStore` for config-change retention only — not as a DI scope. See [presentation-layer.md](presentation-layer.md).
 
 ## Open questions
 

--- a/docs/engineering/presentation-layer.md
+++ b/docs/engineering/presentation-layer.md
@@ -2,7 +2,7 @@
 
 The presentation layer in Tether is built on [Decompose](https://github.com/arkivanov/Decompose). This document describes how it's structured and how to add to it. For the *why* — variants considered and trade-offs — see [adr/adr-presentation-and-navigation.md](adr/adr-presentation-and-navigation.md).
 
-> **Status.** The skeleton (root Component + first screen + `decompose` dependency) lands in the task that follows the ADR. The conventions below are what the skeleton installs and what every screen written after it should follow.
+> **Status.** Skeleton landed in #7 (`DeviceListComponent` + `DeviceListScreen`, Android wiring). Conventions below are what the skeleton installs and what every screen written after it should follow.
 
 ## How it works
 
@@ -24,7 +24,7 @@ Compose talks down to the Component. The Component talks down to `AppContainer` 
 ```kotlin
 class DeviceListComponent(
     componentContext: ComponentContext,
-    private val discovery: MdnsDiscovery,
+    private val discovery: DeviceDiscovery,
     coroutineScope: CoroutineScope = componentContext.coroutineScope(),
 ) : ComponentContext by componentContext {
 
@@ -33,8 +33,8 @@ class DeviceListComponent(
 
     init {
         coroutineScope.launch {
-            discovery.devices.collect { devices ->
-                _state.update { it.copy(devices = devices) }
+            discovery.discoveredDevices.collect { devices ->
+                _state.update { DeviceListState(devices) }
             }
         }
     }
@@ -42,6 +42,8 @@ class DeviceListComponent(
     fun onDeviceClicked(id: DeviceId) { /* ... */ }
 }
 ```
+
+Components depend on **interfaces from `commonMain`** (e.g. `DeviceDiscovery`), not on platform actuals (`MdnsDiscovery`). The actual class implements the interface; the Component never sees the platform type. This keeps presentation tests in `commonTest` and allows fakes without `expect`/`actual` plumbing.
 
 Conventions:
 
@@ -94,7 +96,21 @@ See [Decompose: Navigation overview](https://arkivanov.github.io/Decompose/navig
 
 ## Configuration change (Android)
 
-Decompose hooks into `AppCompatActivity` via `defaultComponentContext(...)`. When the activity is recreated on rotation, the root Component is rebuilt, but `StateKeeper` restores serializable view state and the underlying `AppContainer` repositories are untouched. No work needed in individual Components beyond putting any session-local view state through `stateKeeper.consume(...)` / `register(...)`.
+The root Component is created via Decompose's `retainedComponent { ... }` extension on `ComponentActivity` — **not** `AppCompatActivity` (we don't take that dependency; nothing in the app needs Material-AppCompat themes). `retainedComponent` stores the Component in the Activity's `ViewModelStore`, so it survives rotation without being rebuilt. The underlying `AppContainer` repositories are untouched.
+
+```kotlin
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val component = retainedComponent { componentContext ->
+            DeviceListComponent(componentContext = componentContext, discovery = container.mdnsDiscovery)
+        }
+        setContent { App(component) }
+    }
+}
+```
+
+Session-local view state that is *not* in a repository (transient UI flags, scroll position) can go through `stateKeeper.consume(...)` / `register(...)`, but the default for domain state is: don't duplicate it inside the Component — observe the `AppContainer` repository.
 
 Process-death state restoration is **not currently a goal** — Tether's flows are short-lived enough that a killed process means a fresh start. Revisit if persistence requirements emerge.
 
@@ -106,15 +122,15 @@ Components are testable as plain Kotlin — no Compose runtime, no Robolectric:
 class DeviceListComponentTest {
 
     @Test fun emits_devices_from_discovery() = runTest {
-        val discovery = FakeDiscovery()
-        val context = DefaultComponentContext(LifecycleRegistry())
+        val flow = MutableStateFlow<List<Device>>(emptyList())
+        val lifecycle = LifecycleRegistry().apply { resume() }
         val component = DeviceListComponent(
-            componentContext = context,
-            discovery = discovery,
+            componentContext = DefaultComponentContext(lifecycle),
+            discovery = FakeDeviceDiscovery(flow),
             coroutineScope = backgroundScope,
         )
 
-        discovery.emit(listOf(deviceA, deviceB))
+        flow.value = listOf(deviceA, deviceB)
         runCurrent()
 
         assertEquals(listOf(deviceA, deviceB), component.state.value.devices)
@@ -126,7 +142,7 @@ Patterns:
 
 - Construct with `DefaultComponentContext(LifecycleRegistry())` — the registry becomes the test's lifecycle handle. Drive lifecycle transitions with `lifecycle.resume()` / `destroy()` when the test depends on them.
 - Inject the test's `backgroundScope` (or a `TestScope`) as `coroutineScope` so coroutines run under the test dispatcher.
-- Use **fakes**, not mocks of `HttpClient` / `MdnsDiscovery` (see [dependency-injection.md](dependency-injection.md)).
+- Use **fakes**, not mocks of `HttpClient` / `MdnsDiscovery` (see [dependency-injection.md](dependency-injection.md)). Fakes live in `commonTest/.../<area>/Fake<Interface>.kt` next to the interface they implement — discoverable for the next test that needs the same fake without inlining or DRY-violation.
 - Assert against `component.state.value` snapshots, or capture emissions via `Value.subscribe { ... }` for sequences.
 - Common-test placement: presentation tests live in `commonTest` because the Component itself is `commonMain`.
 

--- a/docs/product/features/README.md
+++ b/docs/product/features/README.md
@@ -35,7 +35,7 @@ Note on `Status` here vs. GitHub Issues: an issue can exist (and even be in prog
 |---------|------|--------|-----|--------|
 | mDNS peer discovery | Discovery | done | _tbd_ | #6 (iOS/macOS) |
 | Pairing | Pairing / Security | scoped | [pairing.md](pairing.md) | #9 (key exchange), #10 (PIN + CLI), #11 (Android UI); iOS, Desktop UI _tbd_ |
-| Device list screen | UI | scoped | [device-list.md](device-list.md) | #7 (Android); iOS, Desktop _tbd_ |
+| Device list screen | UI | in progress | [device-list.md](device-list.md) | #7 (Android); iOS, Desktop _tbd_ |
 | File transfer | Transfer / UI | idea | [file-transfer.md](file-transfer.md) (stub) | #8 (Android send UI), #81 (iOS FileServer receive); iOS UI, Desktop send UI, receive-side UI _tbd_ |
 | Device name bootstrapping | Onboarding | idea | [device-name-bootstrapping.md](device-name-bootstrapping.md) (stub) | _tbd_ |
 

--- a/docs/product/features/device-list.md
+++ b/docs/product/features/device-list.md
@@ -1,8 +1,8 @@
 # Device list screen
 
 **Area:** UI
-**Status:** `scoped`
-**GitHub Issues:** [#7](https://github.com/khmelevartem/tether/issues/7) (Android); iOS, Desktop — _tbd_
+**Status:** `in progress`
+**GitHub Issues:** [#7](https://github.com/khmelevartem/tether/issues/7) (Android, done); iOS, Desktop — _tbd_
 
 ---
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,6 @@ android-compileSdk = "36"
 android-minSdk = "24"
 android-targetSdk = "36"
 androidx-activity = "1.13.0"
-androidx-appcompat = "1.7.1"
 androidx-core = "1.18.0"
 androidx-espresso = "3.7.0"
 androidx-lifecycle = "2.10.0"
@@ -37,7 +36,6 @@ junit = { module = "junit:junit", version.ref = "junit" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-testExt-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-testExt" }
 androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-espresso" }
-androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 compose-uiTooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "composeMultiplatform" }
 androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,8 @@
 [versions]
 agp = "8.11.2"
 clikt = "4.4.0"
+decompose = "3.2.2"
+essenty = "2.2.1"
 android-compileSdk = "36"
 android-minSdk = "24"
 android-targetSdk = "36"
@@ -60,6 +62,9 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 compose-rules-ktlint = { module = "io.nlopez.compose.rules:ktlint", version.ref = "compose-rules" }
+decompose-core = { module = "com.arkivanov.decompose:decompose", version.ref = "decompose" }
+decompose-extensions-compose = { module = "com.arkivanov.decompose:extensions-compose", version.ref = "decompose" }
+essenty-lifecycle-coroutines = { module = "com.arkivanov.essenty:lifecycle-coroutines", version.ref = "essenty" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

Implements the device list screen for Android (and all platforms) using Decompose for state management, resolving #7.

- Extracts `DeviceDiscovery` interface from `MdnsDiscovery` to decouple the discovery contract from implementation
- Adds `DeviceListComponent` (Decompose `ComponentContext`) that subscribes to `DeviceDiscovery.discoveredDevices` flow and exposes `Value<DeviceListState>`
- Adds `DeviceListScreen` composable that renders a loading spinner when no devices are found, or a `LazyColumn` of device cards
- Wires `DeviceListComponent` into `App`, `MainActivity`, `MainViewController`, and Desktop `Main.kt`
- Adds `DeviceListComponentTest` with three virtual-time unit tests covering empty state, device appearance, and device disappearance

## Test plan

- [x] `./gradlew allTests -q` passes (verified by push hook)
- [x] Android APK shows spinner on launch, then populates device cards as peers are discovered via mDNS
- [ ] iOS/macOS compiles and shows the same screen

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)