### PR TITLE
#210: right-size agent models (review-ui/dod → haiku, adversarial → opus)

### DIFF
--- a/.claude/agents/review-adversarial.md
+++ b/.claude/agents/review-adversarial.md
@@ -2,7 +2,7 @@
 name: review-adversarial
 description: Adversarial probe — given findings from earlier review agents, form hypotheses about what's still wrong and verify each. Also cross-checks load-bearing factual claims inherited from inputs against authoritative external docs. Runs LAST in /code-review orchestration. Receives other agents' findings as input.
 tools: Bash, Read, Grep, Glob, WebFetch
-model: sonnet
+model: opus
 ---
 
 You are the last reviewer. By the time you run, six other agents have produced findings on DoD, guides, platform, reuse, correctness, and tests. Your job is **not** to redo their work. Your job is to ask: *what would I expect those six to have missed?*

--- a/.claude/agents/review-dod.md
+++ b/.claude/agents/review-dod.md
@@ -2,7 +2,7 @@
 name: review-dod
 description: Reviews a PR's diff against the issue's Definition of Done. Use as part of /code-review orchestration. Outputs DONE/MISSING/UNVERIFIABLE per criterion. Never blocks on style or correctness — only on scope and AC coverage.
 tools: Bash, Read, Grep, Glob
-model: sonnet
+model: haiku
 ---
 
 You verify that a PR's diff actually delivers what its issue asks for. Nothing else. Correctness, style, tests, platform quirks are other agents' jobs — do not duplicate them.

--- a/.claude/agents/review-ui.md
+++ b/.claude/agents/review-ui.md
@@ -2,7 +2,7 @@
 name: review-ui
 description: Reviews a PR's Compose UI code for conformance to the locked Tether design system — token usage, Material 3 ban, peer-identity color usage, Tabler-only icons, brand-mark geometry. Skip entirely if diff touches no `composeApp/src/**` files. Does not judge product decisions or UX brief conformance.
 tools: Bash, Read, Grep, Glob
-model: sonnet
+model: haiku
 ---
 
 You verify that Compose UI code in a PR uses the design system locked in `docs/engineering/ui-style-guide.md` and `docs/engineering/ui-brand-mark.md`. Your scope is enforcement of system-level rules — distinct from `review-ux` (per-feature UX brief) and `review-guides` (project-wide conventions).


### PR DESCRIPTION
## Summary

Triage of all 17 agents in `.claude/agents/` — three are mismatched to their cognitive load:

| Agent | Was | Now | Why |
|---|---|---|---|
| `review-ui` | sonnet | **haiku** | Pure pattern matching against locked design system: no Material 3 imports, no hardcoded colors, Tabler-only icons, brand-mark geometry. Rules in `ui-style-guide.md` are formal. |
| `review-dod` | sonnet | **haiku** | DoD checklist matching — DONE/MISSING/UNVERIFIABLE per criterion. Structured pass, not free reasoning. |
| `review-adversarial` | sonnet | **opus** | Last-line-of-defense: hypothesizes what's still wrong, cross-checks load-bearing factual claims. Runs once per PR. ROI on heavier model is best here. |

Other 14 agents stay on sonnet — all justified by nuanced judgement (writers compounding through review, deep technical analysis, platform quirks, adjudication-heavy reviewers).

Closes #210.

## Test plan

- [ ] After merge, run `/code-review` on a non-trivial PR — verify haiku-downgraded reviewers still catch obvious DoD gaps and design-system violations
- [ ] Adversarial wave on the same PR should now feel sharper (opus); if it starts hallucinating or padding — revert that one

## Dependency check

n/a (agent frontmatter only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)