### PR TITLE
#105: fix UserPromptSubmit hook output format for sessionTitle

### DIFF
--- a/.claude/hooks/name-session.js
+++ b/.claude/hooks/name-session.js
@@ -28,7 +28,12 @@ try {
     { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }
   ).trim();
   if (!title) process.exit(0);
-  console.log(JSON.stringify({ sessionTitle: `#${issueNum} ${type}: ${title}` }));
+  console.log(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'UserPromptSubmit',
+      sessionTitle: `#${issueNum} ${type}: ${title}`,
+    },
+  }));
 } catch (_) {
   process.exit(0);
 }


### PR DESCRIPTION
## Summary

Fixes `.claude/hooks/name-session.js` — хук выводил плоский JSON, который Claude Code игнорировал.

**До:**
```json
{"sessionTitle":"#9 impl: ..."}
```

**После:**
```json
{
  "hookSpecificOutput": {
    "hookEventName": "UserPromptSubmit",
    "sessionTitle": "#9 impl: ..."
  }
}
```

Теперь `/work-on-issue <N>` и `/code-review <N>` корректно переименовывают сессию.

## Test plan

- [ ] Открыть сессию с `/work-on-issue 9` — название сессии должно стать `#9 impl: Паринг — протокол обмена ключами и TrustedDeviceStore`
- [ ] Открыть сессию с `/code-review 85` — название должно стать `#85 review: #9: Add pairing protocol...`
- [ ] Обычный промпт — название не меняется

Fixes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)