### PR TITLE
#170: design hotspot-first layered discovery

### DIFF
--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -10,6 +10,7 @@ Product-side docs (vision, audience, features) live in [`docs/product/`](../prod
 - [Modules](modules.md) — current monolith, target module split, and the triggers that move a piece of code into its own module.
 - [Dependency Injection](dependency-injection.md) — DI strategy now (manual composition root) and later (Metro). Concrete rules for new code.
 - [Presentation Layer](presentation-layer.md) — Decompose-based components; how to write them, subscribe from Compose, and test.
+- [Peer Discovery](discovery.md) — layered model (mDNS + rendezvous + HTTP-scan + UDP-broadcast + manual entry), contracts, identity, liveness.
 - [UI Style Guide](ui-style-guide.md) — token tables, `TetherTheme` rule, Tabler Icons usage, motion specs, accessibility checklist.
 - [UI Brand Mark](ui-brand-mark.md) — `•—•` geometry, animation states, where the mark appears, and design rationale (why a line, not a knot or arrow).
 - [Testing](testing.md) — структура тестов по source sets, стиль (`runTest`/виртуальное время), особенности Apple-таргетов.
@@ -32,4 +33,5 @@ ADRs in [`adr/`](adr/) capture the *why* behind one-time architectural choices. 
 - [Network stack](adr/adr-network-stack.md) — chose Ktor CIO across all targets tactically; engine swaps under TLS forced upstream. Living-doc сторона — [`transport.md`](transport.md).
 - [Apple FileServer engine](adr/adr-apple-fileserver-engine.md) — chose Ktor CIO Native over hand-rolled HTTP for the Apple-side `FileServer.actual`.
 - [Channel encryption](adr/adr-channel-encryption.md) — chose TLS-with-paired-key-pinning + SecureTransport on Apple. Includes 2026-05-16 Amendment with implementation-plan corrections.
+- [Hotspot-first Discovery](adr/adr-hotspot-discovery.md) — chose layered mDNS + `/hello` rendezvous + HTTP-subnet-scan + UDP-broadcast over raw-multicast-as-primary or Wi-Fi Direct / NAN. Motivated primarily by phone-hotspot transfer.
 

--- a/docs/engineering/adr/adr-hotspot-discovery.md
+++ b/docs/engineering/adr/adr-hotspot-discovery.md
@@ -1,0 +1,96 @@
+# Hotspot-first discovery — layered mDNS + rendezvous + HTTP-scan + UDP-broadcast
+
+**Status:** Accepted — 2026-05-17
+**Issue:** [#170](https://github.com/khmelevartem/tether/issues/170)
+
+## Context
+
+The motivating scenario is **transfer over one device's Wi-Fi hotspot**: a user wants to send a file to someone who has no shared Wi-Fi available, so one of them turns on their phone's hotspot and the other connects to it. This is the dominant mobile-first case — a phone in the AP role is more common in practice than two devices joined to the same home Wi-Fi. The corresponding product feature is [`features/hotspot-transfer/spec.md`](../../product/features/hotspot-transfer/spec.md).
+
+[docs/product/tech-stack.md](../../product/tech-stack.md) commits Tether to mDNS for peer discovery. mDNS works on the hotspot's L3 segment (host and clients share a subnet — the AP's own `192.168.x.0/24`). It does **not** work reliably out of the box because the AP interface is not the device's default route, and naive mDNS bindings miss it:
+
+- **Android-as-host (worst sub-case).** `NsdManager` binds to the system-default network and does not reliably announce or browse on the tether interface (`ap0`/`wlan1`). This is the case LocalSend has not solved either — see [their #270](https://github.com/localsend/localsend/issues/270).
+- **Desktop-as-host.** JmDNS by default binds to the OS-default interface, not the AP interface created by Windows Mobile Hotspot / macOS Internet Sharing / `hostapd`.
+- **iPhone-as-host (Personal Hotspot).** Bonjour publishes across interfaces and is usually fine, but needs verification on `bridge100`.
+
+Two adjacent scenarios fall out of the same root design naturally, and we want them covered while we are in the area:
+
+- **Multicast-blocked networks.** Guest Wi-Fi, captive portals, and enterprise APs with client isolation drop mDNS multicast outright. Not the dominant case for Tether's audience but a real one.
+- **Asymmetric visibility.** One side sees the other but not vice versa — common during hotspot rollouts where mDNS responses propagate one direction but not the other.
+
+Current mDNS-only discovery handles none of these.
+
+## Decision drivers
+
+| Criterion | mDNS only (today) | Raw UDP multicast as primary (LocalSend) | mDNS + rendezvous endpoint | mDNS + HTTP-subnet-scan | mDNS + UDP-broadcast | Wi-Fi Direct / NAN |
+|---|---|---|---|---|---|---|
+| Home Wi-Fi (baseline) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Hotspot, Desktop host | ⚠️ default-iface bug | ✅ | ✅ if either direction sees | ✅ | ✅ | ✅ |
+| Hotspot, Android host | ❌ NSD on tether iface | ✅ if iface enumerated | ✅ if either direction sees | ✅ | ✅ | ✅ |
+| Multicast-blocked LAN | ❌ | ❌ | ❌ alone | ✅ | ⚠️ broadcast often also blocked | ❌ different transport |
+| Asymmetric visibility | ❌ | ❌ alone | ✅ symmetrizes for free | ✅ | ✅ | n/a |
+| Cross-platform parity | ✅ | ✅ | ✅ | ✅ | ⚠️ iOS needs multicast entitlement | ❌ **no Apple public API** |
+| New permissions required | minimal | multicast | none beyond mDNS | none | multicast/broadcast entitlement on iOS | major (Android 13+ `NEARBY_WIFI_DEVICES`, Android-only) |
+| Trust surface increase | baseline | same | same — pairing remains gate | same — pairing remains gate | same | new transport surface |
+| Implementation complexity | already shipped | replace mDNS code paths entirely | one HTTP endpoint + one client trigger | one HTTP scan worker | one UDP listener + sender | platform-specific (Android only) |
+
+## Decision
+
+**Layered discovery.** mDNS remains the primary mechanism. Three additional layers stack on top, each closing a class of failures the previous layer cannot:
+
+| Layer | Mechanism | Closes |
+|---|---|---|
+| 1 | mDNS (NSD / JmDNS / NSNetService) with multi-interface bind on the host side | Home Wi-Fi, hotspot when default-interface bind happens to work |
+| 2 | `POST /hello` rendezvous endpoint — when one side learns of another (through any layer), it POSTs its own `InfoDto` to that peer | Asymmetric visibility; gives both sides the same peer list from a single one-way contact |
+| 3a | HTTP-subnet-scan fallback — when no peers learned for *N* seconds, POST `/hello` to every reachable host on each connected subnet | Multicast-blocked networks where unicast TCP is permitted |
+| 3b | UDP-broadcast fallback — limited broadcast `255.255.255.255:<port>` carrying the same `InfoDto` payload | Networks where broadcast survives but multicast does not |
+| 4 | Manual IP entry + recent peers list | Universal escape hatch — any failure mode, including ones we have not anticipated |
+
+Layer 3a and 3b run independently and complementarily; they are not redundant — they cover different filtering behaviours seen in real APs. Order and concurrency of activation is an engineering detail captured in [docs/engineering/discovery.md](../discovery.md).
+
+The `/hello` payload follows the field shape of LocalSend's [`POST /api/localsend/v2/register`](https://github.com/localsend/protocol) — `alias`, `fingerprint`, `port`, `deviceType`, `version`. This costs nothing now and leaves the door open to future interop without committing to it.
+
+## Considered and rejected
+
+### Raw UDP multicast as primary (drop mDNS)
+
+LocalSend's design: send a UDP packet to a fixed multicast group (`224.0.0.167:53317`) with the device info, listeners reply over HTTP. mDNS is only declared on Apple to satisfy iOS Local Network permission gating.
+
+Rejected for Tether because mDNS already works in our codebase, ships under standard OS APIs (`NsdManager`, `NSNetService`) with no fixed group choice that could conflict with other apps, and is the natural primary mechanism for the home-Wi-Fi case which still dominates. Replacing it would be a large rewrite for marginal gain over adding the rendezvous endpoint on top.
+
+### Wi-Fi Direct / Wi-Fi Aware (NAN)
+
+Wi-Fi Alliance peer-to-peer standards. Could enable discovery and transfer with no shared Wi-Fi at all (truly offline, no router, no hotspot).
+
+Rejected as a primary mechanism: **Apple exposes no public API for either on iOS or macOS.** Using them would break cross-platform parity, which is a product principle ([vision.md](../../product/vision.md)). On Android they would work but produce an Android-only feature surface — an asymmetric capability inconsistent with Tether's promise. Recorded as a Pro-tier hypothesis (Android↔Android offline mode) in [monetization.md](../../product/monetization.md), not a discovery-layer choice.
+
+### Manual entry only (no automatic fallback)
+
+Cheap and universal. Rejected because Tether's audience ([audience.md](../../product/audience.md)) cannot be expected to type IP addresses. Manual entry is an escape hatch for failure cases, not a primary discovery path.
+
+### Drop the symmetry — designate one side as initiator
+
+Wired into LocalSend's API split (upload mode vs download mode). Rejected: the symmetry decision in [tech-stack.md](../../product/tech-stack.md#every-node-is-both-client-and-server) is load-bearing for the product.
+
+## Consequences
+
+**Positive**
+- Closes the hotspot scenario as a first-class user case through a single product spec ([hotspot-transfer/spec.md](../../product/features/hotspot-transfer/spec.md)) and a coherent engineering surface, with adjacent failure classes (multicast-blocked, asymmetric) covered by the same layers.
+- Layers degrade gracefully: home Wi-Fi continues to be served by mDNS alone; users in adverse networks pay a few seconds of fallback time but still succeed.
+- Android-hotspot-as-host — which LocalSend has not solved as of [their #270](https://github.com/localsend/localsend/issues/270) — becomes a Tether differentiator if Layer 1's host-side multi-interface bind work lands cleanly.
+- `/hello` contract leaves a low-cost path to LocalSend interop.
+
+**Negative**
+- Three additional code paths to maintain on the discovery surface (rendezvous endpoint, subnet-scan worker, UDP listener/sender). Each is small and shares the existing discovered-peers upsert path.
+- Identity in `/hello` cannot be a stable fingerprint until [#11 — Pairing UI](https://github.com/khmelevartem/tether/issues/11) lands the keypair flow. Interim identity is per-install random.
+- UDP-broadcast on iOS reuses the multicast network entitlement already required by mDNS — no new entitlement filing.
+- Android 13+ requires `NEARBY_WIFI_DEVICES` permission for host-side multi-interface mDNS work.
+
+**Neutral**
+- Trust model is unchanged. Any device on a reachable subnet could already announce itself over mDNS; subnet-scan and broadcast do not widen this surface. Pairing remains the trust gate before any file moves. See [security.md](../../product/security.md).
+
+## When to revisit
+
+- If we add a transport that does not require a shared L3 subnet (e.g. Bluetooth, Wi-Fi Aware as Pro Android↔Android), the layer model accommodates it as a new Layer with its own row in the table; the ADR remains valid.
+- If LocalSend interop becomes a stated goal, the `/hello` contract elevates from "field-shape compatible" to a versioned protocol commitment — that warrants its own ADR.
+- If a Layer 3 fallback proves dead weight in real-world telemetry (always wins or always loses), it can be retired with a small follow-up ADR rather than reopening this one.

--- a/docs/engineering/adr/adr-hotspot-discovery.md
+++ b/docs/engineering/adr/adr-hotspot-discovery.md
@@ -5,12 +5,12 @@
 
 ## Context
 
-The motivating scenario is **transfer over one device's Wi-Fi hotspot**: a user wants to send a file to someone who has no shared Wi-Fi available, so one of them turns on their phone's hotspot and the other connects to it. This is the dominant mobile-first case — a phone in the AP role is more common in practice than two devices joined to the same home Wi-Fi. The corresponding product feature is [`features/hotspot-transfer/spec.md`](../../product/features/hotspot-transfer/spec.md).
+The motivating scenario is **transfer over one device's Wi-Fi hotspot**: a user wants to send a file to someone who has no shared Wi-Fi available, so one of them turns on their phone's hotspot and the other connects to it. This is an important mobile-first case — not necessarily more frequent than two devices joined to the same home Wi-Fi, but covering the situations where a shared network simply does not exist (travel, no router, captive guest networks, anywhere two people meet without prior infrastructure). The corresponding product feature is [`features/hotspot-transfer/spec.md`](../../product/features/hotspot-transfer/spec.md).
 
 [docs/product/tech-stack.md](../../product/tech-stack.md) commits Tether to mDNS for peer discovery. mDNS works on the hotspot's L3 segment (host and clients share a subnet — the AP's own `192.168.x.0/24`). It does **not** work reliably out of the box because the AP interface is not the device's default route, and naive mDNS bindings miss it:
 
-- **Android-as-host (worst sub-case).** `NsdManager` binds to the system-default network and does not reliably announce or browse on the tether interface (`ap0`/`wlan1`). This is the case LocalSend has not solved either — see [their #270](https://github.com/localsend/localsend/issues/270).
-- **Desktop-as-host.** JmDNS by default binds to the OS-default interface, not the AP interface created by Windows Mobile Hotspot / macOS Internet Sharing / `hostapd`.
+- **Android-as-host (worst sub-case).** The platform's mDNS API binds to the system-default network and does not reliably announce or browse on the tether interface. This is the case LocalSend has not solved either — see [their #270](https://github.com/localsend/localsend/issues/270).
+- **Desktop-as-host.** The Java mDNS library binds to the OS-default interface by default, not the AP interface created by Windows Mobile Hotspot / macOS Internet Sharing / `hostapd`.
 - **iPhone-as-host (Personal Hotspot).** Bonjour publishes across interfaces and is usually fine, but needs verification on `bridge100`.
 
 Two adjacent scenarios fall out of the same root design naturally, and we want them covered while we are in the area:
@@ -30,7 +30,7 @@ Current mDNS-only discovery handles none of these.
 | Multicast-blocked LAN | ❌ | ❌ | ❌ alone | ✅ | ⚠️ broadcast often also blocked | ❌ different transport |
 | Asymmetric visibility | ❌ | ❌ alone | ✅ symmetrizes for free | ✅ | ✅ | n/a |
 | Cross-platform parity | ✅ | ✅ | ✅ | ✅ | ⚠️ iOS needs multicast entitlement | ❌ **no Apple public API** |
-| New permissions required | minimal | multicast | none beyond mDNS | none | multicast/broadcast entitlement on iOS | major (Android 13+ `NEARBY_WIFI_DEVICES`, Android-only) |
+| New permissions required | minimal | multicast | none beyond mDNS | none | multicast entitlement on iOS (already needed by mDNS) | major (Android-only Wi-Fi P2P/Aware grants) |
 | Trust surface increase | baseline | same | same — pairing remains gate | same — pairing remains gate | same | new transport surface |
 | Implementation complexity | already shipped | replace mDNS code paths entirely | one HTTP endpoint + one client trigger | one HTTP scan worker | one UDP listener + sender | platform-specific (Android only) |
 
@@ -44,7 +44,7 @@ Current mDNS-only discovery handles none of these.
 | 2 | `POST /hello` rendezvous endpoint — when one side learns of another (through any layer), it POSTs its own `InfoDto` to that peer | Asymmetric visibility; gives both sides the same peer list from a single one-way contact |
 | 3a | HTTP-subnet-scan fallback — when no peers learned for *N* seconds, POST `/hello` to every reachable host on each connected subnet | Multicast-blocked networks where unicast TCP is permitted |
 | 3b | UDP-broadcast fallback — limited broadcast `255.255.255.255:<port>` carrying the same `InfoDto` payload | Networks where broadcast survives but multicast does not |
-| 4 | Manual IP entry + recent peers list | Universal escape hatch — any failure mode, including ones we have not anticipated |
+| 4 | Out-of-band pairing — QR scan as primary, manual IP entry as fallback (for cases without a usable camera, typically two desktops) — plus a recent peers list of all paired devices | Universal escape hatch — any failure mode, including ones we have not anticipated |
 
 Layer 3a and 3b run independently and complementarily; they are not redundant — they cover different filtering behaviours seen in real APs. Order and concurrency of activation is an engineering detail captured in [docs/engineering/discovery.md](../discovery.md).
 
@@ -83,8 +83,7 @@ Wired into LocalSend's API split (upload mode vs download mode). Rejected: the s
 **Negative**
 - Three additional code paths to maintain on the discovery surface (rendezvous endpoint, subnet-scan worker, UDP listener/sender). Each is small and shares the existing discovered-peers upsert path.
 - Identity in `/hello` cannot be a stable fingerprint until [#11 — Pairing UI](https://github.com/khmelevartem/tether/issues/11) lands the keypair flow. Interim identity is per-install random.
-- UDP-broadcast on iOS reuses the multicast network entitlement already required by mDNS — no new entitlement filing.
-- Android 13+ requires `NEARBY_WIFI_DEVICES` permission for host-side multi-interface mDNS work.
+- Permissions surface on all platforms is unchanged from what mDNS already requires; final permission inventory and rationale flow live in [permissions/spec.md](../../product/features/system/permissions/spec.md).
 
 **Neutral**
 - Trust model is unchanged. Any device on a reachable subnet could already announce itself over mDNS; subnet-scan and broadcast do not widen this surface. Pairing remains the trust gate before any file moves. See [security.md](../../product/security.md).

--- a/docs/engineering/discovery.md
+++ b/docs/engineering/discovery.md
@@ -1,0 +1,185 @@
+# Peer Discovery
+
+How Tether nodes find each other on a local network. Captures the layered design committed to in [adr-hotspot-discovery.md](adr/adr-hotspot-discovery.md), which was driven primarily by the phone-hotspot transfer scenario (see [`features/hotspot-transfer/spec.md`](../product/features/hotspot-transfer/spec.md)).
+
+This is a living doc — it states what should be true of any correct implementation. Where the codebase has not yet caught up, treat the gap as an implementation issue, not a contradiction.
+
+## Goal
+
+From the user's standpoint: open Tether on two devices in the same physical place and see each other in the device list within a few seconds. The headline case is one phone sharing Wi-Fi and the other connected to it. The same design also covers two devices on the same home Wi-Fi, captive guest networks, and anything else that delivers a usable L3 path between the two.
+
+From the engineering standpoint: produce a `DiscoveredDevicesStore` consistent on both sides of a pair, in any scenario where at least one direction of L3 unicast works between them.
+
+## Layered model
+
+Discovery runs four layers stacked top to bottom by speed and reach. Each layer feeds the **same** `DiscoveredDevicesStore`. The store is the single source of truth the UI subscribes to.
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ Layer 1 — mDNS                                                       │
+│   Primary. Always running.                                           │
+│   Host side: multi-interface bind (incl. tether / AP interfaces).    │
+└─────────────────────────────────┬────────────────────────────────────┘
+                                  │ feeds
+┌─────────────────────────────────▼────────────────────────────────────┐
+│ Layer 2 — /hello rendezvous                                          │
+│   Triggered whenever any layer discovers a new peer.                 │
+│   Symmetrizes one-way visibility.                                    │
+└─────────────────────────────────┬────────────────────────────────────┘
+                                  │ feeds
+┌─────────────────────────────────▼────────────────────────────────────┐
+│ Layer 3 — fallback channels (started if store stays empty for N s)   │
+│   3a HTTP-subnet-scan: POST /hello to every reachable host.          │
+│   3b UDP-broadcast: limited broadcast carrying same InfoDto.         │
+│   Run concurrently; both may contribute.                             │
+└─────────────────────────────────┬────────────────────────────────────┘
+                                  │ feeds
+┌─────────────────────────────────▼────────────────────────────────────┐
+│ Layer 4 — Manual IP entry                                            │
+│   User-initiated. Stores entered host:port as a recent peer.         │
+│   Same code path as Layer 2 — POST /hello → store upsert.            │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+Layer 4 is product-level, not automatic; it appears here because it uses the same upsert path and shares contracts with the lower layers.
+
+## Layer 1 — mDNS
+
+Service type `_tether._tcp.`. Each device publishes its own service on the port the `FileServer` is bound to, and browses for the same type on every reachable interface.
+
+### Host-side multi-interface bind
+
+When a device acts as the network's access point — Android Wi-Fi hotspot, macOS Internet Sharing, Windows Mobile Hotspot, Linux `hostapd` — its **AP interface is not the system-default route**. A naive `JmDNS.create()` or `NsdManager.registerService` binds only to the default interface and misses the AP. The implementation enumerates non-loopback, non-link-local IPv4 interfaces and either runs an mDNS instance per interface (JmDNS) or, where the system API does not expose this control (Android `NsdManager`), substitutes a JmDNS-based implementation when the AP role is detected.
+
+Network changes (interface up/down, new IP on existing interface) re-trigger enumeration; stale instances are torn down and rebuilt.
+
+### Permissions
+
+- **Android 13+:** `NEARBY_WIFI_DEVICES` — required for discovery on AP interfaces without the location permission. Without it, JmDNS on `ap0`/`wlan1` silently fails to bind.
+- **Android:** `WifiManager.MulticastLock` held while the host-side AP-interface mDNS instance is active; released when discovery stops.
+- **iOS / macOS:** Local Network usage description; `_tether._tcp.` declared in `NSBonjourServices` in `Info.plist`.
+
+### Self-suppression
+
+mDNS announces propagate back to the announcing host. The implementation filters by the registered service name compared to the device's own name (matching the existing Android NSD pattern: track the *resolved* name returned by `onServiceRegistered`, since the OS may modify it). Once stable identity exists (see [Identity](#identity-and-self-suppression)), self-suppression migrates to the fingerprint.
+
+## Layer 2 — `POST /hello` rendezvous
+
+A single HTTP endpoint that lets one side tell another "here I am". The HTTP request itself is the announcement.
+
+### Endpoint
+
+```
+POST /hello
+Content-Type: application/json
+
+{
+  "alias":       string,           // user-visible device name
+  "fingerprint": string,           // see Identity below; interim placeholder allowed
+  "port":        integer,          // sender's FileServer port
+  "deviceType":  "mobile"|"desktop"|"web"|"headless"|"server",
+  "version":     integer           // protocol version, currently 1
+}
+```
+
+Response: `200 OK` on accepted upsert. Body content is reserved; current responders return an empty JSON object.
+
+The sender's IP is taken from the TCP connection's remote address — clients never include their own IP in the body. This keeps the contract behind NATs honest and matches LocalSend's `/api/localsend/v2/register` shape so future interop is a small, scoped change.
+
+### Trigger
+
+The HTTP client side fires `POST /hello` to every peer that newly appears in `DiscoveredDevicesStore` and which has not yet acknowledged us, where "acknowledged" means: we have observed that peer learn our address (visible in subsequent mDNS announces, or — pragmatically — we have ever received any HTTP request from them).
+
+The endpoint is idempotent; repeated calls upsert. Mis-firing is harmless. The cost of a redundant `/hello` is one HTTP round-trip on a LAN.
+
+### Receiver behaviour
+
+On receipt: build a `Device` from `(remoteAddress, body.port, body.alias, body.fingerprint)` and upsert into `DiscoveredDevicesStore`. The upsert path is identical to the one mDNS resolves into — entries are not tagged by discovery source.
+
+### Self-suppression
+
+Drop `POST /hello` whose `fingerprint` matches the device's own. Until stable fingerprints exist, drop by `(alias, remoteAddress, port)` matching the device's own announced tuple, with an explicit code-side TODO referencing [#11](https://github.com/khmelevartem/tether/issues/11).
+
+## Layer 3a — HTTP-subnet-scan fallback
+
+Activated when `DiscoveredDevicesStore` stays empty for a configurable window after Layers 1–2 are running (current default: small number of seconds; the exact value is implementation choice and lives in the implementation issue, not here).
+
+Enumerate every connected non-loopback IPv4 interface, compute its `/24` (or smaller) subnet from the interface's IP and netmask, and `POST /hello` to each reachable address on a small port set. The port set is whatever set of well-known Tether ports the implementation reserves; today the receive port is OS-assigned, so the scan port is the well-known UDP/TCP rendezvous port that Layer 3b also uses.
+
+Scan is bounded: one pass per fallback window, with concurrency capped to avoid flooding the LAN. Subsequent passes happen only after the store empties again or after a fresh user retry.
+
+### Why HTTP scan rather than rely on broadcast alone
+
+Some networks (corporate APs with client isolation, certain captive setups) drop broadcast and multicast but permit unicast TCP between clients in the same subnet. LocalSend documents this empirically; the choice carries over.
+
+## Layer 3b — UDP-broadcast fallback
+
+Listener bound on a reserved UDP port on every interface. Pings sent as limited broadcast (`255.255.255.255:<port>`) on each connected interface carry the same `InfoDto` payload as `/hello`.
+
+A host receiving a broadcast ping replies by `POST /hello` (Layer 2) over TCP to the sender — the UDP packet's purpose is purely to elicit the rendezvous; the rendezvous payload is the source of truth. This keeps state outside UDP entirely.
+
+### Why UDP-broadcast in addition to HTTP-scan
+
+Some networks do the opposite filtering — broadcast passes (it is part of normal DHCP behaviour, which APs almost universally allow) but unicast scans are throttled or blackholed by switching hardware. The two fallbacks are complementary, not redundant; running both makes us tolerant of either filtering style.
+
+### Apple platforms
+
+UDP listening on a fixed port requires the `multicastNetworkServiceType` entitlement on iOS and macOS — the same one already needed for mDNS. No additional entitlement work beyond what discovery already requires.
+
+## Layer 4 — Manual IP entry
+
+The user types a host (and optionally a port — defaulting to the well-known port) in a dedicated UI surface; the app issues `POST /hello` to that address and on success the resulting peer appears in the device list like any other.
+
+Successful manual entries are persisted as a **recent peers** list shown in the manual-entry UI for one-tap reconnect. The recent-peers list is local to one device and never synced anywhere.
+
+This is the universal escape hatch: any combination of failure modes Layers 1–3 cannot overcome, the user works around with a typed address.
+
+## Identity and self-suppression
+
+The `fingerprint` field in `/hello` and `InfoDto` carries a stable device identity. Its target is the EC P-256 public key fingerprint produced by [Pairing (#11)](https://github.com/khmelevartem/tether/issues/11) — the same identity used by [channel encryption](../product/security.md#channel-encryption) and pairing.
+
+Until pairing identity lands, the field carries a per-install random opaque string sufficient for self-suppression but not for trust. No code path treats it as authentication; trust gating remains pairing. The interim string is regenerated on app reinstall, matching the user-visible "reinstall produces a new identity" behaviour of pairing.
+
+This dependency is reflected as a `TODO` in the discovery implementation referencing [#11](https://github.com/khmelevartem/tether/issues/11). It is not reflected in this document beyond this section, because the *contract* of the `fingerprint` field does not change between interim and final identity — only the source.
+
+## Liveness and TTL
+
+mDNS provides `serviceLost` notifications (NSD, Bonjour); JmDNS surfaces equivalent events. mDNS-discovered peers are removed from the store when their announce times out.
+
+Peers learned via `/hello` or fallback channels do not have a built-in expiry. They are kept while the device has any reason to believe them present:
+
+- **Active reuse extends life.** A successful `GET /health` or any other request to the peer resets a lightweight last-seen timestamp.
+- **Idle expiry.** After a configurable idle window (no successful contact and no recent rediscovery via any layer), the peer is dropped from the store. The user can recover it by triggering rediscovery (any layer) or by selecting it from the recent-peers list (Layer 4).
+
+The idle window is intentionally generous — peers reappear cheaply, and stale entries are a smaller cost than flicker.
+
+## Trust
+
+Discovery is unauthenticated by design across every layer. Any device on a reachable subnet can announce itself over mDNS today; rendezvous, subnet-scan, and broadcast do not widen this surface — they only diversify how an announcement reaches us.
+
+Trust is established exclusively at [pairing](../product/security.md#pairing-flow) time, with the PIN comparison and SPKI-pinned TLS handshake that follow. No file moves between two devices until they have completed pairing. Discovery's job is to populate the device list; the list itself is not a trust claim.
+
+## Cross-layer concerns
+
+### Contracts that span all layers
+
+- `InfoDto` shape (`alias`, `fingerprint`, `port`, `deviceType`, `version`) is identical in `/hello` and in UDP-broadcast payloads. A single deserializer; layers do not see each other.
+- All layers feed `DiscoveredDevicesStore` via the same upsert path. Source of discovery is not stored.
+- All HTTP requests originating from discovery (`/hello` outgoing) use the existing `FileClient`-derived HTTP client. No new HTTP stack.
+
+### Cancellation and lifecycle
+
+Discovery is a single component started and stopped with the app. Inside, every layer is a coroutine (or set of coroutines) owned by a discovery-scope `CoroutineScope` cancelled on `stop()`. Layer 3 fallbacks observe `DiscoveredDevicesStore` and start themselves; nothing in the UI orchestrates them.
+
+### Source-set placement
+
+Per [modules.md](modules.md), discovery code lives in `commonMain` wherever possible. Concrete placement:
+
+- mDNS implementation has per-platform `actual`s (NSD, JmDNS, NSNetService) and stays as today.
+- `/hello` endpoint, client, subnet-scan worker, UDP broadcast listener/sender, manual-entry view model: `commonMain` over Ktor server / Ktor sockets, which now publish for every Tether target (see [adr-apple-fileserver-engine.md](adr/adr-apple-fileserver-engine.md)).
+
+## What this doc does *not* commit to
+
+- **Exact timing constants.** Fallback-activation window, idle-expiry window, scan concurrency. These are implementation choices and live in the implementation issue and code, not here.
+- **Exact port number for the rendezvous UDP/TCP fixed port.** A well-known port is chosen in the implementation issue; revisiting it is a small follow-up, not an ADR.
+- **Wire-protocol-level interop with LocalSend.** The `/hello` payload follows the LocalSend `/api/localsend/v2/register` shape, but is not declared compatible. Compatibility would warrant its own ADR.

--- a/docs/engineering/discovery.md
+++ b/docs/engineering/discovery.md
@@ -35,9 +35,9 @@ Discovery runs four layers stacked top to bottom by speed and reach. Each layer 
 └─────────────────────────────────┬────────────────────────────────────┘
                                   │ feeds
 ┌─────────────────────────────────▼────────────────────────────────────┐
-│ Layer 4 — Manual IP entry                                            │
-│   User-initiated. Stores entered host:port as a recent peer.         │
-│   Same code path as Layer 2 — POST /hello → store upsert.            │
+│ Layer 4 — Out-of-band pairing (QR scan + manual IP entry)            │
+│   User-initiated. QR primary; manual entry for camera-less cases.    │
+│   Same code path as Layer 2 — InfoDto → store upsert.                │
 └──────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -53,11 +53,14 @@ When a device acts as the network's access point — Android Wi-Fi hotspot, macO
 
 Network changes (interface up/down, new IP on existing interface) re-trigger enumeration; stale instances are torn down and rebuilt.
 
-### Permissions
+### Permissions and runtime locks
 
-- **Android 13+:** `NEARBY_WIFI_DEVICES` — required for discovery on AP interfaces without the location permission. Without it, JmDNS on `ap0`/`wlan1` silently fails to bind.
-- **Android:** `WifiManager.MulticastLock` held while the host-side AP-interface mDNS instance is active; released when discovery stops.
-- **iOS / macOS:** Local Network usage description; `_tether._tcp.` declared in `NSBonjourServices` in `Info.plist`.
+OS-mediated grants (manifest entries, Info.plist usage strings, runtime prompts) are owned by [`features/system/permissions/spec.md`](../product/features/system/permissions/spec.md). No new permission is introduced by host-side multi-interface mDNS — the existing mDNS grants cover it on every platform.
+
+Two runtime locks are worth calling out here because they are easy to forget in code review:
+
+- **Android `WifiManager.MulticastLock`** held while the host-side AP-interface mDNS instance is active; released when discovery stops. Without the lock, the OS filters out multicast packets to save battery.
+- **iOS multicast network entitlement** (already filed for mDNS) covers both inbound and outbound UDP-broadcast on the fallback path — see Layer 3b below; no separate entitlement is needed.
 
 ### Self-suppression
 
@@ -124,15 +127,31 @@ Some networks do the opposite filtering — broadcast passes (it is part of norm
 
 ### Apple platforms
 
-UDP listening on a fixed port requires the `multicastNetworkServiceType` entitlement on iOS and macOS — the same one already needed for mDNS. No additional entitlement work beyond what discovery already requires.
+UDP-broadcast reuses the multicast entitlement already covered for mDNS — see Layer 1's "Permissions and runtime locks" note above.
 
-## Layer 4 — Manual IP entry
+## Layer 4 — Out-of-band pairing (QR scan + manual IP entry)
 
-The user types a host (and optionally a port — defaulting to the well-known port) in a dedicated UI surface; the app issues `POST /hello` to that address and on success the resulting peer appears in the device list like any other.
+When automatic discovery fails, the user is offered a way to introduce the two devices without typing.
 
-Successful manual entries are persisted as a **recent peers** list shown in the manual-entry UI for one-tap reconnect. The recent-peers list is local to one device and never synced anywhere.
+### QR scan (primary)
 
-This is the universal escape hatch: any combination of failure modes Layers 1–3 cannot overcome, the user works around with a typed address.
+One device displays a QR code that encodes its own `InfoDto` (`alias`, `fingerprint`, `port`, `deviceType`, `version`) and host IP. The other scans it with the in-app scanner. The decoded payload is fed into the same upsert path as an inbound `POST /hello` — the resulting peer appears in the device list like any other, and the two sides exchange `/hello` immediately so both ends symmetrise.
+
+QR is the primary out-of-band path because it is unambiguous (no transcription errors), works across language and keyboard layouts, and is the same gesture a user already knows from Wi-Fi password sharing.
+
+### Manual IP entry (fallback for cases without a camera)
+
+The user types a host (and optionally a port — defaulting to the well-known port) in a dedicated surface; the app issues `POST /hello` to that address. The typical case is two desktops where neither has a convenient camera to scan the other's QR; less common but real, so manual entry stays first-class.
+
+### Recent peers
+
+A **recent peers** list surfaces previously paired devices for one-tap reconnect, regardless of how they were originally discovered (mDNS, rendezvous, fallback, QR, manual). All paired devices stay in this list; entries age out only on explicit user removal or when pairing is forgotten on either side. The list is local to one device and never synced anywhere.
+
+In the out-of-band entry UI, recent peers appear as a **secondary** section below the QR scanner and manual-entry field — the input is primary, the history is one tap away.
+
+### Why this is Layer 4
+
+Any combination of failure modes Layers 1–3 cannot overcome, the user works around with a scan or a typed address. This layer is the universal escape hatch.
 
 ## Identity and self-suppression
 

--- a/docs/product/features/README.md
+++ b/docs/product/features/README.md
@@ -34,6 +34,7 @@ Note on `Status` here vs. GitHub Issues: an issue can exist (and even be in prog
 | Feature | Area | Status | Doc | Issues |
 |---------|------|--------|-----|--------|
 | mDNS peer discovery | Discovery | done | _tbd_ | #6 (iOS/macOS) |
+| Hotspot transfer | Discovery / Transfer | scoped | [hotspot-transfer/spec.md](hotspot-transfer/spec.md) | [#170](https://github.com/khmelevartem/tether/issues/170) (design); implementation _tbd_ |
 | Pairing | Pairing / Security | scoped | [pairing/spec.md](pairing/spec.md) | #9 (key exchange), #10 (PIN + CLI), #11 (Android UI); iOS, Desktop UI _tbd_ |
 | Device list screen | UI | in progress | [device-list/spec.md](device-list/spec.md) | #7 — Android + iOS done; Desktop _tbd_ |
 | File transfer | Transfer / UI | scoped | [file-transfer/spec.md](file-transfer/spec.md) | #8 (Android send UI), #81 (iOS FileServer receive); iOS UI, Desktop send UI, receive-side UI _tbd_ |

--- a/docs/product/features/hotspot-transfer/spec.md
+++ b/docs/product/features/hotspot-transfer/spec.md
@@ -1,0 +1,73 @@
+# Hotspot transfer — sending files when one device shares Wi-Fi
+
+**Area:** Discovery / Transfer
+**Status:** `scoped`
+**GitHub Issues:** [#170](https://github.com/khmelevartem/tether/issues/170) (design); implementation issues to follow
+
+---
+
+## Why
+
+Tether's two-device exchange only works if both devices can reach each other over a local network. The most common case where this breaks is also the most common case where people *actually* need to move a file between two phones in person: there is no shared Wi-Fi available, so one of them turns on their phone's hotspot and the other connects to it. Apartment with no router. Hotel room with a captive portal on the lobby network. Friend's place where the Wi-Fi password has been long forgotten. A car. A park.
+
+Today the user's expectation in that moment is reasonable — *we are on the same Wi-Fi now, just send the file* — and Tether does not consistently meet it. The Wi-Fi is technically shared, but the discovery layer often fails to reach across the hotspot's tethering interface. The user ends up troubleshooting silence.
+
+This feature closes that. It is also the second meaningful proof point — after [pairing](../pairing/spec.md) — that Tether is honest about its "no cloud, no accounts, two taps" promise: the moment the underlying connectivity exists, Tether finds it and uses it, without asking the user to know what mDNS is.
+
+## What it does
+
+When two devices are on the same Wi-Fi connection — including the case where one of them is *providing* that Wi-Fi via a phone hotspot — they show up in each other's device list within a few seconds, and files transfer in either direction. The user does nothing different from the normal home-Wi-Fi case. No mode switch, no separate "hotspot mode" screen, no special permission they have to know to grant.
+
+If automatic discovery does not succeed within a short window — because of an OS quirk, an unusual hotspot configuration, or a network that drops the underlying broadcasts — the user can type the other device's IP address (which both phones expose in their own Wi-Fi / hotspot settings). The typed peer is remembered for next time so the user does not have to retype it on subsequent encounters.
+
+## User flows
+
+**Primary flow — phone shares Wi-Fi, the other phone connects**
+
+1. Anna wants to send a video to Boris. There is no shared Wi-Fi nearby.
+2. Boris turns on the personal hotspot on his phone; tells Anna the hotspot name and password.
+3. Anna joins Boris's hotspot from her phone's normal Wi-Fi settings.
+4. Both open Tether. Within a few seconds, each sees the other in the device list — the same device list, with the same row appearance, that they would see on home Wi-Fi.
+5. Anna taps Boris, picks the video, completes pairing (if this is their first encounter), and the file transfers.
+
+The roles are interchangeable. Boris can equally send to Anna over the same hotspot; nothing in the flow depends on who is the host.
+
+**Alternative paths**
+
+- **Discovery is slow at first.** If the device list is still empty after a few seconds, Tether quietly tries harder in the background — the user sees no visible change other than the peer appearing slightly later. No "searching…" spinner past the normal initial moment, no failure dialog unless we are confident discovery has truly failed.
+- **Discovery fails.** After a longer window with the list still empty, an unobtrusive affordance appears: *"Don't see the other device? Enter address manually."* Tapping it opens a small screen where the user types the other phone's IP address (and, optionally, a port — pre-filled with the right default). On the other side, the device shows its IP somewhere obvious. The IP is the same information already visible in the phone's own hotspot or Wi-Fi settings.
+- **Reconnecting later.** Manually-entered peers are remembered as a short list of recent addresses. Next time Anna joins Boris's hotspot, Boris is one tap away in the manual-entry screen — she does not retype.
+- **Hotspot is provided by a laptop or desktop instead of a phone.** Same flow. Tether does not care which device is acting as the AP.
+- **Two devices, both on a guest Wi-Fi that blocks peer-to-peer.** Same fallback: manual entry. Tether does not pretend to solve networks that genuinely block all peer-to-peer traffic.
+
+## What "working" looks like
+
+- Both Anna and Boris turn their phones on, Boris enables hotspot, Anna joins it, both open Tether. Within a few seconds, the other device is visible in the list on both phones. No troubleshooting, no permissions surprise mid-flow.
+- Files transfer in either direction at the speed the underlying Wi-Fi link allows. Receiving works whether the device is the hotspot host or a client.
+- If the user has to fall back to manual entry, the IP they type works, and they are not asked to type it again the next time they meet the same device.
+- The whole experience uses the same device-list screen, the same pairing dialog, the same transfer progress — there is no separate "hotspot UI". A user who has never been told about hotspot mode does not realise anything special happened.
+- Reinstalling Tether on one side, or rebooting either phone, does not change behaviour beyond what pairing already specifies (a reinstall is a fresh first-encounter).
+
+## Platform notes
+
+- **Android (host or client).** On first hotspot-host use, the user may see the standard system permission prompt for nearby Wi-Fi devices. The wording is the OS's; Tether does not add a custom explainer beyond what the permission rationale requires.
+- **iOS (host or client).** The Local Network permission prompt appears on first run as it already does for normal Wi-Fi discovery. iOS Personal Hotspot has a "Maximize Compatibility" toggle — Tether works in both modes; the user is not asked to flip it.
+- **macOS as host (Internet Sharing).** Supported. The user enables Internet Sharing from System Settings; Tether does not need to mention this — discovery picks up the shared interface like any other.
+- **Windows / Linux as host.** Supported through the standard OS hotspot facilities (Windows Mobile Hotspot, `nmcli` / `hostapd` on Linux). Same flow.
+- **iPhone as host with a single client.** Works without any special handling. iOS Bonjour publishes on the hotspot interface; nothing user-visible differs.
+
+## Not in this feature
+
+- **Transfer with no Wi-Fi at all** — no router *and* no hotspot. That would require a different transport (Wi-Fi Direct or Wi-Fi Aware), and Apple does not expose a public API for either; it is recorded as an Android-only Pro hypothesis in [monetization.md](../../monetization.md), not part of this feature.
+- **Sharing the hotspot password.** Tether does not help the user broadcast their hotspot SSID or password; that is the OS's job. Tether picks up only after the user has joined the network through the normal Wi-Fi UI.
+- **Cross-subnet discovery.** If the two devices are connected to the same logical network but through a routed boundary (corporate VLANs, mesh repeaters configured as separate subnets), Tether does not bridge that. Manual entry remains the user's escape hatch.
+- **Pairing changes.** Pairing is unchanged — first encounter still shows the 4-digit PIN, regardless of how the two devices found each other.
+- **Trust changes.** Discovery still does not imply trust; pairing remains the gate. See [security.md](../../security.md).
+
+## Open product questions
+
+- **Should the app surface that the device is currently sharing Wi-Fi?** A subtle indicator ("You're sharing Wi-Fi — other devices can find you here") could help the host understand why their phone is suddenly visible to a stranger's Tether install. Could equally be a noisy mode-indicator that nobody reads. Decide after first user observations.
+- **How loud should the fallback be?** When automatic discovery has clearly failed, do we surface "trying harder…" before offering manual entry, or do we stay silent until the manual-entry affordance appears? Quieter is friendlier but slower to discover by users who do not know to wait.
+- **Idle time before the manual-entry affordance appears.** Too short and the user sees it when discovery is still working; too long and they conclude the app is broken. A small number of seconds — exact value tuned after first usage.
+- **Prominence of the recent-peers list.** Should it be the first thing the user sees in manual entry (one tap, common case) or a secondary section below the input field (input first, history second)? The answer depends on how often manual entry is reused vs first-time.
+- **Reciprocal IP visibility.** When the user is about to type an IP, do we show their own IP on the same screen so they can dictate it to the other side? Probably yes; tracked here so the UI design accounts for it.

--- a/docs/product/features/hotspot-transfer/spec.md
+++ b/docs/product/features/hotspot-transfer/spec.md
@@ -34,27 +34,29 @@ The roles are interchangeable. Boris can equally send to Anna over the same hots
 
 **Alternative paths**
 
-- **Discovery is slow at first.** If the device list is still empty after a few seconds, Tether quietly tries harder in the background — the user sees no visible change other than the peer appearing slightly later. No "searching…" spinner past the normal initial moment, no failure dialog unless we are confident discovery has truly failed.
-- **Discovery fails.** After a longer window with the list still empty, an unobtrusive affordance appears: *"Don't see the other device? Enter address manually."* Tapping it opens a small screen where the user types the other phone's IP address (and, optionally, a port — pre-filled with the right default). On the other side, the device shows its IP somewhere obvious. The IP is the same information already visible in the phone's own hotspot or Wi-Fi settings.
-- **Reconnecting later.** Manually-entered peers are remembered as a short list of recent addresses. Next time Anna joins Boris's hotspot, Boris is one tap away in the manual-entry screen — she does not retype.
+- **Discovery is slow at first.** If the device list is still empty after a few seconds, Tether tries harder in the background, silently — no "searching…" spinner, no progress text. The peer just appears slightly later. The user sees no visible change unless and until we are confident automatic discovery has truly failed.
+- **Discovery fails.** After a longer window with the list still empty, an unobtrusive affordance appears: *"Don't see the other device? Scan a QR code."* Tapping it opens the in-app scanner; the other phone shows its QR from the same affordance. Scanning either side completes the introduction — the peer appears on both. The QR encodes the same information `/hello` carries, so once scanned the device is indistinguishable from any other peer in the list.
+- **Two desktops without a convenient camera.** The same affordance offers manual IP entry as a secondary option. The user types the other computer's IP (and, optionally, a port — pre-filled with the right default). Each device shows its own IP in the same surface so the value is easy to dictate. This is the only common case where typing is preferable to scanning.
+- **Reconnecting later.** Every device the user has ever paired with stays in a **recent peers** list, regardless of how it was originally discovered. Next time Anna joins Boris's hotspot, Boris is one tap away — she does not retype, does not rescan. The recent peers list is shown as a secondary section below the QR scanner and the manual-entry field — the primary action is "introduce a new device", the history is one tap away.
 - **Hotspot is provided by a laptop or desktop instead of a phone.** Same flow. Tether does not care which device is acting as the AP.
-- **Two devices, both on a guest Wi-Fi that blocks peer-to-peer.** Same fallback: manual entry. Tether does not pretend to solve networks that genuinely block all peer-to-peer traffic.
+- **Two devices, both on a guest Wi-Fi that blocks peer-to-peer.** Same fallbacks: QR scan or manual entry. Tether does not pretend to solve networks that genuinely block all peer-to-peer traffic.
 
 ## What "working" looks like
 
 - Both Anna and Boris turn their phones on, Boris enables hotspot, Anna joins it, both open Tether. Within a few seconds, the other device is visible in the list on both phones. No troubleshooting, no permissions surprise mid-flow.
 - Files transfer in either direction at the speed the underlying Wi-Fi link allows. Receiving works whether the device is the hotspot host or a client.
-- If the user has to fall back to manual entry, the IP they type works, and they are not asked to type it again the next time they meet the same device.
+- If the user has to fall back to QR scan or manual entry, the introduction succeeds, and they are not asked to repeat the scan or type the IP again the next time they meet the same device — it is already in recent peers.
 - The whole experience uses the same device-list screen, the same pairing dialog, the same transfer progress — there is no separate "hotspot UI". A user who has never been told about hotspot mode does not realise anything special happened.
 - Reinstalling Tether on one side, or rebooting either phone, does not change behaviour beyond what pairing already specifies (a reinstall is a fresh first-encounter).
 
 ## Platform notes
 
-- **Android (host or client).** On first hotspot-host use, the user may see the standard system permission prompt for nearby Wi-Fi devices. The wording is the OS's; Tether does not add a custom explainer beyond what the permission rationale requires.
-- **iOS (host or client).** The Local Network permission prompt appears on first run as it already does for normal Wi-Fi discovery. iOS Personal Hotspot has a "Maximize Compatibility" toggle — Tether works in both modes; the user is not asked to flip it.
-- **macOS as host (Internet Sharing).** Supported. The user enables Internet Sharing from System Settings; Tether does not need to mention this — discovery picks up the shared interface like any other.
-- **Windows / Linux as host.** Supported through the standard OS hotspot facilities (Windows Mobile Hotspot, `nmcli` / `hostapd` on Linux). Same flow.
-- **iPhone as host with a single client.** Works without any special handling. iOS Bonjour publishes on the hotspot interface; nothing user-visible differs.
+Hotspot transfer does not introduce platform permissions of its own — the OS prompts the user sees are the same ones described in [permissions/spec.md](../system/permissions/spec.md) for normal discovery. The cases where hotspot adds nothing user-visible beyond what already exists:
+
+- **iOS Personal Hotspot.** Works in both default and "Maximize Compatibility" modes; the user is not asked to flip the toggle.
+- **macOS as host.** Internet Sharing from System Settings; discovery picks up the shared interface like any other.
+- **Windows / Linux as host.** Windows Mobile Hotspot, `nmcli` / `hostapd` on Linux; same flow.
+- **iPhone as host.** No special handling; Bonjour publishes on the hotspot interface.
 
 ## Not in this feature
 
@@ -67,7 +69,5 @@ The roles are interchangeable. Boris can equally send to Anna over the same hots
 ## Open product questions
 
 - **Should the app surface that the device is currently sharing Wi-Fi?** A subtle indicator ("You're sharing Wi-Fi — other devices can find you here") could help the host understand why their phone is suddenly visible to a stranger's Tether install. Could equally be a noisy mode-indicator that nobody reads. Decide after first user observations.
-- **How loud should the fallback be?** When automatic discovery has clearly failed, do we surface "trying harder…" before offering manual entry, or do we stay silent until the manual-entry affordance appears? Quieter is friendlier but slower to discover by users who do not know to wait.
-- **Idle time before the manual-entry affordance appears.** Too short and the user sees it when discovery is still working; too long and they conclude the app is broken. A small number of seconds — exact value tuned after first usage.
-- **Prominence of the recent-peers list.** Should it be the first thing the user sees in manual entry (one tap, common case) or a secondary section below the input field (input first, history second)? The answer depends on how often manual entry is reused vs first-time.
-- **Reciprocal IP visibility.** When the user is about to type an IP, do we show their own IP on the same screen so they can dictate it to the other side? Probably yes; tracked here so the UI design accounts for it.
+- **Idle time before the out-of-band affordance appears.** Too short and the user sees it when discovery is still working; too long and they conclude the app is broken. A small number of seconds — exact value tuned after first usage.
+- **QR-only vs camera-less symmetry.** Tether shows the QR on each device's out-of-band screen so the other can scan it. For desktop users without a camera, do we always offer both QR (to be scanned by a phone) and manual entry (typed on the desktop), or pick one path per device class? Lean toward always-both for consistency, but worth observing.

--- a/docs/product/features/system/permissions/spec.md
+++ b/docs/product/features/system/permissions/spec.md
@@ -92,7 +92,7 @@ Runtime prompts only. Compile-time declarations are listed per platform below.
 
 **Not required.**
 
-- Local Network discovery — no runtime grant on currently supported API levels; the system mDNS API works under the multicast manifest declaration.
+- Local Network discovery — no runtime grant on currently supported API levels; the system mDNS API works under the multicast manifest declaration. The same `CHANGE_WIFI_MULTICAST_STATE` covers the host-side multi-interface mDNS path used when this Android device is sharing Wi-Fi as a hotspot (see [hotspot-transfer.md](../../hotspot-transfer/spec.md)); no additional grant is needed there.
 - File send — the system photo picker, the system file/folder picker, and the OS share sheet all return scoped per-file references without `READ_MEDIA_*` or `MANAGE_EXTERNAL_STORAGE`.
 - File save — Tether writes to public `Downloads/Tether/` via the OS-managed Downloads collection without `WRITE_EXTERNAL_STORAGE` (legacy, replaced by scoped storage on API 29+; Tether targets API 34+).
 
@@ -109,7 +109,7 @@ Runtime prompts only. Compile-time declarations are listed per platform below.
 
 - File send — the system Photos picker is privacy-preserving since iOS 14, no `NSPhotoLibraryUsageDescription`. The system Files picker and the OS share sheet add no runtime prompt.
 - File save — Tether writes only to its own app container (`On My iPhone → Tether/`); no Photos write (`NSPhotoLibraryAddUsageDescription`), no Files access outside the container.
-- Inbound and outbound TCP within the local network are gated by the Local Network grant alone.
+- Inbound and outbound TCP within the local network are gated by the Local Network grant alone. The same grant covers the UDP-broadcast and HTTP-subnet-scan fallbacks used in [hotspot-transfer.md](../../hotspot-transfer/spec.md); no separate prompt or entitlement is involved.
 
 ## macOS (native Compose target)
 

--- a/docs/product/monetization.md
+++ b/docs/product/monetization.md
@@ -27,6 +27,7 @@ These are *not* committed — they're the directions we'd explore first.
 |-----------|-------------------------|
 | **Folder sync** | A persistent, automated workflow. Power user need. Implementation cost is real (watching, conflict handling). |
 | **Multi-peer / group send** | Sending the same file to several devices at once. Useful for small offices, families with many devices. Convenience, not core. |
+| **Android↔Android offline transfer (Wi-Fi Direct / NAN)** | P2P fallback when no shared Wi-Fi exists at all — no router, no hotspot. Asymmetric by nature (Apple has no public API), so it's an extra mode on a subset of platforms rather than part of the core promise. |
 
 Anything else considered later passes the same test: *does removing it break the promise?* If yes — it stays free.
 

--- a/docs/product/monetization.md
+++ b/docs/product/monetization.md
@@ -28,8 +28,18 @@ These are *not* committed — they're the directions we'd explore first.
 | **Folder sync** | A persistent, automated workflow. Power user need. Implementation cost is real (watching, conflict handling). |
 | **Multi-peer / group send** | Sending the same file to several devices at once. Useful for small offices, families with many devices. Convenience, not core. |
 | **Android↔Android offline transfer (Wi-Fi Direct / NAN)** | P2P fallback when no shared Wi-Fi exists at all — no router, no hotspot. Asymmetric by nature (Apple has no public API), so it's an extra mode on a subset of platforms rather than part of the core promise. |
+| **Advanced discovery (Layers 3 + 4)** | The fallback layers in [hotspot-transfer/spec.md](features/hotspot-transfer/spec.md) — HTTP-subnet-scan, UDP-broadcast, QR scan, manual IP entry — kick in when standard mDNS does not reach. Architecturally cheap to gate by user status (each layer is app-initiated; see the slice diagram in [adr-hotspot-discovery.md](../engineering/adr/adr-hotspot-discovery.md)). Free tier keeps Layers 1–2: home Wi-Fi works, iPhone-as-host hotspot usually works. Paid unlocks the layers that close Android-as-host, multicast-blocked networks, and the manual escape hatch. |
 
 Anything else considered later passes the same test: *does removing it break the promise?* If yes — it stays free.
+
+### A note on the "advanced discovery" hypothesis
+
+The hotspot-transfer spec frames "send a file when there is no shared Wi-Fi" as an important case Tether *should* handle. Gating the most common shape of that case — Android phone sharing Wi-Fi — behind paid would partly contradict that framing. Two readings sit in tension here, neither obviously right:
+
+1. **Hotspot is core; paid is for elsewhere.** Keep all four discovery layers free. Paid features are workflow-level (folder sync, multi-peer), not connectivity-level. Cleaner with the "never restrict the core flow" principle.
+2. **Home / Apple-host hotspot is core; adverse cases are paid.** Free tier covers the scenarios that work *automatically* on a normal network. Paid covers the cases that need active probing (HTTP-scan, UDP-broadcast) and out-of-band rescue (QR, manual). Honest about engineering cost; risk of feeling arbitrary to users.
+
+This split needs a product decision before any pricing work starts. Recording the hypothesis here so the engineering option stays open; the call is not made.
 
 ## Principles
 

--- a/docs/product/security.md
+++ b/docs/product/security.md
@@ -16,6 +16,14 @@ Out of scope:
 - Malicious code on the user's own device.
 - Attacks on the underlying OS / Wi-Fi router.
 
+## Discovery and Trust
+
+Discovery is unauthenticated by design. Any device on a reachable subnet can announce itself — that is true today through mDNS and remains true through the additional discovery channels described in [tech-stack.md](tech-stack.md) and [`docs/engineering/discovery.md`](../engineering/discovery.md): the `/hello` rendezvous endpoint, HTTP-subnet-scan, and UDP-broadcast fallbacks. None of these widens the trust surface beyond what mDNS already exposes — they only diversify how a peer's existence reaches the device list. The list itself is not a trust claim.
+
+The trust gate is **pairing**. No file moves between two devices until they have completed the first-encounter PIN comparison and exchanged keys. Discovery's job is to make sure both devices see each other; pairing decides which of them they will accept files from.
+
+Manual IP entry has the same trust properties: it adds a peer to the device list, not to the trusted-devices store. The user still goes through pairing the first time they exchange a file with a manually-entered peer.
+
 ## Pairing Flow
 
 First-time connection between two devices:

--- a/docs/product/tech-stack.md
+++ b/docs/product/tech-stack.md
@@ -93,8 +93,7 @@ The engineering layout, contracts, and runtime behaviour live in [`docs/engineer
 
 - **Same L3 subnet required.** Discovery cannot cross routed boundaries without explicit configuration. A hotspot link counts as one subnet — host and clients can find each other; two devices on opposite sides of a router or a corporate VLAN cannot.
 - **Adverse networks degrade gracefully, not silently.** Guest Wi-Fi, captive portals, and client-isolated enterprise APs may drop multicast and/or broadcast. The layered discovery model (see above) routes around most of these; the user-visible failure mode and the manual-entry escape hatch are specified in [`features/hotspot-transfer/spec.md`](features/hotspot-transfer/spec.md).
-- **iOS Local Network permission.** Required for discovery (mDNS and UDP-broadcast both fall under it); user will see the system prompt on first run.
-- **Android `INTERNET` permission** and **`NEARBY_WIFI_DEVICES`** (Android 13+) for host-side multi-interface discovery, plus `WifiManager.MulticastLock` while host-side mDNS is active on the AP interface.
+- **Per-platform permissions** for discovery, notifications, file save, and inbound network — runtime prompts and manifest declarations live in [`features/system/permissions/spec.md`](features/system/permissions/spec.md), not duplicated here.
 - **macOS:** Apple Silicon only (`macosArm64`). Intel support (`macosX64()`) is cheap to add — one line in `kotlin { ... }`, plus a small permanent build/test/release tax (extra compile cycle, extra artifact in releases). Skipped now because the Intel Mac population among target users is small and shrinking; revisit when an actual user reports it.
 - **Java 21 (Temurin)** for Windows (JVM) and the build itself.
 - **Compose on macOS is experimental** — accepted; flagged in build configuration.

--- a/docs/product/tech-stack.md
+++ b/docs/product/tech-stack.md
@@ -35,58 +35,43 @@ For implementation-side guidance — module layout, layering principles, and DI 
 
 **Tradeoff:** historically Ktor's server modules were JVM-only. Since Ktor 3.0 (October 2024) `ktor-server-cio` is also published for Kotlin/Native (`iosArm64`, `iosSimulatorArm64`, `macosArm64`), and the project moved the server stack into `commonMain` accordingly — see [adr-network-stack.md](../engineering/adr/adr-network-stack.md) and [adr-apple-fileserver-engine.md](../engineering/adr/adr-apple-fileserver-engine.md). The "every node is server and client" symmetry now holds on every supported target.
 
-#### Options on the table
-
-1. **Per-platform server `actual` implementations.** Common `expect class FileServer` with platform-specific implementations:
-   - Desktop (Windows/Linux) + Android: Ktor CIO, shared via a `jvmMain` intermediate source set. Ktor CIO publishes an Android artifact and runs on ART — no separate library needed.
-   - iOS / macOS: GCDWebServer via cinterop, or build on top of Apple's `Network.framework`.
-
-   *Pros:* Ktor on four of five targets (only Apple needs a different implementation), one server codebase for the `jvmMain` family.
-   *Cons:* still two codebases for one role (`jvmMain` vs Apple Native), cinterop work for Apple targets.
-
-2. **Custom minimal HTTP server in `commonMain` over `kotlinx-io` / sockets.** Roll our own ~200-500-line HTTP server. We control exactly which features we use (we don't need most of HTTP).
-
-   *Pros:* one codebase for all platforms, no cinterop, no per-platform bugs.
-   *Cons:* writing HTTP is famously full of corner cases (chunked encoding, headers, keep-alive). Real risk of subtle interop bugs against curl / browsers / future tooling.
-
-3. **Wait for / track `ktor-server` Kotlin/Native.** The Ktor team has been working toward Native server support. If a stable release exists by the time we reach MVP, prefer it.
-
-   *Pros:* same codebase as JVM, leverages Ktor's correctness.
-   *Cons:* timing is out of our hands; cannot block MVP on it.
-
-4. **Drop the symmetry — one direction per pair.** E.g. "phone always sends, laptop always receives." Rejected: contradicts the "any device sends to any device" principle in [vision.md](vision.md).
-
-**Direction (chosen, implemented in #34/#35):** option 1 with the `jvmMain` intermediate source set. Ktor CIO server lives in `jvmMain` and is shared between Android and Desktop. Android hosts it inside a foreground `Service` so the peer stays reachable when the app is backgrounded. Apple targets still need their own `actual` — tracked as a follow-up. If Ktor Native server lands stable before we start the Apple side, option 3 becomes preferable for Apple targets.
-
-#### Source set layout (target state)
+#### Source set layout
 
 ```
-commonMain
-├── jvmMain      ← Ktor CIO server (Android + Desktop)
-│   ├── androidMain  ← NSD discovery
-│   └── desktopMain  ← JmDNS discovery, CLI (Windows + Linux)
-└── appleMain    ← NSNetService discovery, server actual (iOS + macOS Native)
+commonMain                      ← Ktor server dependencies (CIO, core, content-negotiation)
+├── jvmMain                     ← Ktor CIO server actual (Android + Desktop)
+│   ├── androidMain             ← NSD discovery
+│   └── desktopMain             ← JmDNS discovery, CLI (Windows + Linux)
+└── appleMain                   ← Ktor CIO Native server actual, NSNetService discovery (iOS + macOS)
     ├── iosMain
     └── macosMain
 ```
 
 Linux ships in `desktopMain` alongside Windows — same JVM target, same APIs. No separate Native target for Linux.
 
-### mDNS over BLE / Wi-Fi Direct / hand-typed addresses
+### Discovery — hotspot-first, layered around mDNS
 
-**Decision:** Discovery uses mDNS (Bonjour) on every platform.
+**Decision:** Discovery is built to make phone-hotspot transfer work as a first-class scenario, not an edge case. mDNS (Bonjour) is the primary mechanism on every platform; an HTTP rendezvous endpoint symmetrizes one-way visibility; HTTP-subnet-scan and UDP-broadcast act as complementary fallbacks for networks where multicast is dropped; manual IP entry is a universal escape hatch. The whole stack is designed so that "one phone shares Wi-Fi, the other connects to it" works without the user knowing what discovery is.
 
-**Why:** Works without pairing the underlying transport, requires no special permissions on most platforms, runs over the existing Wi-Fi the user is already on. BLE has range/throughput issues; Wi-Fi Direct is poorly supported across our targets; hand-typing IPs is a non-starter for the audience (see [audience.md](audience.md)).
+**Why mDNS as primary:** Works without pairing the underlying transport, requires no special permissions on most platforms, runs over the existing Wi-Fi the user is already on. It is the natural fit when both devices are on the same Wi-Fi.
 
-**Tradeoff:** Some networks block mDNS — guest Wi-Fi, enterprise APs with client isolation, certain captive portals. Acceptable: the primary scenario is home Wi-Fi, where mDNS works.
+**Why additional layers:** mDNS alone breaks the hotspot scenario because the AP interface (`ap0`/`wlan1`/`bridge100`/…) is not the device's default route, and naive mDNS bindings miss it. Android-as-host is the worst sub-case — `NsdManager` does not reliably reach the tether interface — and it is the most common real-world configuration. The same layers also cover networks that drop multicast (guest Wi-Fi, captive portals, client-isolated enterprise APs) and one-way visibility, but the hotspot driver is what motivates the design.
+
+**Why not the alternatives:**
+- BLE — range and throughput unfit for file transfer.
+- Wi-Fi Direct and Wi-Fi Aware (NAN) — Apple exposes no public API on iOS or macOS; using them would break platform parity (see [vision.md](vision.md)). Recorded as an Android-only Pro hypothesis in [monetization.md](monetization.md).
+- Hand-typed IPs as the only path — non-starter for the audience (see [audience.md](audience.md)). Acceptable as a fallback layer, not a primary one.
+- Raw UDP multicast on a fixed group as the primary discovery (LocalSend's approach) — would mean rewriting working code paths to replace, not extend, mDNS, for marginal gain over adding the rendezvous endpoint on top.
+
+**Tradeoff:** Three additional code paths beyond mDNS (rendezvous endpoint, subnet-scan worker, broadcast listener/sender). Each is small and shares `commonMain` plumbing. Identity in the rendezvous payload is interim (per-install random) until pairing identity ([#11](https://github.com/khmelevartem/tether/issues/11)) lands.
+
+The engineering layout, contracts, and runtime behaviour live in [`docs/engineering/discovery.md`](../engineering/discovery.md); the decision rationale and rejected alternatives in [`adr-hotspot-discovery.md`](../engineering/adr/adr-hotspot-discovery.md). The user-visible side — hotspot scenarios, troubleshooting, manual entry, recent peers — is its own feature spec at [`features/hotspot-transfer/spec.md`](features/hotspot-transfer/spec.md).
 
 ### Ktor for both server and client
 
 **Decision:** Use Ktor on both sides instead of mixing OkHttp / raw sockets / platform HTTP stacks.
 
-**Why:** One mental model, coroutine-native, multiplatform client. Streaming uploads/downloads are first-class.
-
-**Tradeoff:** Ktor server's JVM-only nature creates the asymmetry noted above.
+**Why:** One mental model, coroutine-native, multiplatform on both sides. Streaming uploads/downloads are first-class.
 
 ### Streaming transfers from day one
 
@@ -106,10 +91,10 @@ Linux ships in `desktopMain` alongside Windows — same JVM target, same APIs. N
 
 ## Constraints
 
-- **Same Wi-Fi network required.** mDNS doesn't cross subnets without explicit configuration.
-- **mDNS may be blocked** on guest networks, captive portals, and enterprise APs with client isolation. Tether should detect and explain, not silently fail.
-- **iOS Local Network permission.** Required for discovery to work; user will see the system prompt on first run.
-- **Android `INTERNET` and local-network permissions.** Standard, but worth being explicit.
+- **Same L3 subnet required.** Discovery cannot cross routed boundaries without explicit configuration. A hotspot link counts as one subnet — host and clients can find each other; two devices on opposite sides of a router or a corporate VLAN cannot.
+- **Adverse networks degrade gracefully, not silently.** Guest Wi-Fi, captive portals, and client-isolated enterprise APs may drop multicast and/or broadcast. The layered discovery model (see above) routes around most of these; the user-visible failure mode and the manual-entry escape hatch are specified in [`features/hotspot-transfer/spec.md`](features/hotspot-transfer/spec.md).
+- **iOS Local Network permission.** Required for discovery (mDNS and UDP-broadcast both fall under it); user will see the system prompt on first run.
+- **Android `INTERNET` permission** and **`NEARBY_WIFI_DEVICES`** (Android 13+) for host-side multi-interface discovery, plus `WifiManager.MulticastLock` while host-side mDNS is active on the AP interface.
 - **macOS:** Apple Silicon only (`macosArm64`). Intel support (`macosX64()`) is cheap to add — one line in `kotlin { ... }`, plus a small permanent build/test/release tax (extra compile cycle, extra artifact in releases). Skipped now because the Intel Mac population among target users is small and shrinking; revisit when an actual user reports it.
 - **Java 21 (Temurin)** for Windows (JVM) and the build itself.
 - **Compose on macOS is experimental** — accepted; flagged in build configuration.


### PR DESCRIPTION
## Summary

Design pass for [#170](https://github.com/khmelevartem/tether/issues/170) — closes the gate before implementation. No runtime code changed; this PR is the documentation set the implementation issues will execute against.

- New ADR [`adr-hotspot-discovery.md`](docs/engineering/adr/adr-hotspot-discovery.md): chose layered discovery (mDNS primary + `/hello` rendezvous + HTTP-subnet-scan + UDP-broadcast + manual entry) over raw-multicast-as-primary, Wi-Fi Direct/NAN, and manual-only. Driver is phone-hotspot transfer; multicast-blocked and asymmetric visibility fall out of the same design.
- New engineering living doc [`discovery.md`](docs/engineering/discovery.md): runtime picture of the layers, `/hello` contract (LocalSend-`InfoDto`-shape compatible), identity placeholder until pairing fingerprint ([#11](https://github.com/khmelevartem/tether/issues/11)) lands, TTL/liveness, multi-interface bind rules.
- New product spec [`features/hotspot-transfer/spec.md`](docs/product/features/hotspot-transfer/spec.md): user-facing flows, fallback to manual entry, platform notes, what "working" looks like.
- Corrections to long-lived docs uncovered during the design pass:
  - `tech-stack.md` — rewrite of the discovery section (now hotspot-first, layered), updated permissions in Constraints, Wi-Fi Direct/NAN rejection re-grounded in the Apple-no-public-API constraint instead of "poorly supported".
  - `security.md` — added "Discovery and Trust" subsection clarifying that the new channels don't widen the trust surface; pairing remains the gate.
  - `monetization.md` — recorded Android↔Android offline transfer (Wi-Fi Direct / NAN) as a Pro hypothesis.
- Indexes updated: `docs/engineering/README.md`, `docs/product/features/README.md`.

## Test plan

- [ ] Verify all internal links resolve (no `discovery-resilience` references remained).
- [ ] Cross-check the new ADR against the existing [`adr-network-stack.md`](docs/engineering/adr/adr-network-stack.md) and [`adr-apple-fileserver-engine.md`](docs/engineering/adr/adr-apple-fileserver-engine.md) — no contradictions.
- [ ] Read [`hotspot-transfer/spec.md`](docs/product/features/hotspot-transfer/spec.md) as a non-engineer; confirm no code names leak through.
- [ ] Confirm follow-up implementation issues can be opened against this design without needing prior context from the conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)