### PR TITLE
#150: hold WifiLock and partial WakeLock during active Android transfers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ captures
 !*.xcworkspace/contents.xcworkspacedata
 **/xcshareddata/WorkspaceSettings.xcsettings
 node_modules/
+.claude/scheduled_tasks.lock

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <!-- Required to join multicast groups used by NSD/mDNS service discovery. -->
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
+    <!-- Required by WifiManager.createWifiLock on some API levels. -->
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
     <!-- Foreground service hosting Ktor FileServer + NSD discovery so the Android peer
          stays reachable while the app is backgrounded. -->

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -14,6 +14,7 @@
          Android 15+ applies a 6h/day cumulative limit to dataSync — tracked in issue #59. -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
         android:name=".TetherApp"

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/di/AndroidAppContainer.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/di/AndroidAppContainer.kt
@@ -2,10 +2,18 @@ package com.tubetoast.tether.di
 
 import com.tubetoast.tether.discovery.DiscoveredDevicesStore
 import com.tubetoast.tether.discovery.MdnsDiscovery
+import com.tubetoast.tether.network.AndroidTransferLockHolder
+import com.tubetoast.tether.network.DefaultTransferActivityTracker
+import com.tubetoast.tether.network.TransferActivityTracker
 
 class AndroidAppContainer(
     config: AndroidAppConfig,
 ) : JvmAppContainer(config) {
     val application = config.application
+    private val lockHolder = AndroidTransferLockHolder(application)
+    override val transferActivityTracker: TransferActivityTracker = DefaultTransferActivityTracker(
+        onFirstEnter = lockHolder::acquire,
+        onLastExit = lockHolder::release,
+    )
     override val mdnsDiscovery: MdnsDiscovery = MdnsDiscovery(application, DiscoveredDevicesStore())
 }

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/AndroidTransferLockHolder.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/AndroidTransferLockHolder.kt
@@ -3,13 +3,19 @@ package com.tubetoast.tether.network
 import android.annotation.SuppressLint
 import android.content.Context
 import android.net.wifi.WifiManager
-import android.os.Build
 import android.os.PowerManager
 
 class AndroidTransferLockHolder(
     context: Context,
 ) {
-    private val wifiLock: WifiManager.WifiLock = createWifiLock(context)
+    // HIGH_PERF (deprecated API 29) is intentional: LOW_LATENCY only activates while the screen
+    // is on and the app is foreground, but the bug under fix is screen-off transfers — so the
+    // newer constant would silently no-op exactly when we need it.
+    @Suppress("DEPRECATION")
+    private val wifiLock: WifiManager.WifiLock =
+        (context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager)
+            .createWifiLock(WifiManager.WIFI_MODE_FULL_HIGH_PERF, "tether:transfer")
+            .also { it.setReferenceCounted(false) }
 
     private val wakeLock: PowerManager.WakeLock =
         (context.applicationContext.getSystemService(Context.POWER_SERVICE) as PowerManager)
@@ -32,16 +38,4 @@ class AndroidTransferLockHolder(
 
     internal val isWifiLockHeld: Boolean get() = wifiLock.isHeld
     internal val isWakeLockHeld: Boolean get() = wakeLock.isHeld
-
-    private fun createWifiLock(context: Context): WifiManager.WifiLock {
-        val wifi = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
-        val mode =
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                WifiManager.WIFI_MODE_FULL_LOW_LATENCY
-            } else {
-                @Suppress("DEPRECATION")
-                WifiManager.WIFI_MODE_FULL_HIGH_PERF
-            }
-        return wifi.createWifiLock(mode, "tether:transfer").also { it.setReferenceCounted(false) }
-    }
 }

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/AndroidTransferLockHolder.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/AndroidTransferLockHolder.kt
@@ -8,9 +8,9 @@ import android.os.PowerManager
 class AndroidTransferLockHolder(
     context: Context,
 ) {
-    // HIGH_PERF (deprecated API 29) is intentional: LOW_LATENCY only activates while the screen
-    // is on and the app is foreground, but the bug under fix is screen-off transfers — so the
-    // newer constant would silently no-op exactly when we need it.
+    // HIGH_PERF on API 24-28 is the effective protection for screen-off transfers; on API 29+
+    // the OS silently substitutes LOW_LATENCY (screen-on/foreground only), so the WifiLock
+    // is a no-op on Android 10+. WakeLock below still works on all versions. See knowledge doc.
     @Suppress("DEPRECATION")
     private val wifiLock: WifiManager.WifiLock =
         (context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager)

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/AndroidTransferLockHolder.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/AndroidTransferLockHolder.kt
@@ -18,8 +18,7 @@ class AndroidTransferLockHolder(
 
     fun acquire() {
         if (!wifiLock.isHeld) wifiLock.acquire()
-        // Transfer duration is bounded by the tracker (releaseAll on service onDestroy + per-transfer
-        // refcount). A WakelockTimeout would force a wrong upper bound on streaming transfers.
+        // Timeout would bound streaming transfers arbitrarily; release is guaranteed by the tracker.
         if (!wakeLock.isHeld) {
             @SuppressLint("WakelockTimeout")
             wakeLock.acquire()

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/AndroidTransferLockHolder.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/AndroidTransferLockHolder.kt
@@ -1,0 +1,33 @@
+package com.tubetoast.tether.network
+
+import android.content.Context
+import android.net.wifi.WifiManager
+import android.os.PowerManager
+
+class AndroidTransferLockHolder(
+    context: Context,
+) {
+    private val wifiLock: WifiManager.WifiLock =
+        (context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager)
+            .createWifiLock(WifiManager.WIFI_MODE_FULL_HIGH_PERF, "tether:transfer")
+            .also {
+                // Delegate reference counting to DefaultTransferActivityTracker; OS ref-counting
+                // would require matching acquire/release pairs that the tracker already manages.
+                it.setReferenceCounted(false)
+            }
+
+    private val wakeLock: PowerManager.WakeLock =
+        (context.applicationContext.getSystemService(Context.POWER_SERVICE) as PowerManager)
+            .newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "tether:transfer")
+            .also { it.setReferenceCounted(false) }
+
+    fun acquire() {
+        if (!wifiLock.isHeld) wifiLock.acquire()
+        if (!wakeLock.isHeld) wakeLock.acquire()
+    }
+
+    fun release() {
+        if (wakeLock.isHeld) wakeLock.release()
+        if (wifiLock.isHeld) wifiLock.release()
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/AndroidTransferLockHolder.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/AndroidTransferLockHolder.kt
@@ -1,20 +1,15 @@
 package com.tubetoast.tether.network
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.net.wifi.WifiManager
+import android.os.Build
 import android.os.PowerManager
 
 class AndroidTransferLockHolder(
     context: Context,
 ) {
-    private val wifiLock: WifiManager.WifiLock =
-        (context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager)
-            .createWifiLock(WifiManager.WIFI_MODE_FULL_HIGH_PERF, "tether:transfer")
-            .also {
-                // Delegate reference counting to DefaultTransferActivityTracker; OS ref-counting
-                // would require matching acquire/release pairs that the tracker already manages.
-                it.setReferenceCounted(false)
-            }
+    private val wifiLock: WifiManager.WifiLock = createWifiLock(context)
 
     private val wakeLock: PowerManager.WakeLock =
         (context.applicationContext.getSystemService(Context.POWER_SERVICE) as PowerManager)
@@ -23,11 +18,31 @@ class AndroidTransferLockHolder(
 
     fun acquire() {
         if (!wifiLock.isHeld) wifiLock.acquire()
-        if (!wakeLock.isHeld) wakeLock.acquire()
+        // Transfer duration is bounded by the tracker (releaseAll on service onDestroy + per-transfer
+        // refcount). A WakelockTimeout would force a wrong upper bound on streaming transfers.
+        if (!wakeLock.isHeld) {
+            @SuppressLint("WakelockTimeout")
+            wakeLock.acquire()
+        }
     }
 
     fun release() {
         if (wakeLock.isHeld) wakeLock.release()
         if (wifiLock.isHeld) wifiLock.release()
+    }
+
+    internal val isWifiLockHeld: Boolean get() = wifiLock.isHeld
+    internal val isWakeLockHeld: Boolean get() = wakeLock.isHeld
+
+    private fun createWifiLock(context: Context): WifiManager.WifiLock {
+        val wifi = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+        val mode =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                WifiManager.WIFI_MODE_FULL_LOW_LATENCY
+            } else {
+                @Suppress("DEPRECATION")
+                WifiManager.WIFI_MODE_FULL_HIGH_PERF
+            }
+        return wifi.createWifiLock(mode, "tether:transfer").also { it.setReferenceCounted(false) }
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/TetherForegroundService.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/TetherForegroundService.kt
@@ -96,6 +96,7 @@ class TetherForegroundService : LifecycleService() {
     }
 
     override fun onDestroy() {
+        (application as AppContainerProvider).container.transferActivityTracker.releaseAll()
         runningMdnsDiscovery?.let { mdnsDiscovery ->
             try {
                 mdnsDiscovery.stop()

--- a/composeApp/src/androidUnitTest/kotlin/com/tubetoast/tether/network/AndroidTransferLockHolderTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/tubetoast/tether/network/AndroidTransferLockHolderTest.kt
@@ -8,7 +8,6 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
-import org.robolectric.shadows.ShadowPowerManager
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -24,29 +23,51 @@ class AndroidTransferLockHolderTest {
         holder = AndroidTransferLockHolder(context)
     }
 
-    private fun isWakeLockHeld(): Boolean =
-        ShadowPowerManager.getLatestWakeLock()?.isHeld ?: false
-
     @Test
-    fun `acquire then release toggles wake lock`() {
+    fun `acquire then release toggles both locks`() {
         holder.acquire()
-        assertTrue(isWakeLockHeld(), "wake lock should be held after acquire")
+        assertTrue(holder.isWakeLockHeld, "wake lock should be held after acquire")
+        assertTrue(holder.isWifiLockHeld, "wifi lock should be held after acquire")
         holder.release()
-        assertFalse(isWakeLockHeld(), "wake lock should be released after release")
+        assertFalse(holder.isWakeLockHeld, "wake lock should be released after release")
+        assertFalse(holder.isWifiLockHeld, "wifi lock should be released after release")
     }
 
     @Test
-    fun `double acquire is idempotent`() {
+    fun `double acquire is idempotent for both locks`() {
         holder.acquire()
         holder.acquire()
-        assertTrue(isWakeLockHeld())
+        assertTrue(holder.isWakeLockHeld)
+        assertTrue(holder.isWifiLockHeld)
         holder.release()
-        assertFalse(isWakeLockHeld(), "single release should drop the lock")
+        assertFalse(holder.isWakeLockHeld, "single release should drop wake lock")
+        assertFalse(holder.isWifiLockHeld, "single release should drop wifi lock")
     }
 
     @Test
     fun `release without prior acquire is a no-op`() {
         holder.release()
-        assertFalse(isWakeLockHeld())
+        assertFalse(holder.isWakeLockHeld)
+        assertFalse(holder.isWifiLockHeld)
+    }
+
+    @Test
+    fun `tracker callbacks drive both locks end-to-end`() = kotlinx.coroutines.test.runTest {
+        val tracker = DefaultTransferActivityTracker(
+            onFirstEnter = holder::acquire,
+            onLastExit = holder::release,
+        )
+        assertFalse(holder.isWakeLockHeld, "no lock before any transfer")
+        assertFalse(holder.isWifiLockHeld, "no lock before any transfer")
+        var observedInsideWake = false
+        var observedInsideWifi = false
+        tracker.withActiveTransfer {
+            observedInsideWake = holder.isWakeLockHeld
+            observedInsideWifi = holder.isWifiLockHeld
+        }
+        assertTrue(observedInsideWake, "wake lock should be held inside active transfer")
+        assertTrue(observedInsideWifi, "wifi lock should be held inside active transfer")
+        assertFalse(holder.isWakeLockHeld, "wake lock should be released after transfer")
+        assertFalse(holder.isWifiLockHeld, "wifi lock should be released after transfer")
     }
 }

--- a/composeApp/src/androidUnitTest/kotlin/com/tubetoast/tether/network/AndroidTransferLockHolderTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/tubetoast/tether/network/AndroidTransferLockHolderTest.kt
@@ -1,0 +1,52 @@
+package com.tubetoast.tether.network
+
+import android.content.Context
+import com.tubetoast.tether.TetherApp
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowPowerManager
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = TetherApp::class)
+class AndroidTransferLockHolderTest {
+    private lateinit var holder: AndroidTransferLockHolder
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+        holder = AndroidTransferLockHolder(context)
+    }
+
+    private fun isWakeLockHeld(): Boolean =
+        ShadowPowerManager.getLatestWakeLock()?.isHeld ?: false
+
+    @Test
+    fun `acquire then release toggles wake lock`() {
+        holder.acquire()
+        assertTrue(isWakeLockHeld(), "wake lock should be held after acquire")
+        holder.release()
+        assertFalse(isWakeLockHeld(), "wake lock should be released after release")
+    }
+
+    @Test
+    fun `double acquire is idempotent`() {
+        holder.acquire()
+        holder.acquire()
+        assertTrue(isWakeLockHeld())
+        holder.release()
+        assertFalse(isWakeLockHeld(), "single release should drop the lock")
+    }
+
+    @Test
+    fun `release without prior acquire is a no-op`() {
+        holder.release()
+        assertFalse(isWakeLockHeld())
+    }
+}

--- a/composeApp/src/androidUnitTest/kotlin/com/tubetoast/tether/network/TetherForegroundServiceTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/tubetoast/tether/network/TetherForegroundServiceTest.kt
@@ -3,12 +3,19 @@ package com.tubetoast.tether.network
 import android.app.Service
 import android.content.Intent
 import com.tubetoast.tether.TetherApp
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowPowerManager
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -44,7 +51,23 @@ class TetherForegroundServiceTest {
     @Test
     fun `onDestroy does not throw when server and discovery were never started`() {
         val controller = Robolectric.buildService(TetherForegroundService::class.java).create()
-        // destroy without ever calling start() — should not throw
         controller.destroy()
     }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `onDestroy releases tracker locks while a transfer is still active`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val controller = Robolectric.buildService(TetherForegroundService::class.java).create()
+            val tracker = (controller.get().application as TetherApp).container.transferActivityTracker
+            val barrier = CompletableDeferred<Unit>()
+            val transfer = async { tracker.withActiveTransfer { barrier.await() } }
+            val heldBeforeDestroy = ShadowPowerManager.getLatestWakeLock()?.isHeld == true
+            controller.destroy()
+            val heldAfterDestroy = ShadowPowerManager.getLatestWakeLock()?.isHeld == true
+            barrier.complete(Unit)
+            transfer.await()
+            assertTrue(heldBeforeDestroy, "wake lock should be held during active transfer")
+            assertFalse(heldAfterDestroy, "onDestroy must release locks via tracker.releaseAll()")
+        }
 }

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/di/AppleAppContainer.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/di/AppleAppContainer.kt
@@ -14,6 +14,7 @@ open class AppleAppContainer(
             port = 0,
             trustedDeviceStore = config.trustedDeviceStore,
             deviceKeyPair = config.deviceKeyPair,
+            tracker = transferActivityTracker,
         )
     }
     override val mdnsDiscovery: MdnsDiscovery = MdnsDiscovery(DiscoveredDevicesStore())

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/network/FileServer.apple.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/network/FileServer.apple.kt
@@ -2,8 +2,6 @@
 
 package com.tubetoast.tether.network
 
-import com.tubetoast.tether.network.DefaultTransferActivityTracker
-import com.tubetoast.tether.network.TransferActivityTracker
 import com.tubetoast.tether.security.DeviceKeyPair
 import com.tubetoast.tether.security.TrustedDeviceStore
 import io.ktor.server.cio.CIO

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/network/FileServer.apple.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/network/FileServer.apple.kt
@@ -2,6 +2,8 @@
 
 package com.tubetoast.tether.network
 
+import com.tubetoast.tether.network.DefaultTransferActivityTracker
+import com.tubetoast.tether.network.TransferActivityTracker
 import com.tubetoast.tether.security.DeviceKeyPair
 import com.tubetoast.tether.security.TrustedDeviceStore
 import io.ktor.server.cio.CIO
@@ -28,6 +30,7 @@ actual class FileServer(
     downloadsDir: String? = null,
     private val trustedDeviceStore: TrustedDeviceStore,
     private val deviceKeyPair: DeviceKeyPair,
+    private val tracker: TransferActivityTracker = DefaultTransferActivityTracker(),
 ) {
     private val downloadsDir: String = downloadsDir ?: defaultDownloadsDir()
     private var server: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
@@ -37,7 +40,7 @@ actual class FileServer(
         val storage = AppleUploadStorage(downloadsDir)
         storage.ensureRoot()
         val srv = embeddedServer(CIO, port = port) {
-            installFileServerRoutes(storage, trustedDeviceStore, deviceKeyPair.publicKey)
+            installFileServerRoutes(storage, trustedDeviceStore, deviceKeyPair.publicKey, tracker)
         }.start(wait = false)
         server = srv
         return runBlocking { srv.engine.resolvedConnectors() }.first().port

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
@@ -1,8 +1,10 @@
 package com.tubetoast.tether.di
 
 import com.tubetoast.tether.discovery.MdnsDiscovery
+import com.tubetoast.tether.network.DefaultTransferActivityTracker
 import com.tubetoast.tether.network.FileClient
 import com.tubetoast.tether.network.FileServer
+import com.tubetoast.tether.network.TransferActivityTracker
 import com.tubetoast.tether.security.TrustedDeviceStore
 
 abstract class AppContainer(
@@ -11,6 +13,7 @@ abstract class AppContainer(
     val deviceName: String = config.deviceName
     abstract val fileServer: FileServer
     abstract val mdnsDiscovery: MdnsDiscovery
-    open val fileClient: FileClient = FileClient.default()
+    open val transferActivityTracker: TransferActivityTracker = DefaultTransferActivityTracker()
+    open val fileClient: FileClient by lazy { FileClient.default(transferActivityTracker) }
     abstract val trustedDeviceStore: TrustedDeviceStore
 }

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
@@ -30,10 +30,13 @@ import kotlin.time.Duration.Companion.seconds
 
 class FileClient(
     private val client: HttpClient,
+    private val tracker: TransferActivityTracker = DefaultTransferActivityTracker(),
     private val noProgressTimeout: Duration = DEFAULT_NO_PROGRESS_TIMEOUT,
 ) : Closeable {
     companion object {
-        fun default(): FileClient = FileClient(
+        fun default(
+            tracker: TransferActivityTracker = DefaultTransferActivityTracker(),
+        ): FileClient = FileClient(
             client = HttpClient(CIO) {
                 install(ContentNegotiation) { json() }
                 install(HttpTimeout) {
@@ -41,6 +44,7 @@ class FileClient(
                     socketTimeoutMillis = HttpTimeoutConfig.INFINITE_TIMEOUT_MS
                 }
             },
+            tracker = tracker,
         )
     }
 
@@ -55,12 +59,14 @@ class FileClient(
         fileName: String,
         totalBytes: Long? = null,
         onProgress: ((bytesTransferred: Long, totalBytes: Long?) -> Unit)? = null,
-    ): SendResult = try {
-        sendInternal(device, channel, fileName, totalBytes, onProgress)
-    } catch (e: CancellationException) {
-        throw e
-    } catch (e: Throwable) {
-        SendResult.Failure(e.message ?: e::class.simpleName ?: "unknown error")
+    ): SendResult = tracker.withActiveTransfer {
+        try {
+            sendInternal(device, channel, fileName, totalBytes, onProgress)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            SendResult.Failure(e.message ?: e::class.simpleName ?: "unknown error")
+        }
     }
 
     override fun close() {

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileServer.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileServer.kt
@@ -1,13 +1,5 @@
 package com.tubetoast.tether.network
 
-/**
- * The expect declaration intentionally omits a constructor: JVM's `actual`
- * takes `(port, downloadsDir, trustedDeviceStore, deviceKeyPair, tracker)`,
- * Apple's takes the same minus `downloadsDir`. KMP allows this — actuals are
- * free to declare their own constructors when expect declares none. Common
- * code never instantiates `FileServer` directly; only the platform-specific
- * `*AppContainer` does, and it knows its own constructor.
- */
 expect class FileServer {
     fun start(): Int
 

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileServer.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileServer.kt
@@ -2,10 +2,11 @@ package com.tubetoast.tether.network
 
 /**
  * The expect declaration intentionally omits a constructor: JVM's `actual`
- * takes `(port, downloadsDir)`, Apple's stub takes no args. KMP allows this
- * — actuals are free to declare their own constructors when expect declares
- * none. Common code never instantiates `FileServer` directly; only the
- * platform-specific `*AppContainer` does, and it knows its own constructor.
+ * takes `(port, downloadsDir, trustedDeviceStore, deviceKeyPair, tracker)`,
+ * Apple's takes the same minus `downloadsDir`. KMP allows this — actuals are
+ * free to declare their own constructors when expect declares none. Common
+ * code never instantiates `FileServer` directly; only the platform-specific
+ * `*AppContainer` does, and it knows its own constructor.
  */
 expect class FileServer {
     fun start(): Int

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileServerRoutes.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileServerRoutes.kt
@@ -39,6 +39,7 @@ internal fun Application.installFileServerRoutes(
     storage: UploadStorage,
     trustedDeviceStore: TrustedDeviceStore,
     serverPublicKey: ByteArray,
+    tracker: TransferActivityTracker = DefaultTransferActivityTracker(),
 ) {
     install(ContentNegotiation) { json() }
     routing {
@@ -72,19 +73,21 @@ internal fun Application.installFileServerRoutes(
             val destination = storage.resolveDestination(fileName)
             var uploadComplete = false
             try {
-                val body = call.receiveChannel()
-                val bytesWritten = storage.writeBody(body, destination)
-                // Ktor closes the body channel silently when the client disconnects
-                // mid-stream. closedCause covers exceptional close; the Content-Length
-                // comparison covers clean close on incomplete bodies.
-                body.closedCause?.let { throw it }
-                val expected = call.request.contentLength()
-                if (expected != null && bytesWritten < expected) {
-                    error("FileServer: incomplete upload — got $bytesWritten of $expected bytes")
+                tracker.withActiveTransfer {
+                    val body = call.receiveChannel()
+                    val bytesWritten = storage.writeBody(body, destination)
+                    // Ktor closes the body channel silently when the client disconnects
+                    // mid-stream. closedCause covers exceptional close; the Content-Length
+                    // comparison covers clean close on incomplete bodies.
+                    body.closedCause?.let { throw it }
+                    val expected = call.request.contentLength()
+                    if (expected != null && bytesWritten < expected) {
+                        error("FileServer: incomplete upload — got $bytesWritten of $expected bytes")
+                    }
+                    uploadComplete = true
+                    storage.logInfo("received '$fileName' — $bytesWritten bytes → $destination")
+                    call.respond(HttpStatusCode.OK, mapOf("savedPath" to destination))
                 }
-                uploadComplete = true
-                storage.logInfo("received '$fileName' — $bytesWritten bytes → $destination")
-                call.respond(HttpStatusCode.OK, mapOf("savedPath" to destination))
             } catch (e: Exception) {
                 storage.logError("upload failed for '$fileName' — ${e.message ?: "unknown error"}")
                 try {

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/TransferActivityTracker.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/TransferActivityTracker.kt
@@ -1,0 +1,39 @@
+package com.tubetoast.tether.network
+
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+
+interface TransferActivityTracker {
+    suspend fun <T> withActiveTransfer(block: suspend () -> T): T
+
+    fun releaseAll()
+}
+
+@OptIn(ExperimentalAtomicApi::class)
+class DefaultTransferActivityTracker(
+    private val onFirstEnter: () -> Unit = {},
+    private val onLastExit: () -> Unit = {},
+) : TransferActivityTracker {
+    private val count = AtomicInt(0)
+
+    override suspend fun <T> withActiveTransfer(block: suspend () -> T): T {
+        if (count.fetchAndAdd(1) == 0) onFirstEnter()
+        try {
+            return block()
+        } finally {
+            if (decrementIfPositive() == 0) onLastExit()
+        }
+    }
+
+    override fun releaseAll() {
+        if (count.exchange(0) > 0) onLastExit()
+    }
+
+    private fun decrementIfPositive(): Int {
+        while (true) {
+            val cur = count.load()
+            if (cur == 0) return -1
+            if (count.compareAndSet(cur, cur - 1)) return cur - 1
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/TransferActivityTracker.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/TransferActivityTracker.kt
@@ -9,6 +9,15 @@ interface TransferActivityTracker {
     fun releaseAll()
 }
 
+/**
+ * State transitions (`enter`/`exit`/`releaseAll`) run as CAS retry loops: read the current
+ * state, compute the next one, and try to swap atomically. If another thread won the swap
+ * between read and write, the loop retries with the fresh state. This is a standard
+ * lock-free pattern — `synchronized` is unavailable in commonMain, and a coroutine `Mutex`
+ * can't guard `releaseAll` (non-suspend, called from `onDestroy`). The `held` flag inside
+ * `State` makes both `onFirstEnter` and `onLastExit` fire exactly once per holding period
+ * regardless of how transitions interleave.
+ */
 @OptIn(ExperimentalAtomicApi::class)
 class DefaultTransferActivityTracker(
     private val onFirstEnter: () -> Unit = {},

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/TransferActivityTracker.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/TransferActivityTracker.kt
@@ -1,6 +1,6 @@
 package com.tubetoast.tether.network
 
-import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 interface TransferActivityTracker {
@@ -14,26 +14,54 @@ class DefaultTransferActivityTracker(
     private val onFirstEnter: () -> Unit = {},
     private val onLastExit: () -> Unit = {},
 ) : TransferActivityTracker {
-    private val count = AtomicInt(0)
+    private data class State(
+        val count: Int,
+        val held: Boolean,
+    )
+
+    private val state = AtomicReference(State(0, false))
 
     override suspend fun <T> withActiveTransfer(block: suspend () -> T): T {
-        if (count.fetchAndAdd(1) == 0) onFirstEnter()
+        enter()
         try {
             return block()
         } finally {
-            if (decrementIfPositive() == 0) onLastExit()
+            exit()
         }
     }
 
     override fun releaseAll() {
-        if (count.exchange(0) > 0) onLastExit()
+        while (true) {
+            val old = state.load()
+            if (state.compareAndSet(old, State(0, false))) {
+                if (old.held) onLastExit()
+                return
+            }
+        }
     }
 
-    private fun decrementIfPositive(): Int {
+    private fun enter() {
         while (true) {
-            val cur = count.load()
-            if (cur == 0) return -1
-            if (count.compareAndSet(cur, cur - 1)) return cur - 1
+            val old = state.load()
+            val acquireNow = old.count == 0 && !old.held
+            val new = State(old.count + 1, if (acquireNow) true else old.held)
+            if (state.compareAndSet(old, new)) {
+                if (acquireNow) onFirstEnter()
+                return
+            }
+        }
+    }
+
+    private fun exit() {
+        while (true) {
+            val old = state.load()
+            val newCount = if (old.count > 0) old.count - 1 else 0
+            val releaseNow = newCount == 0 && old.held
+            val new = State(newCount, if (releaseNow) false else old.held)
+            if (state.compareAndSet(old, new)) {
+                if (releaseNow) onLastExit()
+                return
+            }
         }
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/network/DefaultTransferActivityTrackerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/network/DefaultTransferActivityTrackerTest.kt
@@ -1,0 +1,105 @@
+package com.tubetoast.tether.network
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultTransferActivityTrackerTest {
+    @Test
+    fun `first enter fires onFirstEnter`() = runTest {
+        var enters = 0
+        val tracker = DefaultTransferActivityTracker(onFirstEnter = { enters++ })
+        tracker.withActiveTransfer {}
+        assertEquals(1, enters)
+    }
+
+    @Test
+    fun `second enter does not re-fire onFirstEnter`() = runTest {
+        var enters = 0
+        val tracker = DefaultTransferActivityTracker(onFirstEnter = { enters++ })
+        tracker.withActiveTransfer {
+            tracker.withActiveTransfer {}
+        }
+        assertEquals(1, enters)
+    }
+
+    @Test
+    fun `intermediate exit does not fire onLastExit`() = runTest {
+        var exits = 0
+        val tracker = DefaultTransferActivityTracker(onLastExit = { exits++ })
+        tracker.withActiveTransfer {
+            tracker.withActiveTransfer {}
+            assertEquals(0, exits)
+        }
+    }
+
+    @Test
+    fun `last exit fires onLastExit exactly once`() = runTest {
+        var exits = 0
+        val tracker = DefaultTransferActivityTracker(onLastExit = { exits++ })
+        tracker.withActiveTransfer {
+            tracker.withActiveTransfer {}
+        }
+        assertEquals(1, exits)
+    }
+
+    @Test
+    fun `exception inside withActiveTransfer still decrements and fires onLastExit`() = runTest {
+        var exits = 0
+        val tracker = DefaultTransferActivityTracker(onLastExit = { exits++ })
+        runCatching { tracker.withActiveTransfer { error("boom") } }
+        assertEquals(1, exits)
+    }
+
+    @Test
+    fun `two parallel withActiveTransfer cause only one acquire and one release`() = runTest(
+        UnconfinedTestDispatcher(),
+    ) {
+        var enters = 0
+        var exits = 0
+        val tracker = DefaultTransferActivityTracker(
+            onFirstEnter = { enters++ },
+            onLastExit = { exits++ },
+        )
+        val barrier = kotlinx.coroutines.CompletableDeferred<Unit>()
+        val job1 = async {
+            tracker.withActiveTransfer {
+                barrier.await()
+            }
+        }
+        val job2 = async {
+            tracker.withActiveTransfer {
+                barrier.await()
+            }
+        }
+        barrier.complete(Unit)
+        awaitAll(job1, job2)
+        assertEquals(1, enters)
+        assertEquals(1, exits)
+    }
+
+    @Test
+    fun `releaseAll when count greater than zero fires onLastExit and resets`() = runTest(UnconfinedTestDispatcher()) {
+        var exits = 0
+        val tracker = DefaultTransferActivityTracker(onLastExit = { exits++ })
+        val barrier = kotlinx.coroutines.CompletableDeferred<Unit>()
+        val job = async { tracker.withActiveTransfer { barrier.await() } }
+        tracker.releaseAll()
+        barrier.complete(Unit)
+        job.await()
+        assertEquals(1, exits)
+    }
+
+    @Test
+    fun `releaseAll when count is zero fires nothing`() = runTest {
+        var exits = 0
+        val tracker = DefaultTransferActivityTracker(onLastExit = { exits++ })
+        tracker.releaseAll()
+        assertEquals(0, exits)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/network/FileServerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/network/FileServerTest.kt
@@ -44,7 +44,10 @@ class FileServerTest {
         cleanupPaths.clear()
     }
 
-    private fun newServer(downloadsDir: File? = null): FileServer {
+    private fun newServer(
+        downloadsDir: File? = null,
+        tracker: TransferActivityTracker = DefaultTransferActivityTracker(),
+    ): FileServer {
         val configDir = Files.createTempDirectory("tether-fs-test-keys").toFile().also(cleanupPaths::add)
         val resolvedDownloads = downloadsDir ?: Files
             .createTempDirectory("tether-fs-test-dl")
@@ -55,6 +58,7 @@ class FileServerTest {
             downloadsDir = resolvedDownloads,
             trustedDeviceStore = TrustedDeviceStore(configDir),
             deviceKeyPair = DeviceKeyPair(configDir),
+            tracker = tracker,
         )
         startedServer = server
         return server
@@ -249,6 +253,33 @@ class FileServerTest {
                 assertEquals(payload.size, saved.size, "size mismatch")
                 assertContentEquals(payload, saved, "content mismatch on $sizeMb MB roundtrip")
             }
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `upload notifies transfer tracker once on entry and once on exit`() {
+        val tmpDir = Files.createTempDirectory("tether-test").toFile().also(cleanupPaths::add)
+        var enters = 0
+        var exits = 0
+        val tracker = DefaultTransferActivityTracker(
+            onFirstEnter = { enters++ },
+            onLastExit = { exits++ },
+        )
+        val server = newServer(downloadsDir = tmpDir, tracker = tracker)
+        val port = server.start()
+        val client = HttpClient(CIO) { install(ContentNegotiation) { json() } }
+        try {
+            runBlocking {
+                val response = client.post("http://localhost:$port/upload?name=track.txt") {
+                    contentType(ContentType.Application.OctetStream)
+                    setBody("payload".toByteArray())
+                }
+                assertEquals(HttpStatusCode.OK, response.status)
+            }
+            assertEquals(1, enters, "tracker.onFirstEnter must fire exactly once per upload")
+            assertEquals(1, exits, "tracker.onLastExit must fire exactly once per upload")
         } finally {
             client.close()
         }

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/di/JvmAppContainer.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/di/JvmAppContainer.kt
@@ -15,6 +15,7 @@ abstract class JvmAppContainer(
             downloadsDir = downloadsDir,
             trustedDeviceStore = config.trustedDeviceStore,
             deviceKeyPair = config.deviceKeyPair,
+            tracker = transferActivityTracker,
         )
     }
 }

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/network/FileServer.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/network/FileServer.kt
@@ -1,5 +1,7 @@
 package com.tubetoast.tether.network
 
+import com.tubetoast.tether.network.DefaultTransferActivityTracker
+import com.tubetoast.tether.network.TransferActivityTracker
 import com.tubetoast.tether.security.DeviceKeyPair
 import com.tubetoast.tether.security.TrustedDeviceStore
 import io.ktor.server.cio.CIO
@@ -16,6 +18,7 @@ actual class FileServer(
     private val downloadsDir: File = File(System.getProperty("user.home"), "Downloads/Tether"),
     private val trustedDeviceStore: TrustedDeviceStore,
     private val deviceKeyPair: DeviceKeyPair,
+    private val tracker: TransferActivityTracker = DefaultTransferActivityTracker(),
 ) {
     private var server: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
 
@@ -24,7 +27,7 @@ actual class FileServer(
         val storage = JvmUploadStorage(downloadsDir)
         storage.ensureRoot()
         val srv = embeddedServer(CIO, port = port) {
-            installFileServerRoutes(storage, trustedDeviceStore, deviceKeyPair.publicKey)
+            installFileServerRoutes(storage, trustedDeviceStore, deviceKeyPair.publicKey, tracker)
         }.start(wait = false)
         server = srv
         // resolvedConnectors() returns the actual OS-assigned port when port=0 was specified,

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/network/FileServer.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/network/FileServer.kt
@@ -1,7 +1,5 @@
 package com.tubetoast.tether.network
 
-import com.tubetoast.tether.network.DefaultTransferActivityTracker
-import com.tubetoast.tether.network.TransferActivityTracker
 import com.tubetoast.tether.security.DeviceKeyPair
 import com.tubetoast.tether.security.TrustedDeviceStore
 import io.ktor.server.cio.CIO

--- a/docs/knowledge/android-fgs.md
+++ b/docs/knowledge/android-fgs.md
@@ -132,10 +132,17 @@ transfer completes. The FGS type does not prevent either.
 `PowerManager.WakeLock` (`PARTIAL_WAKE_LOCK`) for the duration of each active transfer.
 Release both when the last concurrent transfer finishes.
 
-`WIFI_MODE_FULL_HIGH_PERF` is deprecated since API 29 in favor of
-`WIFI_MODE_FULL_LOW_LATENCY`, but `LOW_LATENCY` only activates while the screen is on and
-the app is foreground — neither holds for our screen-locked transfer case. The deprecated
-constant remains the correct choice here; suppress the warning at the call site.
+**Known platform limitation — WifiLock on API 29+.** `WIFI_MODE_FULL_HIGH_PERF` is
+deprecated since API 29 and the OS silently substitutes any acquired lock with
+`WIFI_MODE_FULL_LOW_LATENCY`, which only activates while the screen is on and the app is
+foreground. There is no public replacement that keeps the Wi-Fi radio active during
+screen-off on Android 10+. Practical consequence:
+
+- API 24-28: WifiLock + WakeLock both effective — full fix.
+- API 29+: only WakeLock is effective. Wi-Fi radio power-save mid-transfer remains a
+  possible failure mode on screen-off; the WakeLock prevents CPU throttling but cannot
+  keep the radio awake. The lock is still acquired (no harm) so the fix is forward-
+  compatible if Android ever exposes a screen-off Wi-Fi lock.
 
 **Anti-pattern:** holding the locks for the entire FGS lifetime keeps the radio and CPU
 active even when no transfer is running, draining the battery with no user benefit.
@@ -164,3 +171,4 @@ override val transferActivityTracker: TransferActivityTracker = DefaultTransferA
     onLastExit = lockHolder::release,
 )
 ```
+

--- a/docs/knowledge/android-fgs.md
+++ b/docs/knowledge/android-fgs.md
@@ -116,3 +116,46 @@ for MVP; proper persistent state (SharedPreferences flag) tracked in #58.
     android:name=".MainActivity"
     android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|uiMode|keyboardHidden">
 ```
+
+---
+
+## Wi-Fi / wake locks during active transfers
+
+**Symptom:** transfers of large files abort mid-way when the screen is locked.
+No network error on the sender side; the receiver's upload handler gets a closed channel.
+
+**Root cause:** Wi-Fi power-save mode (radio parks itself when the screen turns off) and
+Android Doze (CPU throttled, process suspended) can tear the TCP connection before the
+transfer completes. The FGS type does not prevent either.
+
+**Fix:** hold a `WifiManager.WifiLock` (`WIFI_MODE_FULL_HIGH_PERF`) and a
+`PowerManager.WakeLock` (`PARTIAL_WAKE_LOCK`) for the duration of each active transfer.
+Release both when the last concurrent transfer finishes.
+
+**Anti-pattern:** holding the locks for the entire FGS lifetime keeps the radio and CPU
+active even when no transfer is running, draining the battery with no user benefit.
+
+**Implementation:**
+
+- `AndroidTransferLockHolder` (`androidMain`) owns both locks with `setReferenceCounted(false)`.
+  Reference counting is delegated to `DefaultTransferActivityTracker`; the holder's acquire/release
+  are idempotent guards (`isHeld` check).
+- `DefaultTransferActivityTracker` (`commonMain`) wraps each upload (server-side) and send
+  (client-side) with `withActiveTransfer { … }`. On `0 → 1` it calls `onFirstEnter`; on `N → 0`
+  it calls `onLastExit`. Concurrent transfers share a single lock.
+- `TetherForegroundService.onDestroy` calls `transferActivityTracker.releaseAll()` before stopping
+  the server, releasing any locks held by in-flight transfers killed by the OS.
+
+```xml
+<!-- AndroidManifest.xml -->
+<uses-permission android:name="android.permission.WAKE_LOCK" />
+```
+
+```kotlin
+// AndroidAppContainer.kt
+private val lockHolder = AndroidTransferLockHolder(application)
+override val transferActivityTracker: TransferActivityTracker = DefaultTransferActivityTracker(
+    onFirstEnter = lockHolder::acquire,
+    onLastExit = lockHolder::release,
+)
+```

--- a/docs/knowledge/android-fgs.md
+++ b/docs/knowledge/android-fgs.md
@@ -128,10 +128,14 @@ No network error on the sender side; the receiver's upload handler gets a closed
 Android Doze (CPU throttled, process suspended) can tear the TCP connection before the
 transfer completes. The FGS type does not prevent either.
 
-**Fix:** hold a `WifiManager.WifiLock` (`WIFI_MODE_FULL_LOW_LATENCY` on API ≥ 29,
-`WIFI_MODE_FULL_HIGH_PERF` on older releases) and a `PowerManager.WakeLock`
-(`PARTIAL_WAKE_LOCK`) for the duration of each active transfer. Release both when the
-last concurrent transfer finishes.
+**Fix:** hold a `WifiManager.WifiLock` (`WIFI_MODE_FULL_HIGH_PERF`) and a
+`PowerManager.WakeLock` (`PARTIAL_WAKE_LOCK`) for the duration of each active transfer.
+Release both when the last concurrent transfer finishes.
+
+`WIFI_MODE_FULL_HIGH_PERF` is deprecated since API 29 in favor of
+`WIFI_MODE_FULL_LOW_LATENCY`, but `LOW_LATENCY` only activates while the screen is on and
+the app is foreground — neither holds for our screen-locked transfer case. The deprecated
+constant remains the correct choice here; suppress the warning at the call site.
 
 **Anti-pattern:** holding the locks for the entire FGS lifetime keeps the radio and CPU
 active even when no transfer is running, draining the battery with no user benefit.

--- a/docs/knowledge/android-fgs.md
+++ b/docs/knowledge/android-fgs.md
@@ -128,9 +128,10 @@ No network error on the sender side; the receiver's upload handler gets a closed
 Android Doze (CPU throttled, process suspended) can tear the TCP connection before the
 transfer completes. The FGS type does not prevent either.
 
-**Fix:** hold a `WifiManager.WifiLock` (`WIFI_MODE_FULL_HIGH_PERF`) and a
-`PowerManager.WakeLock` (`PARTIAL_WAKE_LOCK`) for the duration of each active transfer.
-Release both when the last concurrent transfer finishes.
+**Fix:** hold a `WifiManager.WifiLock` (`WIFI_MODE_FULL_LOW_LATENCY` on API ≥ 29,
+`WIFI_MODE_FULL_HIGH_PERF` on older releases) and a `PowerManager.WakeLock`
+(`PARTIAL_WAKE_LOCK`) for the duration of each active transfer. Release both when the
+last concurrent transfer finishes.
 
 **Anti-pattern:** holding the locks for the entire FGS lifetime keeps the radio and CPU
 active even when no transfer is running, draining the battery with no user benefit.


### PR DESCRIPTION
## Summary

Closes #150. Refcounted `WifiLock(HIGH_PERF)` + `PARTIAL_WAKE_LOCK` held only while at
least one FileServer upload or FileClient send is in flight. Locks live in
`AndroidTransferLockHolder` (androidMain); orchestration in
`DefaultTransferActivityTracker` (commonMain) with lock-free `AtomicReference<State>`
CAS so that `releaseAll()` from `onDestroy` cannot race with `withActiveTransfer`.

## Files

- common: `TransferActivityTracker` + `DefaultTransferActivityTracker`
- common: `FileServerRoutes`, `FileClient` wrap their bodies in `withActiveTransfer`
- android: `AndroidTransferLockHolder` (WifiLock + WakeLock), wired via `AndroidAppContainer`
- android: `TetherForegroundService.onDestroy` calls `tracker.releaseAll()`
- manifest: `WAKE_LOCK` + `ACCESS_WIFI_STATE`
- tests: tracker unit tests (race + exception + parallel + idempotency), Robolectric
  lock-holder, FGS onDestroy verification, FileServer tracker-integration

## AC

- [x] WifiLock(`HIGH_PERF`) acquired only during active transfer
- [x] PARTIAL_WAKE_LOCK acquired only during active transfer
- [x] Refcount correct for parallel transfers
- [x] Release on success / cancel / error / onDestroy
- [x] `WAKE_LOCK` permission in manifest
- [x] `./gradlew :composeApp:assembleDebug -q` green
- [x] `./gradlew :composeApp:testDebugUnitTest -q` green
- [ ] Manual ≥500 MB send at locked screen — **operator verification**
- [x] `docs/knowledge/android-fgs.md` extended

## Known limitation

On API 29+ Android silently substitutes `WIFI_MODE_FULL_HIGH_PERF` with
`WIFI_MODE_FULL_LOW_LATENCY`, which only activates while the screen is on and the app
is foregrounded. The WifiLock therefore no-ops on Android 10+; only `PARTIAL_WAKE_LOCK`
is effective. WakeLock alone covers CPU-side Doze throttling, which is the dominant
failure mode per peer-project evidence (Syncthing, KDE Connect, LocalSend). The
remaining Wi-Fi-radio gap on API 29+ is tracked in #164 (per-socket TCP keepalive).
Documented in `docs/knowledge/android-fgs.md`.

## Smoke

🟢 Desktop CLI sanity (`/health`, `/pair` shape, mDNS publish/browse, stdin commands,
`send` roundtrip), real-device send Desktop → Android (CPH2653 over Wi-Fi) at 288 ms,
`compileKotlinMacosArm64` + `compileKotlinIosSimulatorArm64` green. `./gradlew allTests`
green locally.

## Test plan

- [x] `./gradlew allTests -q`
- [x] Real-device receive via smoke
- [ ] Operator: ≥500 MB transfer with screen locked on Android 10+

🤖 Generated with [Claude Code](https://claude.com/claude-code)
