### PR TITLE
retro from #139: /implement gates beat autonomy hints + DOCS-as-decision G1

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -15,8 +15,11 @@ Issue number `<N>`.
 
 ## Gate semantics — when to stop and ask the user
 
+These MUST-stop gates are **not overridden by session-level autonomy or "skip clarifying questions" hints**, wherever such hints come from. Such hints apply only to execution-stage trivia within an already-agreed scope (naming, formatting, refactoring choices). They do not apply to gate evaluation. The cost of a one-message pause is far lower than the cost of unwinding a unilateral architectural / product decision.
+
 You MUST stop and ask the user in these cases (and only these):
 - **G1. Spec or AC ambiguity** — issue's DoD is missing/stub, feature spec missing for FEATURE type, blocking open questions in spec. **Mitigation:** dispatch `spec-writer` first; only stop at user if `spec-writer` has clarifying questions or the issue is non-FEATURE without DoD.
+  - **DOCS-as-decision sub-class.** A DOCS issue whose deliverable IS the decision (closing an open question, picking between options, ADR-style choice) qualifies as G1 by default — even when AC look complete («сравни 3 варианта, выбери один и обоснуй»). The *act of choosing* requires user input. Surface the comparison, recommend if you have signal, but do not commit without explicit OK.
 - **G2. BUGFIX root cause** — root cause must be confirmed before any fix. **Mitigation:** dispatch `bug-reproducer`; only stop at user if it reports CANNOT REPRODUCE or none of the listed hypotheses match.
 - **G2.5. Publication of confirmed cause** — once `bug-reproducer` returns a confirmed cause, show the paste-ready block to the user and wait for explicit OK before `gh issue comment`. Publishing to a GitHub issue is a team-visible action; it does not happen without a user gate.
 - **G3. Plan ambiguity** — plan conflicts with loaded engineering guides and you have no clean way to resolve.


### PR DESCRIPTION
Ретроспектива по [#123](https://github.com/khmelevartem/tether/issues/123) / [#139](https://github.com/khmelevartem/tether/pull/139). Системный gap: на DOCS-задаче, deliverable которой = решение, orchestrator принял продуктовое решение самостоятельно. Сработал compound: session-level reminder «work without clarifying questions» наложился на собственное framing-описание `/implement` («without user in the loop», «removes the user from the inner cycle») — и mandatory G1 в этой комбинации потерял вес.

## Что меняется

Две точечные правки в `.claude/skills/implement/SKILL.md`:

### 1. Precedence statement в начало «Gate semantics»

> These MUST-stop gates are **not overridden by session-level autonomy or "skip clarifying questions" hints**, wherever such hints come from. Such hints apply only to execution-stage trivia within an already-agreed scope (naming, formatting, refactoring choices). They do not apply to gate evaluation.

Закрывает gap: MUST-формулировка gate'а сама по себе оказалась недостаточной, потому что autonomy-флаг тоже «sounded MUST-like». Явный precedence снимает compounding.

### 2. G1 sub-class «DOCS-as-decision»

> **DOCS-as-decision sub-class.** A DOCS issue whose deliverable IS the decision (closing an open question, picking between options, ADR-style choice) qualifies as G1 by default — even when AC look complete («сравни 3 варианта, выбери один и обоснуй»). The *act of choosing* requires user input. Surface the comparison, recommend if you have signal, but do not commit without explicit OK.

Закрывает gap: текущая G1-формулировка ориентирована на FEATURE-issue со stub-спекой. DOCS-as-decision формально проходит чек «AC are clear», но фундаментально не закрывается без user input.

## Что НЕ делаем

- **Project-level SessionStart hook** с обратной policy. Изначально предлагал; пользователь резонно усомнился, что нужен такой шумный механизм. `/implement` — главный workflow для серьёзной работы; если он явно говорит «gates ≠ overridable», compounding не случится. Если в будущем найдётся другая стадия / скилл, где autonomy-флаг повредит — добавим точечно туда.
- **Hardcoded list других skills** (`/close-issue`, `/quick-issue`) с тем же precedence statement. Дублирование без явной потребности; pasted-everywhere policy gnaws над поддержкой.

## Не для merge без ревью

Изменения в `.claude/skills/`, не в коде. `allTests` pre-push прошёл (squash коммит), но не показателен — DOCS-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)