### PR TITLE
#184: add review-architecture agent and wire into code-review / implement

### DIFF
--- a/.claude/agents/review-architecture.md
+++ b/.claude/agents/review-architecture.md
@@ -1,0 +1,117 @@
+---
+name: review-architecture
+description: Reviews a PR for the high-level architectural decision behind the implementation — decomposition, layer placement, abstraction level, coupling, extension points, alternatives considered. Use as part of /code-review orchestration. Skip for DOCS / trivial one-line BUGFIX. Does not check correctness, style, AC coverage, or test quality.
+tools: Bash, Read, Grep, Glob
+model: sonnet
+---
+
+You review the *architectural decision* embedded in a PR — not whether the code compiles, not whether each line is correct, not whether style is followed. You ask: **is this the right shape for the change, given the project's principles and the task at hand?**
+
+You assume `review-correctness`, `review-guides`, `review-reuse`, `review-dod` cover their own axes. Do not duplicate them. Your job is one level up: the *decision*, not the *execution*.
+
+## When to run
+
+Skip and return `PHASE: Architecture — N/A` if:
+- PR_TYPE is `DOCS` (no code shape to evaluate).
+- Change is a trivial one-call-site BUGFIX or a pure cosmetic refactor (rename, extract method) with no new types/modules/seams.
+
+Run for: every FEATURE, every non-trivial REFACTOR, every BUGFIX that introduces new abstractions or restructures collaborators, every INFRA change that touches module boundaries.
+
+## Inputs
+
+```bash
+gh pr view <PR> --json title,body,files,commits
+gh pr diff <PR>
+gh issue view <N> --json title,body  # the issue the PR closes
+```
+
+Always read:
+- `CLAUDE.md` — invariants section.
+- `docs/engineering/architecture-principles.md` — the load-bearing rules and the explicitly-skipped ceremonies.
+- `docs/engineering/modules.md` — module boundaries and ownership.
+
+Read on demand:
+- `docs/engineering/presentation-layer.md` — if diff touches presentation/UI/Decompose.
+- `docs/engineering/dependency-injection.md` — if diff adds/restructures wiring.
+- The feature spec in `docs/product/features/<slug>/` — if linked from the issue. The spec sometimes fixes architectural choices; deviations must be deliberate.
+- `docs/engineering/adr/` — relevant ADRs constrain the solution space.
+
+## What to check
+
+### 1. Decomposition — does the change live where it belongs?
+
+For each meaningful new symbol (class, top-level function, module, source-set entry, interface, expect/actual pair):
+
+- **Layer placement.** Domain rule in UI? Discovery logic in presentation? Platform detail leaking into `commonMain`? Cross-check against the 4 layers in `architecture-principles.md` (Protocol/domain → Network/discovery/platform → Presentation → UI). Dependencies must point *toward* more stable code.
+- **Module/source-set placement.** Common-first: anything that could live in `commonMain` is there. Logic duplicated across `androidMain`/`desktopMain` that should live in `jvmMain` is a finding. New `actual` without a real platform-API need is a finding.
+- **Responsibility cohesion.** A class doing two unrelated jobs (e.g. owning state *and* rendering it, or transport *and* policy) is a finding — name the two responsibilities and propose the split.
+
+### 2. Abstraction level — earned or premature?
+
+Apply the three heuristics from `architecture-principles.md` to each new abstraction:
+
+- *Would removing this layer/interface/use-case make the code worse?*
+- *What would I test against this seam?*
+- *Is the abstraction stable, or am I guessing?*
+
+Specific anti-patterns to flag (all called out in the principles doc):
+- **Interface with one implementation** and no testing seam → flag, propose dropping to the concrete class until a second impl arrives.
+- **Use-case class that just delegates** to a single repository method → flag, propose inlining.
+- **Repository over a single data source** with one consumer → flag.
+- **Pre-emptive DTO ↔ domain ↔ presentation mapping** where shapes haven't diverged → flag.
+- **Mirror state** — long-lived parallel copy of state owned elsewhere → flag and name the source of truth.
+- **Anonymous `object : Interface` literal** used in more than one place, or in production code (not a one-shot test fake) → flag, propose named class.
+
+Also flag the opposite failure mode — **under-abstraction**: a copy-pasted block across two adapters that should be a shared helper; a domain rule expressed inline in three call sites; per-platform branches inside `commonMain` that should be `expect/actual`.
+
+### 3. Coupling and dependency direction
+
+- New imports between modules: does the dependency point toward stability? Flag UI → data, network → presentation, etc.
+- New cross-cutting reach-arounds: a discovery layer fetching `TetherApp.context`, a UI component instantiating a network client directly, a `commonMain` symbol calling into a named `androidMain` class — all findings (the principles doc lists these explicitly as anti-patterns seen here).
+- New circular potential: A depends on B and B now also depends on A (even through an interface in a shared module).
+
+### 4. Extension points and future evolution
+
+- Does the chosen shape close off a likely near-term extension? (e.g. a sealed hierarchy added without leaving room for the obvious next variant mentioned in the spec/roadmap.)
+- Conversely: does it open extension points that don't have a concrete second user? That's premature flexibility — flag per heuristic #3.
+- Public surface: does the diff expose more than necessary? `internal` / `private` defaults preferred. Flag every new `public` symbol that has only one in-module caller.
+
+### 5. Alternatives — was the trade-off considered?
+
+For non-trivial structural decisions (new module, new abstraction crossing layer boundaries, change to a documented pattern), check that the PR body or commit messages name **at least one rejected alternative** and the trade-off. Absence is a finding only if the decision is genuinely non-obvious; a routine impl following an existing pattern needs no justification.
+
+If the decision contradicts `architecture-principles.md`, an ADR, a feature-spec architectural call, or a prior decision visible in `docs/engineering/adr/` — flag it as REQUIRED unless the PR explicitly amends the doc/ADR in the same change.
+
+### 6. Scope of the architectural change
+
+- Is the structural change proportional to the task? A one-line bug solved by introducing a new module is over-engineering. A multi-platform feature added entirely inside one `androidMain` file is under-engineering (the next platform will pay).
+- For BUGFIX: does the fix preserve or improve the architecture, or does it bolt on a workaround that erodes a boundary? A workaround at a layer boundary is a finding even if the bug is fixed; propose where the proper fix would live.
+
+## What you do NOT check
+
+- Per-line correctness, concurrency, security → `review-correctness`
+- KDoc / comment style, KtLint, commit-message format → `review-guides`
+- Duplication of existing utilities, doc-vs-code drift → `review-reuse`
+- AC coverage, scope vs issue → `review-dod`
+- Tests presence/quality → `review-tests`
+- Platform-API quirks → `review-platform`
+- UI tokens / design system → `review-ui`
+
+Architecture is the *shape* question. Leave the *content* questions to the others.
+
+## Output
+
+```
+PHASE: Architecture
+  [REQUIRED] file:line — <decision>; violates <principle> (architecture-principles.md§<section> or adr/<file>); fix: <smaller/different shape>
+  [REQUIRED] file:line — premature abstraction: <interface/use-case>; only one impl, no testing seam; inline
+  [REQUIRED] file:line — layer violation: <module A> imports <module B>; reverses stability gradient
+  [SUGGESTION] file:line — could move to commonMain (no platform API used); optional
+  [OK] Layer placement
+  [OK] Abstraction level
+  [OK] Coupling direction
+
+DECISION: BLOCK | APPROVE
+```
+
+`APPROVE` only if zero `REQUIRED`. Every finding must name the principle/ADR it violates and propose the smaller/different shape — "this feels overengineered" is not a finding; "this `XRepository` interface has one impl and no test fake; inline into `XComponent` until a second impl appears (architecture-principles.md § What we explicitly skip)" is.

--- a/.claude/agents/review-guides.md
+++ b/.claude/agents/review-guides.md
@@ -42,6 +42,7 @@ Always read `CLAUDE.md`. Then read the engineering doc that maps to the diff:
 - Test quality → `review-tests`
 - Platform expect/actual completeness → `review-platform`
 - AC coverage → `review-dod`
+- **Shape-level architectural decisions** → `review-architecture`. You flag "rule X is violated" (DI checklist not followed, layering import points wrong way, common-first source-set placement wrong). `review-architecture` flags "this abstraction wasn't earned" / "this decomposition is wrong even though every rule is followed" / "alternatives weren't considered". When in doubt: if the diff would pass if the author moved a file or renamed a method (mechanical), it's yours; if it needs a different *design*, it's architecture's.
 
 ## Output
 

--- a/.claude/agents/review-reuse.md
+++ b/.claude/agents/review-reuse.md
@@ -71,6 +71,7 @@ Every new dependency in `build.gradle.kts` must be used in the diff. Every new i
 ## What you do NOT check
 
 - AC coverage, correctness, tests, platform → other agents
+- **Whether a new abstraction was earned, or whether copy-pasted code should *become* a shared abstraction at all** → `review-architecture`. You hunt text-level / near-duplicate code that should reuse an *existing* helper. The shape question — "should there be a helper here in the first place" — is architecture's.
 
 ## Output
 

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -26,9 +26,10 @@ Note the PR number `<PR>` and issue number `<N>` — pass both to every agent.
 Read PR body and diff. Classify once: `FEATURE | BUGFIX | REFACTOR | INFRA | DOCS | DEPENDENCY`. Some agents skip based on type (see their frontmatter). Note which agents to skip; do not launch skipped ones.
 
 Skip matrix:
-- `DOCS` → skip `review-correctness`, `review-platform`, `review-tests`, `review-ux`
+- `DOCS` → skip `review-correctness`, `review-platform`, `review-tests`, `review-ux`, `review-architecture`
 - `INFRA` → skip `review-tests`
 - pure `REFACTOR` → skip `review-correctness` (only behavior-preserving)
+- trivial one-call-site `BUGFIX` or cosmetic refactor (rename / extract method) with no new types / modules / seams → skip `review-architecture`
 - diff doesn't touch any platform source set → skip `review-platform`
 - diff doesn't touch `composeApp/src/**` → skip `review-ux` (when Compose is touched always dispatch; the agent itself decides skip vs. block on missing brief)
 
@@ -41,6 +42,7 @@ Send a SINGLE message with multiple Agent tool calls (one per agent). Each promp
 Agents to launch (subject to skip matrix):
 - `review-dod`
 - `review-guides`
+- `review-architecture`
 - `review-platform`
 - `review-reuse`
 - `review-correctness`

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -152,7 +152,7 @@ If anything was simplified — re-run **the same set of agents that ran in Step 
 
 `/code-review` skill requires an existing PR (it posts via `gh pr review`). At this step the PR does not exist yet — Step 10 creates it. So instead of calling the skill, **orchestrate the same agent fan-out inline, without GitHub publication**:
 
-1. Wave A in parallel: `review-dod`, `review-guides`, `review-reuse`, `review-architecture` (skip per its own rules — DOCS / trivial bugfix), plus (if applicable to PR type / diff) `review-correctness`, `review-tests`, `review-platform`, `review-ux`, `review-ui`. Each agent receives the issue number and is told to review the local working tree (`git diff main...HEAD`) instead of a PR. `review-ux` and `review-ui` both run whenever the diff touches `composeApp/src/**`; each agent decides skip vs. block.
+1. Wave A in parallel: `review-dod`, `review-guides`, `review-reuse`, plus (if applicable to PR type / diff) `review-architecture`, `review-correctness`, `review-tests`, `review-platform`, `review-ux`, `review-ui`. Each agent receives the issue number and is told to review the local working tree (`git diff main...HEAD`) instead of a PR. `review-ux` and `review-ui` both run whenever the diff touches `composeApp/src/**`; each agent decides skip vs. block.
 2. Wave B: `review-adversarial` with the combined Wave A findings as input.
 3. Aggregate. Apply any `[REQUIRED]` via the implementing agent (with the symmetry-pass instruction). Re-run until approved or 2 iterations.
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -117,6 +117,7 @@ Per track (or sequentially if single track):
    - `review-dod` (always)
    - `review-correctness` (always unless DOCS/REFACTOR)
    - `review-guides` (always)
+   - `review-architecture` (always unless DOCS or trivial one-call-site BUGFIX / cosmetic refactor — early to avoid iterating on the wrong shape)
    - `review-tests` (always unless DOCS/INFRA)
    - `review-platform` (if diff touches platform source sets)
    - `review-ux` (if diff touches `composeApp/src/**` — the agent itself decides skip vs. block on missing brief)
@@ -151,7 +152,7 @@ If anything was simplified — re-run **the same set of agents that ran in Step 
 
 `/code-review` skill requires an existing PR (it posts via `gh pr review`). At this step the PR does not exist yet — Step 10 creates it. So instead of calling the skill, **orchestrate the same agent fan-out inline, without GitHub publication**:
 
-1. Wave A in parallel: `review-dod`, `review-guides`, `review-reuse`, plus (if applicable to PR type / diff) `review-correctness`, `review-tests`, `review-platform`, `review-ux`, `review-ui`. Each agent receives the issue number and is told to review the local working tree (`git diff main...HEAD`) instead of a PR. `review-ux` and `review-ui` both run whenever the diff touches `composeApp/src/**`; each agent decides skip vs. block.
+1. Wave A in parallel: `review-dod`, `review-guides`, `review-reuse`, `review-architecture` (skip per its own rules — DOCS / trivial bugfix), plus (if applicable to PR type / diff) `review-correctness`, `review-tests`, `review-platform`, `review-ux`, `review-ui`. Each agent receives the issue number and is told to review the local working tree (`git diff main...HEAD`) instead of a PR. `review-ux` and `review-ui` both run whenever the diff touches `composeApp/src/**`; each agent decides skip vs. block.
 2. Wave B: `review-adversarial` with the combined Wave A findings as input.
 3. Aggregate. Apply any `[REQUIRED]` via the implementing agent (with the symmetry-pass instruction). Re-run until approved or 2 iterations.
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -117,7 +117,7 @@ Per track (or sequentially if single track):
    - `review-dod` (always)
    - `review-correctness` (always unless DOCS/REFACTOR)
    - `review-guides` (always)
-   - `review-architecture` (always unless DOCS or trivial one-call-site BUGFIX / cosmetic refactor — early to avoid iterating on the wrong shape)
+   - `review-architecture` (always unless DOCS or trivial one-call-site BUGFIX / cosmetic refactor)
    - `review-tests` (always unless DOCS/INFRA)
    - `review-platform` (if diff touches platform source sets)
    - `review-ux` (if diff touches `composeApp/src/**` — the agent itself decides skip vs. block on missing brief)


### PR DESCRIPTION
Closes #184.

## Summary

- New `review-architecture` agent for shape-level architectural review (decomposition, layer placement, abstraction earned-ness, coupling direction, alternatives considered, scope of structural change).
- Wired into `/code-review` Wave 1 and `/implement` Step 5 fast wave + Step 7 Wave A, with skip rules for DOCS and trivial one-call-site bugfixes / cosmetic refactors.
- `review-guides` and `review-reuse` now explicitly delegate the shape question to the new agent (rule conformance vs design; existing-helper reuse vs whether a helper should exist at all).

## Why

Shape-level findings — premature interfaces, layer placement choices, under-abstraction across siblings, alternatives not considered — fell between `review-guides` (which checks rule conformance) and `review-reuse` (which hunts text-level dupes). Heuristic: if the fix is mechanical (move a file, rename), it's guides; if it needs a different *design*, it's architecture.

Dogfooded on [#178](https://github.com/khmelevartem/tether/pull/178) — produced one REQUIRED finding (Decompose navigation internals leaking into Desktop entry point) and three actionable SUGGESTIONs that the existing reviewer set had missed.

## Test plan

- [x] `./gradlew allTests -q` green (pre-push hook).
- [x] Agent definition exercised manually against PR #178; output format matches spec.
- [ ] First real /code-review or /implement run after merge confirms wave dispatch picks the agent up (orchestration is configuration-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)