### PR TITLE
#93: FileClient sets Content-Length when totalBytes known

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
@@ -11,7 +11,7 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
-import io.ktor.http.contentType
+import io.ktor.http.content.OutgoingContent
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteChannel
 import io.ktor.utils.io.ByteReadChannel
@@ -38,7 +38,7 @@ class FileClient : Closeable {
         totalBytes: Long? = null,
         onProgress: ((bytesTransferred: Long, totalBytes: Long?) -> Unit)? = null,
     ): SendResult = if (onProgress == null) {
-        doSend(device, channel, fileName)
+        doSend(device, channel, fileName, totalBytes)
     } else {
         // Launch the copy into a pipe concurrently with the Ktor upload so that
         // Ktor reads from the pipe while we are filling it. coroutineScope waits
@@ -46,7 +46,7 @@ class FileClient : Closeable {
         coroutineScope {
             val pipe = ByteChannel(autoFlush = true)
             launch { copyWithProgress(channel, pipe, totalBytes, onProgress) }
-            doSend(device, pipe, fileName)
+            doSend(device, pipe, fileName, totalBytes)
         }
     }
 
@@ -58,11 +58,11 @@ class FileClient : Closeable {
         device: Device,
         channel: ByteReadChannel,
         fileName: String,
+        totalBytes: Long?,
     ): SendResult = try {
         val response = client.post("http://${device.host}:${device.port}/upload") {
             parameter("name", fileName)
-            contentType(ContentType.Application.OctetStream)
-            setBody(channel)
+            setBody(channel.asOctetStreamContent(totalBytes))
         }
         if (response.status == HttpStatusCode.OK) {
             val body = response.body<Map<String, String>>()
@@ -75,6 +75,14 @@ class FileClient : Closeable {
         SendResult.Failure(e.message ?: "unknown error")
     }
 }
+
+private fun ByteReadChannel.asOctetStreamContent(totalBytes: Long?): OutgoingContent =
+    object : OutgoingContent.ReadChannelContent() {
+        override val contentType: ContentType = ContentType.Application.OctetStream
+        override val contentLength: Long? = totalBytes
+
+        override fun readFrom(): ByteReadChannel = this@asOctetStreamContent
+    }
 
 private const val COPY_BUFFER_SIZE = 8 * 1024
 

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/network/FileClientTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/network/FileClientTest.kt
@@ -30,10 +30,11 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
-import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
 
 class FileClientTest {
     private val device
@@ -174,8 +175,14 @@ class FileClientTest {
                     fileName = "trunc-prod.bin",
                     totalBytes = declared,
                 )
-                assertNotEquals(SendResult.Success::class, result::class)
-                delay(200.milliseconds) // let server-side catch/finally settle
+                assertIs<SendResult.Failure>(result)
+                // Poll until server-side finally{ deleteIfExists } completes — robuster than fixed delay.
+                val deadline = TimeSource.Monotonic.markNow() + 3.seconds
+                while (deadline.hasNotPassedNow()) {
+                    val partial = tmpDir.listFiles()?.any { it.name.startsWith("trunc-prod") } ?: false
+                    if (!partial) break
+                    delay(20.milliseconds)
+                }
                 val partial = tmpDir.listFiles()?.filter { it.name.startsWith("trunc-prod") } ?: emptyList()
                 assertTrue(
                     partial.isEmpty(),

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/network/FileClientTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/network/FileClientTest.kt
@@ -2,15 +2,38 @@ package com.tubetoast.tether.network
 
 import com.tubetoast.tether.protocol.Device
 import com.tubetoast.tether.protocol.SendResult
+import io.ktor.http.HttpHeaders
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.call
+import io.ktor.server.application.install
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.request.contentLength
+import io.ktor.server.request.receiveChannel
+import io.ktor.server.response.respond
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import io.ktor.utils.io.ByteChannel
+import io.ktor.utils.io.readAvailable
+import io.ktor.utils.io.writeFully
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.io.FileNotFoundException
 import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.io.path.writeBytes
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 
 class FileClientTest {
     private val device
@@ -77,6 +100,88 @@ class FileClientTest {
                 assertTrue(content.contentEquals(saved), "Saved content does not match sent content")
             }
             Files.deleteIfExists(file)
+        } finally {
+            teardown(client)
+        }
+    }
+
+    @Test
+    fun `send sets Content-Length and omits chunked transfer encoding when totalBytes known`() {
+        data class Captured(
+            val contentLength: Long?,
+            val transferEncoding: String?,
+        )
+        val captured = AtomicReference<Captured>()
+        val captureServer = embeddedServer(CIO, port = 0) {
+            install(ContentNegotiation) { json() }
+            routing {
+                post("/upload") {
+                    val channel = call.receiveChannel()
+                    val buf = ByteArray(8 * 1024)
+                    while (!channel.isClosedForRead) channel.readAvailable(buf)
+                    captured.set(
+                        Captured(
+                            contentLength = call.request.contentLength(),
+                            transferEncoding = call.request.headers[HttpHeaders.TransferEncoding],
+                        ),
+                    )
+                    call.respond(mapOf("savedPath" to "ignored"))
+                }
+            }
+        }.start(wait = false)
+        val port = runBlocking {
+            captureServer.engine
+                .resolvedConnectors()
+                .first()
+                .port
+        }
+        val client = FileClient()
+        try {
+            val payload = ByteArray(2048) { (it % 251).toByte() }
+            val file = Files.createTempFile("content-length-test", ".bin")
+            file.writeBytes(payload)
+            runBlocking {
+                client.send(
+                    device = Device(id = "x@127.0.0.1:$port", name = "x", host = "127.0.0.1", port = port),
+                    file = file,
+                )
+            }
+            Files.deleteIfExists(file)
+            val c = captured.get() ?: error("server did not capture request")
+            assertEquals(payload.size.toLong(), c.contentLength, "Content-Length must equal file size")
+            assertNull(c.transferEncoding, "Transfer-Encoding must be absent (no chunked)")
+        } finally {
+            client.close()
+            captureServer.stop(0, 0)
+        }
+    }
+
+    @Test
+    fun `truncated upload with known totalBytes fails and leaves no partial file`() {
+        val client = setup()
+        try {
+            val declared = 64L * 1024
+            val delivered = 4 * 1024
+            val partialChannel = ByteChannel(autoFlush = true)
+            runBlocking {
+                CoroutineScope(Dispatchers.IO).launch {
+                    partialChannel.writeFully(ByteArray(delivered) { 0x42 })
+                    partialChannel.cancel(java.io.IOException("simulated mid-upload disconnect"))
+                }
+                val result = client.send(
+                    device = device,
+                    channel = partialChannel,
+                    fileName = "trunc-prod.bin",
+                    totalBytes = declared,
+                )
+                assertNotEquals(SendResult.Success::class, result::class)
+                delay(200.milliseconds) // let server-side catch/finally settle
+                val partial = tmpDir.listFiles()?.filter { it.name.startsWith("trunc-prod") } ?: emptyList()
+                assertTrue(
+                    partial.isEmpty(),
+                    "no partial file should remain in $tmpDir, found: ${partial.map { it.name }}",
+                )
+            }
         } finally {
             teardown(client)
         }

--- a/docs/knowledge/ktor-server-cio.md
+++ b/docs/knowledge/ktor-server-cio.md
@@ -33,9 +33,9 @@ if (expected != null && bytesCopied < expected) {
 }
 ```
 
-If Content-Length is *not* set (the client used chunked transfer encoding without declaring a size), there is no reliable way to detect truncation from the body channel alone — make the client send Content-Length whenever the body size is known.
+If Content-Length is *not* set (the client used chunked transfer encoding without declaring a size), there is no reliable way to detect truncation from the body channel alone — make the client send Content-Length whenever the body size is known. Our `FileClient` does this via `OutgoingContent.ReadChannelContent.contentLength` when `totalBytes` is provided (#93); plain `setBody(channel)` would silently fall back to chunked encoding.
 
-**Reference:** [`FileServerRoutes.kt`](../../composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileServerRoutes.kt) — `installFileServerRoutes`.
+**Reference:** [`FileServerRoutes.kt`](../../composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileServerRoutes.kt) — `installFileServerRoutes`; [`FileClient.kt`](../../composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt) — `asOctetStreamContent`.
 
 ---
 


### PR DESCRIPTION
Closes #93.

## Summary

- `FileClient.doSend` теперь оборачивает body в `OutgoingContent.ReadChannelContent` c явным `contentLength = totalBytes`. Раньше `setBody(ByteReadChannel)` без `contentLength` форсил Ktor на chunked encoding → `call.request.contentLength()` на сервере был `null` → server-side truncation detection из #81 не срабатывал в production-флоу `FileClient.send(path)`.
- `totalBytes = null` (общий API в commonMain) сохраняет старое chunked-поведение — это допустимо, потому что в продакшне всегда передаётся файл с известным размером (см. Out of scope в issue).
- `FileClientJvm` не менялся: `totalBytes = Files.size(file)` уже передавался в `send`, теперь он доходит до wire.

## Tests

В `composeApp/src/desktopTest/.../FileClientTest.kt`:

1. **`send sets Content-Length and omits chunked transfer encoding when totalBytes known`** — поднимает capture-Ktor-сервер, шлёт файл через `FileClient.send(path)`, ассертит `Content-Length == file.size` и отсутствие `Transfer-Encoding`.
2. **`truncated upload with known totalBytes fails and leaves no partial file`** — регрессионный сценарий из DoD: через production API клиент шлёт меньше байт, чем `totalBytes`, и закрывает поток с исключением. Сервер возвращает 5xx, partial-файл удаляется (`FileServerRoutes.finally → deleteIfExists`).

`./gradlew allTests` — зелёный.

## Smoke verdict

🟡 — Desktop CLI startup, mDNS publish, Desktop↔Desktop send через CLI (полный production-флоу `FileClient.send(path)` → JVM `FileServer`), Android FGS+NSD+health, cross-discovery, native compile (macosArm64, iosSimulatorArm64) — PASS. Desktop→Android send SKIP из-за NAT эмулятора (`10.0.2.16` недостижим с хоста; environmental, не связано с PR).

## Что осталось проверить вручную

- **Desktop → Android send на реальной WiFi-сети** — самый важный пункт для этого PR: production-сценарий с Content-Length, который смоук не смог проверить из-за emulator NAT. Любой Android-девайс в одной подсети с macOS.
- iOS simulator / физический iPhone — out of scope (FileServer.apple — stub).
- Android → Desktop send — нет CLI на Android.

## Dependency check

Новых зависимостей нет. `OutgoingContent.ReadChannelContent` — публичный API Ktor, тот же модуль `ktor-http`, что уже в графе.

🤖 Generated with [Claude Code](https://claude.com/claude-code)