### PR TITLE
retro from #175: prime simplify wave with CLAUDE.md comment rules

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -141,7 +141,7 @@ After all tracks converge. Iterative fix cycles accumulate scaffolding (temp hel
 
 Dispatch the implementing agent once more:
 
-> All findings are resolved. Make one simplification pass over the diff: remove dead branches, inline single-use helpers, drop comments restating code, collapse trivial wrappers. Do not change behavior; do not touch anything outside the diff. Run `./gradlew allTests -q` after.
+> All findings are resolved. Make one simplification pass over the diff: remove dead branches, inline single-use helpers, collapse trivial wrappers. **For every comment / KDoc / prose paragraph in the diff — including `.claude/skills/**`, `docs/`, and Markdown — apply CLAUDE.md §Code style rules (lines 72-75) literally, not by personal taste.** Do not change behavior; do not touch anything outside the diff. Run `./gradlew allTests -q` after.
 
 If anything was simplified — re-run **the same set of agents that ran in Step 5 for this PR type** (i.e. dod + guides + correctness + tests + platform-if-touched + ux-if-touched + ui-if-touched) **plus `review-reuse`** on the simplified diff. `review-reuse` is critical here because duplication is what most likely accumulated across iterations and tracks. `review-platform`, `review-ux`, and `review-ui` follow the same skip rules as Step 5 (platform set touched / `composeApp/src/**` touched). If clean, proceed.
 


### PR DESCRIPTION
## Summary

Ретро по #174 / [#175](https://github.com/khmelevartem/tether/pull/175).

В первом simplify-проходе по комментариям в `smoke-test/SKILL.md` я применял персональные эвристики; пользователю пришлось редиректить на канон («найди гайды по комментам в проекте»). Step 6 в `/implement` говорил «drop comments restating code» — это лишь часть Rule 1 из CLAUDE.md §Code style; Rules 3 (правило-не-история) и 4 (runtime-снапшот → инвариант) не упоминались и применялись на интуицию.

Правка одна: в Step 6 simplify prompt вместо точечного перечисления — явная ссылка на CLAUDE.md:72-75 с указанием применять буквально, не по вкусу. Coder в simplify-проходе теперь сверяется с каноном по умолчанию.

## Test plan

- [ ] Следующий вызов `/implement` → Step 6 simplify wave прогоняется на diff'е с комментариями → правки соответствуют CLAUDE.md:72-75 без дополнительного редиректа от пользователя.

🤖 Generated with [Claude Code](https://claude.com/claude-code)