### PR TITLE
retro from #200: scope cohesion rule for feature specs and ux briefs

### DIFF
--- a/.claude/agents/spec-writer.md
+++ b/.claude/agents/spec-writer.md
@@ -56,7 +56,7 @@ Create `docs/product/features/<slug>/spec.md` from the template (creating the pe
 
 - **One spec per feature, all platforms.** Don't write "Android X" + "iOS X" separately — see template comment.
 - **No module names, file paths, gradle tasks** in the spec. If a sentence reads like a how-to, it belongs in the issue, not here.
-- **Scope cohesion pass before showing the diff.** Re-read each section and ask: "does this section depend on the feature's central invariant?". If a section describes a concept that survives without that invariant (e.g. row visualisation in a network-state spec) — it belongs to another feature. Move it to the right spec and leave a `Not in this feature` bullet here with the new owner's link. Adjacent concepts that came up during interview are the most common offenders.
+- **Scope cohesion pass before showing the diff.** Re-read each section and ask: "does this section depend on the feature's central invariant?". If a section describes a concept that survives without that invariant — it belongs to another feature. Move it to the right spec and leave a `Not in this feature` bullet here with the new owner's link.
 - **Status: `scoped`** once written and answered. `idea` is for unfilled specs; `in progress` once the implementing issue is open.
 - **Link the issue** in `GitHub Issues:` line.
 - **Update `docs/product/features/README.md`** — add a row in the table with the new file, status, and issue.

--- a/.claude/agents/spec-writer.md
+++ b/.claude/agents/spec-writer.md
@@ -56,6 +56,7 @@ Create `docs/product/features/<slug>/spec.md` from the template (creating the pe
 
 - **One spec per feature, all platforms.** Don't write "Android X" + "iOS X" separately — see template comment.
 - **No module names, file paths, gradle tasks** in the spec. If a sentence reads like a how-to, it belongs in the issue, not here.
+- **Scope cohesion pass before showing the diff.** Re-read each section and ask: "does this section depend on the feature's central invariant?". If a section describes a concept that survives without that invariant (e.g. row visualisation in a network-state spec) — it belongs to another feature. Move it to the right spec and leave a `Not in this feature` bullet here with the new owner's link. Adjacent concepts that came up during interview are the most common offenders.
 - **Status: `scoped`** once written and answered. `idea` is for unfilled specs; `in progress` once the implementing issue is open.
 - **Link the issue** in `GitHub Issues:` line.
 - **Update `docs/product/features/README.md`** — add a row in the table with the new file, status, and issue.

--- a/.claude/agents/ux-expert.md
+++ b/.claude/agents/ux-expert.md
@@ -103,6 +103,8 @@ component names from code.
 
 Re-read and verify: every screen has every state with real copy, every interaction has a fail mode, every non-text affordance has a semantic label, every platform delta is explicit (or explicitly "default"), conceptual components are named at the pattern level (not as code identifiers), and no open question is left dangling.
 
+**Scope cohesion pass.** For each section / screen / state, ask: "does it depend on the central invariant of this feature?". If a screen, row variant, or component describes behaviour that survives without the feature's invariant (e.g. a paired-vs-unpaired row contract in a network-state brief), it belongs to another feature's brief. Move it to that brief and leave an Information-architecture pointer here; do not silently keep adjacent-concept UI in this brief.
+
 ## Output to the orchestrator
 
 Report under 150 words: brief path, screens introduced/modified, platform-delta count (rough), open UX questions, conceptual-component count.

--- a/docs/product/features/_template.md
+++ b/docs/product/features/_template.md
@@ -23,9 +23,7 @@
 > **Scope cohesion.** Every section must depend on the feature's central invariant.
 > Before declaring the spec ready, for each section ask: "if I remove the central
 > invariant, does this section lose its meaning?". If no — the section belongs to
-> another feature; move it to that spec and leave a cross-reference here. Adjacent
-> concepts that come up while scoping (e.g. pairing UI in a network-state spec) are
-> the most common offenders.
+> another feature; move it to that spec and leave a cross-reference here.
 >
 > **Cross-ref on move.** Whenever a concept is moved into another spec — either
 > because of scope cohesion, or to honour a single owner — add a bullet to

--- a/docs/product/features/_template.md
+++ b/docs/product/features/_template.md
@@ -19,6 +19,19 @@
 > Don't write a separate "Android X" and "iOS X" spec — write one and put per-platform
 > user-visible quirks in `Platform notes`. Don't write a separate "X infrastructure" and
 > "X UI" spec — write one. See [README.md](README.md) → «What counts as one feature».
+>
+> **Scope cohesion.** Every section must depend on the feature's central invariant.
+> Before declaring the spec ready, for each section ask: "if I remove the central
+> invariant, does this section lose its meaning?". If no — the section belongs to
+> another feature; move it to that spec and leave a cross-reference here. Adjacent
+> concepts that come up while scoping (e.g. pairing UI in a network-state spec) are
+> the most common offenders.
+>
+> **Cross-ref on move.** Whenever a concept is moved into another spec — either
+> because of scope cohesion, or to honour a single owner — add a bullet to
+> `Not in this feature` naming the new owner and linking the destination. This keeps
+> navigation intact and prevents the next scoping pass from re-importing the same
+> content.
 
 ## Why
 


### PR DESCRIPTION
Retro from #200 (which itself moved row contract out of wifi-availability into device-list — it had landed in the wrong spec during first scoping).

## Signal

Adjacent concepts get pulled into a feature spec / ux brief during scoping because the conversation that produces them is cross-cutting. Caught only by manual review after the fact. Already the second occurrence in close succession.

## Fix

Codify "scope cohesion" as a rule, applied at three places:

- `docs/product/features/_template.md` — preamble rule: each section must depend on the feature's central invariant; cross-ref the new owner when content moves out.
- `.claude/agents/spec-writer.md` — explicit "scope cohesion pass" step before showing the diff.
- `.claude/agents/ux-expert.md` — explicit "scope cohesion pass" in "Before declaring the brief ready".

## Test plan

- [x] DOCS-only changes, `./gradlew allTests -q` green on push.
- [ ] Visual: rules read as load-bearing, not "as we discussed in #200".

🤖 Generated with [Claude Code](https://claude.com/claude-code)