### PR TITLE
retro from #86: forbid [OPTIONAL] tests in code-review

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -99,6 +99,11 @@ Identify the trust boundary: everything from outside the process is untrusted un
 
 **For FEATURE / BUGFIX:** For each test ask: if the behavior under test were broken, would this test actually fail? Cross-reference tests against edge cases in the issue — flag gaps. Check that tests are isolated from each other and will work in CI.
 
+**Тесты не помечаются как `[OPTIONAL]`.** Если сценарий (a) автоматизируется в текущей тестовой инфраструктуре и (b) относится к скоупу задачи — пункт DoD, "Краевые случаи" / non-functional requirement из issue, или поведение, которое PR вводит/меняет — это `[REQUIRED]`. Метки приоритета ("nice-to-have", "follow-up", "in lockstep later", "не блокер") не делают релевантный автоматизируемый тест опциональным. Единственные легитимные причины **не** требовать тест:
+- сценарий не автоматизируется без непропорциональной инфраструктуры (real disk-full fixture, hardware-only condition, реальный network drop) — явно это указать;
+- сценарий действительно вне скоупа (не в DoD, не в краевых случаях, не затронут диффом) — явно это указать.
+Всё остальное — `[REQUIRED]`; пусть автор спорит, если не согласен. Особенно: краевые случаи, перечисленные в issue ("Краевые случаи" / DoD / нефункциональные требования), по построению внутри скоупа — пометить отсутствие теста для них как `[OPTIONAL]` это баг ревью.
+
 **Regression gap check (BUGFIX / REFACTOR):** For every piece of logic the PR removes or replaces, ask: was that logic covered by a test? If no — flag it as a gap. A missing test for the old behavior means a silent regression is possible the moment someone touches that code again. The fix must either add the missing test or explicitly document why the old behavior is intentionally abandoned.
 
 **For REFACTOR:** Do not require new tests. Instead verify: existing tests still pass (green in CI), test coverage has not decreased, and no test was deleted or weakened to make the refactor pass.


### PR DESCRIPTION
## Summary

Ретро по PR #86 (issue #81). В Round-1 ревью три сценария, **прямо перечисленные в DoD и "Краевых случаях" issue #81** (restart-after-stop, multi-MB streaming, mid-upload disconnect), были помечены как `[OPTIONAL]`. Когда тесты всё-таки написали — mid-upload disconnect вскрыл реальный server-side баг: silent accept усечённой загрузки → 200 OK + partial file, и в JVM, и в Native actuals. Баг жил с #35.

Симметрично патчу в `/check-review` (consumer side, ушёл в #86) — добавляю producer-side guard в `/code-review`: тесты вообще не помечаем как `[OPTIONAL]`. Если сценарий автоматизируется и в скоупе — это `[REQUIRED]`. Два узких исключения (нет автоматизации / реально вне скоупа) описаны явно.

## Test plan

- [x] Diff trivial: один markdown файл, +5 строк.
- [x] KtLint pre-commit hook green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)