### PR TITLE
retro from #160: tighten review agents on test-API drift and reachability

### DIFF
--- a/.claude/agents/review-correctness.md
+++ b/.claude/agents/review-correctness.md
@@ -61,10 +61,6 @@ If PR_TYPE is BUGFIX: does the fix address the **root cause** or only the sympto
 - Style / idioms → review-guides
 - Platform-specific quirks → review-platform
 
-## Reachability claims — verify against the diff
-
-Before claiming a branch is unreachable, dead, or covered/uncovered, trace it through the actual code and tests in the diff. Cite the file:line you checked. LLM-default abstract reasoning misjudges reachability often enough that unsupported claims are a recurrent false-positive class.
-
 ## Output
 
 ```

--- a/.claude/agents/review-correctness.md
+++ b/.claude/agents/review-correctness.md
@@ -61,6 +61,10 @@ If PR_TYPE is BUGFIX: does the fix address the **root cause** or only the sympto
 - Style / idioms → review-guides
 - Platform-specific quirks → review-platform
 
+## Reachability claims — verify against the diff
+
+Before claiming a branch is unreachable, dead, or covered/uncovered, trace it through the actual code and tests in the diff. Cite the file:line you checked. LLM-default abstract reasoning misjudges reachability often enough that unsupported claims are a recurrent false-positive class.
+
 ## Output
 
 ```

--- a/.claude/agents/review-guides.md
+++ b/.claude/agents/review-guides.md
@@ -32,7 +32,7 @@ Always read `CLAUDE.md`. Then read the engineering doc that maps to the diff:
 3. **Layering** — presentation does not import data, data does not import presentation, etc. Read `architecture-principles.md` for the actual layer names.
 4. **Comment style** — comments only where code cannot express intent. Flag narrative comments restating method names; flag KDoc that repeats the signature.
 5. **Commit naming** — every commit message starts with `#<issue>: `. Run `gh pr view <PR> --json commits --jq '.commits[].messageHeadline'`.
-6. **Idioms** — Kotlin official style is enforced by KtLint (do not flag style); flag non-idiomatic patterns: `!!` where nullable handling is expected, manual loops where `map`/`filter` fits, `runBlocking` in non-test code.
+6. **Idioms** — Kotlin official style is enforced by KtLint (do not flag style); flag non-idiomatic patterns: `!!` where nullable handling is expected, manual loops where `map`/`filter` fits, `runBlocking` anywhere (production: refactor to `suspend`; tests: `runTest` + `TestDispatcher` per `testing.md§Стиль`). For tests, `review-tests` owns the detailed check — surface here only if `review-tests` is out of scope (DOCS/INFRA PR).
 7. **Doc-vs-code drift** — if PR changes an architectural pattern documented in `docs/engineering/`, the doc must be updated in the same PR (especially "doc-as-spec" for first real implementation of a skeleton).
 
 ## What you do NOT check

--- a/.claude/agents/review-guides.md
+++ b/.claude/agents/review-guides.md
@@ -32,7 +32,7 @@ Always read `CLAUDE.md`. Then read the engineering doc that maps to the diff:
 3. **Layering** — presentation does not import data, data does not import presentation, etc. Read `architecture-principles.md` for the actual layer names.
 4. **Comment style** — comments only where code cannot express intent. Flag narrative comments restating method names; flag KDoc that repeats the signature.
 5. **Commit naming** — every commit message starts with `#<issue>: `. Run `gh pr view <PR> --json commits --jq '.commits[].messageHeadline'`.
-6. **Idioms** — Kotlin official style is enforced by KtLint (do not flag style); flag non-idiomatic patterns: `!!` where nullable handling is expected, manual loops where `map`/`filter` fits, `runBlocking` anywhere (production: refactor to `suspend`; tests: `runTest` + `TestDispatcher` per `testing.md§Стиль`). For tests, `review-tests` owns the detailed check — surface here only if `review-tests` is out of scope (DOCS/INFRA PR).
+6. **Idioms** — Kotlin official style is enforced by KtLint (do not flag style); flag non-idiomatic patterns: `!!` where nullable handling is expected, manual loops where `map`/`filter` fits, `runBlocking` anywhere (production: refactor to `suspend`; tests: `runTest` + `TestDispatcher` per `testing.md`).
 7. **Doc-vs-code drift** — if PR changes an architectural pattern documented in `docs/engineering/`, the doc must be updated in the same PR (especially "doc-as-spec" for first real implementation of a skeleton).
 
 ## What you do NOT check

--- a/.claude/agents/review-tests.md
+++ b/.claude/agents/review-tests.md
@@ -57,6 +57,16 @@ A test that skips itself on the platform/configuration where the bug lives is un
 
 Default fix for a CI-red test is in the code. Flag as `[REQUIRED]` any PR change that deletes a failing test, rewrites it into a narrower fast-check, or weakens assertions/timeouts/inputs to make it pass. Exception: the test was demonstrably wrong — must be stated explicitly in the PR.
 
+### 7. Coroutine test API — `runTest` + `TestDispatcher`, not `runBlocking`
+
+Per `testing.md§Стиль`: coroutine tests use `runTest` + `TestDispatcher`, not `runBlocking`. Flag `runBlocking` in any new or modified test as `[REQUIRED]`. The only legitimate exception per `testing.md§Реальное время vs виртуальное` is waiting on events from external native APIs running on real threads outside the test's `CoroutineScope` (JmDNS, NsdManager, real Ktor server engine) — and even then the test must explain in a comment WHY virtual time cannot substitute.
+
+"Pre-existing file-wide convention" is NOT a valid excuse. A documented rule violation is drift, not convention; flag it as `[REQUIRED]` even if the orchestrator's prompt pre-classifies it as out of scope. The PR either fixes the drift in this PR or files a tracked follow-up before merge.
+
+### 8. Reachability claims — verify against the diff
+
+Before claiming a code branch is unreachable, dead, or untested — trace it through the tests that exist in the diff (not just the ones you imagine). A `[REQUIRED]` finding of "branch X has no test" must cite which existing tests you checked and how the branch escaped them. Do not assume reachability from abstract reasoning; LLM-default plausibility is wrong often enough that this is a recurrent class of false-positive review.
+
 ## What you do NOT check
 
 - AC coverage → review-dod


### PR DESCRIPTION
## Summary

Two systemic gaps surfaced in PR #160 reviews:

1. **review-guides / review-tests let \`runBlocking\` in tests slip through** as "pre-existing file-wide convention, out of scope" — though \`testing.md§Стиль\` explicitly requires \`runTest\` + \`TestDispatcher\`. The orchestrator's prompt pre-classified it as out-of-scope and agents accepted that classification, requiring the project owner to flag it manually via PR comments.

2. **review-correctness and review-tests claimed branches were unreachable/uncovered** without tracing the actual tests in the diff. Reviewer in iter5 said \`source.closedCause\` branch was unreachable; it was reachable and covered by an existing test in the same diff. LLM-default plausibility-reasoning is the recurrent failure mode here.

## Changes

- \`.claude/agents/review-tests.md\` — new section 7 ("Coroutine test API: runTest + TestDispatcher, not runBlocking"). \`runBlocking\` in tests is \`[REQUIRED]\`; "pre-existing convention" is drift, not excuse; orchestrator's out-of-scope pre-classification doesn't override documented rules. New section 8 ("Reachability claims — verify against the diff").
- \`.claude/agents/review-guides.md\` — line 35 update: \`runBlocking\` flagged anywhere with test-side path delegated to review-tests.
- \`.claude/agents/review-correctness.md\` — adds the same "Reachability claims" rule.

## Test plan

- [ ] Next BUGFIX/REFACTOR PR with new tests should now have review-tests catch any \`runBlocking\` outside the testing.md exception clause.
- [ ] Next adversarial-style review where an agent claims "branch X is unreachable" should cite file:line traced through the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)