### PR TITLE
retro from #134: /implement re-entry contract for PR feedback

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -13,6 +13,15 @@ You are the orchestrator for implementing a single GitHub issue. You do NOT writ
 
 Issue number `<N>`.
 
+## Re-entry contract
+
+Skill идемпотентен по issue. На каждом вызове первым делом проверь `gh pr list --search "issue:#<N>" --state open`:
+
+- **PR нет** → стартуй Step 1.
+- **PR есть и открыт** → ты в pull-request feedback итерации. На текущей feature-branch могут быть новые комменты ревьюера или коммиты после прошлого прогона. Прогон **обязан** включать на свежем diff'е: Step 4 (inner loop reviewers) → Step 5 (simplify) → Step 6 (full review wave A + adversarial) → Step 7 (smoke, скоуп по diff'у). Из дисциплины на re-entry ничего пропускать нельзя — иначе review-итерации проходят с меньшим качеством, чем первичная имплементация.
+
+Шаги 8-9 (commit + present G5 + push) — в re-entry упрощаются: коммит идёт в существующую ветку, force-push не нужен, новый PR не создавать.
+
 ## Gate semantics — when to stop and ask the user
 
 These MUST-stop gates are **not overridden by session-level autonomy or "skip clarifying questions" hints**, wherever such hints come from. Such hints apply only to execution-stage trivia within an already-agreed scope (naming, formatting, refactoring choices). They do not apply to gate evaluation. The cost of a one-message pause is far lower than the cost of unwinding a unilateral architectural / product decision.
@@ -45,8 +54,6 @@ Classify PR type. For FEATURE, look up `docs/product/features/README.md` for spe
 - фразы-затычки: «дополни если есть чем», «должно работать корректно», «и так далее».
 
 Любой такой пробел — повод вернуться к G1, не «допилить по дороге».
-
-**Existing draft PR.** Если по issue уже есть открытый PR (даже draft) — НЕ пропускай Step 5 (inner loop) и Step 7 (full pre-PR review) на текущем diff'е. Без них orchestrator превращается в одного исполнителя, и весь quality framework обходится.
 
 **Worktree setup — do this BEFORE dispatching any agent that edits files.** If you are not already in `.claude/worktrees/<branch>/`:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Desktop исходники разделены на два source set: `desktopMa
 ## Slash commands и скиллы
 
 **Скиллы** (`.claude/skills/`) — основной путь, multi-agent оркестрация:
-- `/implement <N>` — end-to-end оркестратор задачи. Планирует, гоняет coder↔reviewers цикл, smoke, доводит до PR. Пользователь только в гейтах G1-G5 (см. SKILL.md).
+- `/implement <N>` — end-to-end оркестратор задачи. Планирует, гоняет coder↔reviewers цикл, smoke, доводит до PR. Пользователь только в гейтах G1-G5 (см. SKILL.md). Идемпотентен: повторный вызов по issue с открытым PR — re-entry в inner loop + simplify + full review + smoke на свежем diff'е. Этот же вход используется для отработки ручного ревью на PR.
 - `/code-review <PR>` — параллельный multi-agent review с постингом в GitHub.
 
 **Команды** (`.claude/commands/`):


### PR DESCRIPTION
## Summary

- Hoist re-entry rule to top-level **Re-entry contract** section in `/implement` SKILL.md — covers what to do when the skill is re-invoked on an issue that already has an open PR.
- Remove the buried duplicate note in Step 1 (had stale step numbers 5/7 instead of 4/6 too).
- One-liner addition in CLAUDE.md slash-commands list: \`/implement <N>\` повторно по issue с открытым PR = re-entry в Steps 4-7 на свежем diff'е. Это же вход для отработки ручного ревью на PR.

## Gap addressed

On the source PR #134 the second \`/implement\` invocation (after manual review yielded a structural rework request) skipped Steps 5 (simplify), 6 (full review wave A + adversarial), and partial Step 7 (smoke). Caused by the re-entry rule being a sub-note inside Step 1 — invisible when the skill enters mid-conversation after Step 9. New top-level contract makes Steps 4-7 mandatory on every re-entry.

## Test plan

- [ ] Read updated SKILL.md / CLAUDE.md — wording matches what /implement actually does on re-entry
- [ ] No links / step numbers broken in SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)