### PR TITLE
#98: add UserPromptSubmit hook for auto-naming sessions

### DIFF
--- a/.claude/hooks/name-session.js
+++ b/.claude/hooks/name-session.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+// Sets sessionTitle when a session starts with /work-on-issue or /code-review.
+// Format: "#<N> impl: <title>" or "#<N> review: <title>"
+
+const input = JSON.parse(require('fs').readFileSync('/dev/stdin', 'utf8'));
+const prompt = (input.prompt || '').toLowerCase();
+
+const workMatch = prompt.match(/work[_-]on[_-]issue\D*(\d+)|изучи\s+issue\s+(\d+)/);
+const reviewMatch = prompt.match(/code[_-]review\D*(\d+)/);
+
+let issueNum = null;
+let type = null;
+
+if (workMatch) {
+  issueNum = workMatch[1] || workMatch[2];
+  type = 'impl';
+} else if (reviewMatch) {
+  issueNum = reviewMatch[1];
+  type = 'review';
+}
+
+if (!issueNum) process.exit(0);
+
+const { execSync } = require('child_process');
+try {
+  const title = execSync(
+    `gh issue view ${issueNum} --json title --jq '.title'`,
+    { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }
+  ).trim();
+  if (!title) process.exit(0);
+  console.log(JSON.stringify({ sessionTitle: `#${issueNum} ${type}: ${title}` }));
+} catch (_) {
+  process.exit(0);
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/name-session.js"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [


### PR DESCRIPTION
## Summary

- Добавлен `.claude/hooks/name-session.js` — при промптах вида `work-on-issue <N>` или `code-review <N>` запрашивает заголовок issue через `gh issue view` и возвращает `sessionTitle`
- Формат: `#N impl: <title>` для work-on-issue, `#N review: <title>` для code-review
- Нерелевантный промпт и несуществующий issue → тихий exit, название не меняется
- Зарегистрирован `UserPromptSubmit` хук в `.claude/settings.json`

Closes #98

## Test plan

- [ ] Начать сессию с `@.claude/commands/work-on-issue.md <N>` — название должно стать `#N impl: <title>`
- [ ] Начать сессию с `@.claude/commands/code-review.md <N>` — название должно стать `#N review: <title>`
- [ ] Обычный промпт — название не меняется

🤖 Generated with [Claude Code](https://claude.com/claude-code)