### PR TITLE
#157: extend pre-push hook to compile all targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ on:
     branches: [ "**" ]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
-    name: Lint & Test
+    name: KtLint
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -15,5 +15,18 @@ jobs:
           distribution: temurin
           java-version: '21'
       - uses: gradle/actions/setup-gradle@v3
-      - name: KtLint + tests
-        run: ./gradlew ktlintCheck allTests
+      - name: KtLint check (all modules)
+        run: ./gradlew ktlintCheck
+
+  test:
+    runs-on: ubuntu-latest
+    name: Tests
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: gradle/actions/setup-gradle@v3
+      - name: Run tests (all modules)
+        run: ./gradlew allTests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,28 +5,16 @@ on:
     branches: [ "**" ]
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    name: KtLint
+  build:
+    runs-on: macos-latest
+    name: Build & Test
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '21'
+      - uses: android-actions/setup-android@v3
       - uses: gradle/actions/setup-gradle@v3
-      - name: KtLint check (all modules)
-        run: ./gradlew ktlintCheck
-
-  test:
-    runs-on: ubuntu-latest
-    name: Tests
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '21'
-      - uses: gradle/actions/setup-gradle@v3
-      - name: Run tests (all modules)
-        run: ./gradlew allTests
+      - name: Lint, test, and build all targets
+        run: ./gradlew ktlintCheck allTests :composeApp:installCli :composeApp:createDistributable :composeApp:assembleDebug :composeApp:linkDebugFrameworkIosSimulatorArm64 -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: android-actions/setup-android@v3
       - uses: gradle/actions/setup-gradle@v3
       - name: Lint, test, and build all targets
-        run: ./gradlew ktlintCheck allTests :composeApp:installCli :composeApp:createDistributable :composeApp:assembleDebug :composeApp:linkDebugFrameworkIosSimulatorArm64 -q
+        run: ./gradlew ktlintCheck allTests :composeApp:installCli :composeApp:createDistributable :composeApp:assembleDebug :composeApp:linkDebugFrameworkIosSimulatorArm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,14 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
-    name: Build & Test
+    runs-on: ubuntu-latest
+    name: Lint & Test
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '21'
-      - uses: android-actions/setup-android@v3
       - uses: gradle/actions/setup-gradle@v3
-      - name: Lint, test, and build all targets
-        run: ./gradlew ktlintCheck allTests :composeApp:installCli :composeApp:createDistributable :composeApp:assembleDebug :composeApp:linkDebugFrameworkIosSimulatorArm64
+      - name: KtLint + tests
+        run: ./gradlew ktlintCheck allTests

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -62,18 +62,18 @@ if [ -n "$COMMON_DIR" ]; then
   fi
 fi
 
-echo "🧪 Running tests (all modules)..."
-./gradlew allTests --quiet
+echo "🧪 Running tests + building all targets (CLI, Desktop UI, Android, iOS)..."
+./gradlew allTests :composeApp:installCli :composeApp:createDistributable :composeApp:assembleDebug :composeApp:linkDebugFrameworkIosSimulatorArm64 --quiet
 
 if [ $? -ne 0 ]; then
   echo ""
-  echo "❌ Tests failed — push aborted."
-  echo "💡 Run './gradlew allTests' to see the details."
+  echo "❌ Tests or build failed — push aborted."
+  echo "💡 Re-run the failing task without --quiet to see details."
   echo ""
   exit 1
 fi
 
-echo "✅ All tests passed"
+echo "✅ Tests passed, all targets compile"
 exit 0
 EOF
 


### PR DESCRIPTION
## Summary
- Pre-push hook теперь после `allTests` собирает все 4 таргета: Desktop CLI, Desktop UI, Android debug APK, iOS simulator framework — одним вызовом `./gradlew`.
- Раньше ни CI, ни push не проверяли, что Android/iOS/Desktop UI собираются после правок — проблемы вылезали только при ручной сборке или smoke.
- CI намеренно не трогаем: замер показал, что параллельные ubuntu job'ы упирались в `allTests`, объединение не давало wall-clock выигрыша. Компиляция всех таргетов требует macOS runner — слишком дорого для каждой ветки.

Closes #157.

## Test plan
- [x] `git push` отрабатывает hook: тесты + сборка CLI/Desktop UI/Android/iOS framework — все зелёные.
- [x] CI остаётся без изменений.
