### PR TITLE
retro from #135: review-adversarial verifies inherited facts; per-platform spec layout as valid

### DIFF
--- a/.claude/agents/review-adversarial.md
+++ b/.claude/agents/review-adversarial.md
@@ -1,7 +1,7 @@
 ---
 name: review-adversarial
-description: Adversarial probe — given findings from earlier review agents, form hypotheses about what's still wrong and verify each. Runs LAST in /code-review orchestration. Receives other agents' findings as input.
-tools: Bash, Read, Grep, Glob
+description: Adversarial probe — given findings from earlier review agents, form hypotheses about what's still wrong and verify each. Also verifies factual claims inherited from input sources (issue body, sibling specs, prior findings) against authoritative external docs. Runs LAST in /code-review orchestration. Receives other agents' findings as input.
+tools: Bash, Read, Grep, Glob, WebFetch
 model: sonnet
 ---
 
@@ -31,14 +31,16 @@ For every PR there exists a category of bug the structured reviewers naturally m
 - **Build / packaging.** New resource in commonMain that needs a specific gradle handling for one target.
 - **Compatibility with installed-on-user-device older app version** for serialized formats.
 - **What happens if user does X right at moment Y** — interaction with system events: backgrounding, network drop, low memory.
+- **Facts inherited from input sources.** The issue body, sibling specs, and prior reviewer findings carry claims that propagate uncritically into the PR — OS version thresholds, third-party API behavior, deployed-config invariants, "X works on platform Y because Z". The structured reviewers tend to check internal consistency, not external truth. The most load-bearing 1–3 inherited claims deserve a cross-check against authoritative public docs.
 
 ## Procedure
 
 1. Read the diff and the issue.
 2. Read the prior findings — do **not** repeat them. Look for what they *don't* address.
 3. Formulate 3–7 concrete hypotheses, each of the form: "If <specific condition>, then <specific failure>, because <mechanism>". Vague hypotheses ("could be racy") are useless — be specific or drop the hypothesis.
-4. For each hypothesis, verify against the code: grep, read, trace. Try to disprove it.
-5. Report only hypotheses that survive your attempt to disprove them, or that you couldn't fully verify from static reading.
+4. Identify factual claims the PR asserts that came from outside (sibling specs, issue body, prior findings). Pick the 1–3 most load-bearing — the ones whose falseness would invalidate a real chunk of the PR — and verify them against authoritative public docs via WebFetch. Treat disproven claims as confirmed findings on par with hypothesis-based ones.
+5. For each hypothesis from step 3, verify against the code: grep, read, trace. Try to disprove it.
+6. Report only items that survive your attempt to disprove them, or that you couldn't fully verify.
 
 ## Output
 

--- a/.claude/agents/review-adversarial.md
+++ b/.claude/agents/review-adversarial.md
@@ -1,6 +1,6 @@
 ---
 name: review-adversarial
-description: Adversarial probe — given findings from earlier review agents, form hypotheses about what's still wrong and verify each. Also verifies factual claims inherited from input sources (issue body, sibling specs, prior findings) against authoritative external docs. Runs LAST in /code-review orchestration. Receives other agents' findings as input.
+description: Adversarial probe — given findings from earlier review agents, form hypotheses about what's still wrong and verify each. Also cross-checks load-bearing factual claims inherited from inputs against authoritative external docs. Runs LAST in /code-review orchestration. Receives other agents' findings as input.
 tools: Bash, Read, Grep, Glob, WebFetch
 model: sonnet
 ---
@@ -31,14 +31,14 @@ For every PR there exists a category of bug the structured reviewers naturally m
 - **Build / packaging.** New resource in commonMain that needs a specific gradle handling for one target.
 - **Compatibility with installed-on-user-device older app version** for serialized formats.
 - **What happens if user does X right at moment Y** — interaction with system events: backgrounding, network drop, low memory.
-- **Facts inherited from input sources.** The issue body, sibling specs, and prior reviewer findings carry claims that propagate uncritically into the PR — OS version thresholds, third-party API behavior, deployed-config invariants, "X works on platform Y because Z". The structured reviewers tend to check internal consistency, not external truth. The most load-bearing 1–3 inherited claims deserve a cross-check against authoritative public docs.
+- **Facts inherited from inputs.** Claims from the issue body, sibling specs, and prior findings tend to propagate without verification. Structured reviewers check internal consistency, not external truth — the load-bearing ones deserve a cross-check against authoritative public docs.
 
 ## Procedure
 
 1. Read the diff and the issue.
 2. Read the prior findings — do **not** repeat them. Look for what they *don't* address.
 3. Formulate 3–7 concrete hypotheses, each of the form: "If <specific condition>, then <specific failure>, because <mechanism>". Vague hypotheses ("could be racy") are useless — be specific or drop the hypothesis.
-4. Identify factual claims the PR asserts that came from outside (sibling specs, issue body, prior findings). Pick the 1–3 most load-bearing — the ones whose falseness would invalidate a real chunk of the PR — and verify them against authoritative public docs via WebFetch. Treat disproven claims as confirmed findings on par with hypothesis-based ones.
+4. Pick 1–3 load-bearing inherited factual claims and verify them via WebFetch. Treat disproven claims as confirmed findings.
 5. For each hypothesis from step 3, verify against the code: grep, read, trace. Try to disprove it.
 6. Report only items that survive your attempt to disprove them, or that you couldn't fully verify.
 

--- a/docs/product/features/_template.md
+++ b/docs/product/features/_template.md
@@ -65,8 +65,7 @@
      user-visible platform differences, remove this section entirely.
 
      For features with strong platform asymmetry, per-platform top-level
-     sections (Android / iOS / macOS / Desktop) may replace this single
-     `## Platform notes` block. -->
+     sections may replace this single block. -->
 
 -
 

--- a/docs/product/features/_template.md
+++ b/docs/product/features/_template.md
@@ -62,7 +62,11 @@
      can't be replicated on one target.
      Implementation differences (NSD vs JmDNS, view models, build tasks)
      do NOT belong here — those live in the issue. If there are no
-     user-visible platform differences, remove this section entirely. -->
+     user-visible platform differences, remove this section entirely.
+
+     For features with strong platform asymmetry, per-platform top-level
+     sections (Android / iOS / macOS / Desktop) may replace this single
+     `## Platform notes` block. -->
 
 -
 


### PR DESCRIPTION
Two retro outcomes from #122.

**`.claude/agents/review-adversarial.md`** — verifying load-bearing inherited factual claims is now part of the default brief, not a thing the orchestrator has to remember to ask for. `WebFetch` added to tools.

**`docs/product/features/_template.md`** — one-line note that per-platform top-level sections are a valid layout for strongly platform-asymmetric features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)