### PR TITLE
#101: PreToolUse hook — pre-commit engineering checklist

### DIFF
--- a/.claude/hooks/pre-git-checklist.sh
+++ b/.claude/hooks/pre-git-checklist.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# PreToolUse hook: injects a short technical checklist before `git commit`.
+# Reads tool input JSON from stdin, writes hookSpecificOutput JSON to stdout.
+
+set -euo pipefail
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+
+case "$cmd" in
+  *"git commit"*) ;;
+  *) exit 0 ;;
+esac
+
+read -r -d '' CHECKLIST <<'EOF' || true
+Pre-commit checklist (быстрая проверка перед `git commit`):
+
+- [ ] commit message: `#<issue>: ...` (issue существует?)
+- [ ] правки внутри worktree (`.claude/worktrees/<branch>/`), не в корне
+- [ ] новый код в `commonMain`, если не нужен platform API → docs/engineering/architecture-principles.md
+- [ ] правильный source set / hierarchy (`jvmMain` > android+desktop, `appleMain` > ios+macos) → docs/engineering/modules.md
+- [ ] DI: компонент зарегистрирован и резолвится через граф, без ручных `new`/`object` → docs/engineering/dependency-injection.md
+- [ ] UI/state — по слоям presentation, без бизнес-логики во вьюхах → docs/engineering/presentation-layer.md
+- [ ] тесты добавлены/обновлены, гоняются `./gradlew allTests -q` → docs/engineering/testing.md
+- [ ] комментарии минимальны (приватные методы вместо пояснений)
+- [ ] KtLint руками НЕ запускался, форматирование не правил руками
+- [ ] runtime-changing PR? — `/smoke-test` перед merge
+- [ ] странное поведение платформы? — сначала загляни в `docs/knowledge/`
+
+Сомневаешься в архитектурном решении — открой соответствующий файл из `docs/engineering/` прежде чем коммитить.
+EOF
+
+# Emit additionalContext for the model.
+python3 - "$CHECKLIST" <<'PY'
+import json, sys
+ctx = sys.argv[1]
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "additionalContext": ctx,
+    }
+}))
+PY

--- a/.claude/hooks/pre-git-checklist.sh
+++ b/.claude/hooks/pre-git-checklist.sh
@@ -15,16 +15,13 @@ esac
 read -r -d '' CHECKLIST <<'EOF' || true
 Pre-commit checklist (быстрая проверка перед `git commit`):
 
-- [ ] commit message: `#<issue>: ...` (issue существует?)
 - [ ] правки внутри worktree (`.claude/worktrees/<branch>/`), не в корне
 - [ ] новый код в `commonMain`, если не нужен platform API → docs/engineering/architecture-principles.md
 - [ ] правильный source set / hierarchy (`jvmMain` > android+desktop, `appleMain` > ios+macos) → docs/engineering/modules.md
 - [ ] DI: компонент зарегистрирован и резолвится через граф, без ручных `new`/`object` → docs/engineering/dependency-injection.md
 - [ ] UI/state — по слоям presentation, без бизнес-логики во вьюхах → docs/engineering/presentation-layer.md
-- [ ] тесты добавлены/обновлены, гоняются `./gradlew allTests -q` → docs/engineering/testing.md
+- [ ] покрытие тестами: ≥70% для общей логики, ≥90% для алгоритмов → docs/engineering/testing.md
 - [ ] комментарии минимальны (приватные методы вместо пояснений)
-- [ ] KtLint руками НЕ запускался, форматирование не правил руками
-- [ ] runtime-changing PR? — `/smoke-test` перед merge
 - [ ] странное поведение платформы? — сначала загляни в `docs/knowledge/`
 
 Сомневаешься в архитектурном решении — открой соответствующий файл из `docs/engineering/` прежде чем коммитить.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/pre-git-checklist.sh"
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [


### PR DESCRIPTION
## Summary

- Добавляет Claude-side `PreToolUse` hook с matcher `Bash`, который перед `git commit` инжектит в контекст модели короткий чеклист со ссылками на `docs/engineering/*` («сомневаешься — посмотри сюда»).
- На нерелевантных Bash-командах хук молчит (exit 0).
- Только `git commit` — `git push` намеренно не триггерит (к этому моменту коммит уже сформирован, чеклист поздно).

Closes #101.

## Test plan

- [x] `echo '{"tool_input":{"command":"git commit -m x"}}' | bash .claude/hooks/pre-git-checklist.sh` — отдаёт JSON `hookSpecificOutput.additionalContext`
- [x] `echo '{"tool_input":{"command":"ls"}}' | bash .claude/hooks/pre-git-checklist.sh` — пусто, exit 0
- [x] end-to-end: при коммите этого PR хук сработал и пробросил чеклист в контекст

🤖 Generated with [Claude Code](https://claude.com/claude-code)