### PR TITLE
#74: KydraLog as unified KMP logging facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ tether --name MyMac --port 8080
 
 Проверка, что сервер живой: `curl http://localhost:<port>/health` → `Tether OK`.
 
+Подробные логи (DEBUG): `TETHER_LOG_DEBUG=true tether` или `-Dtether.log.debug=true`. Полные правила и платформенные гейты — [`docs/engineering/logging.md`](docs/engineering/logging.md).
+
 Пример сессии:
 ```
 > send Phone /tmp/photo.jpg

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -92,6 +92,7 @@ kotlin {
         // src/appleMain/ and src/jvmMain/ are picked up by their respective source sets.
 
         commonMain.dependencies {
+            implementation(libs.kydra.log)
             implementation(libs.compose.runtime)
             implementation(libs.compose.foundation)
             implementation(libs.compose.material3)
@@ -120,6 +121,10 @@ kotlin {
         commonTest.dependencies {
             implementation(libs.kotlin.test)
             implementation(libs.kotlinx.coroutines.test)
+        }
+
+        jvmMain.dependencies {
+            implementation(libs.slf4j.simple)
         }
 
         androidMain.dependencies {

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/MainActivity.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -15,15 +14,18 @@ import com.arkivanov.decompose.retainedComponent
 import com.tubetoast.tether.di.AppContainerProvider
 import com.tubetoast.tether.network.TetherForegroundService
 import com.tubetoast.tether.presentation.DeviceListComponent
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.warn
+import ru.pocketbyte.kydra.log.wrapper.withTag
 
-private const val TAG = "MainActivity"
+private val log = KydraLog.withTag(default = "Tether.MainActivity")
 
 class MainActivity : ComponentActivity() {
     private val notificationPermissionRequest = registerForActivityResult(
         ActivityResultContracts.RequestPermission(),
     ) { granted ->
         if (!granted) {
-            Log.w(TAG, "POST_NOTIFICATIONS denied — foreground service notification will not appear")
+            log.warn { "POST_NOTIFICATIONS denied — foreground service notification will not appear" }
         }
     }
 

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/TetherApp.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/TetherApp.kt
@@ -1,14 +1,22 @@
 package com.tubetoast.tether
 
 import android.app.Application
+import android.content.pm.ApplicationInfo
 import com.tubetoast.tether.di.AndroidAppContainer
 import com.tubetoast.tether.di.AppContainerProvider
 import com.tubetoast.tether.di.TetherAppConfig
+import com.tubetoast.tether.logging.initTetherLogging
 
 class TetherApp :
     Application(),
     AppContainerProvider {
     override val container: AndroidAppContainer by lazy {
         AndroidAppContainer(TetherAppConfig(application = this))
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        val debuggable = (applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
+        initTetherLogging(debugEnabled = debuggable)
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.android.kt
@@ -4,13 +4,16 @@ import android.content.Context
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.os.Build
-import android.util.Log
 import com.tubetoast.tether.protocol.Device
 import kotlinx.coroutines.flow.StateFlow
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.debug
+import ru.pocketbyte.kydra.log.warn
+import ru.pocketbyte.kydra.log.wrapper.withTag
 import java.util.concurrent.ConcurrentLinkedQueue
 
 private const val SERVICE_TYPE = "_tether._tcp."
-private const val TAG = "MdnsDiscovery"
+private val log = KydraLog.withTag(default = "Tether.MdnsDiscovery.Android")
 
 actual class MdnsDiscovery(
     private val context: Context,
@@ -36,55 +39,55 @@ actual class MdnsDiscovery(
     private fun makeRegistrationListener(): NsdManager.RegistrationListener =
         object : NsdManager.RegistrationListener {
             override fun onRegistrationFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
-                Log.w(TAG, "NSD registration failed, errorCode=$errorCode")
+                log.warn { "NSD registration failed, errorCode=$errorCode" }
             }
 
             override fun onUnregistrationFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
-                Log.w(TAG, "NSD unregistration failed, errorCode=$errorCode")
+                log.warn { "NSD unregistration failed, errorCode=$errorCode" }
             }
 
             override fun onServiceRegistered(serviceInfo: NsdServiceInfo) {
                 if (nsdManager == null) return
                 if (this !== registrationListener) return
-                Log.d(TAG, "NSD service registered: ${serviceInfo.serviceName}")
+                log.debug { "NSD service registered: ${serviceInfo.serviceName}" }
                 // NsdManager may modify the requested name (e.g. strip special chars or resolve conflicts).
                 // Track the actual registered name so self-filter in onServiceFound stays accurate.
                 ownName = serviceInfo.serviceName
             }
 
             override fun onServiceUnregistered(serviceInfo: NsdServiceInfo) {
-                Log.d(TAG, "NSD service unregistered: ${serviceInfo.serviceName}")
+                log.debug { "NSD service unregistered: ${serviceInfo.serviceName}" }
             }
         }
 
     private val discoveryListener = object : NsdManager.DiscoveryListener {
         override fun onStartDiscoveryFailed(serviceType: String, errorCode: Int) {
-            Log.w(TAG, "NSD discovery start failed, errorCode=$errorCode")
+            log.warn { "NSD discovery start failed, errorCode=$errorCode" }
         }
 
         override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) {
-            Log.w(TAG, "NSD discovery stop failed, errorCode=$errorCode")
+            log.warn { "NSD discovery stop failed, errorCode=$errorCode" }
         }
 
         override fun onDiscoveryStarted(serviceType: String) {
-            Log.d(TAG, "NSD discovery started for $serviceType")
+            log.debug { "NSD discovery started for $serviceType" }
         }
 
         override fun onDiscoveryStopped(serviceType: String) {
-            Log.d(TAG, "NSD discovery stopped for $serviceType")
+            log.debug { "NSD discovery stopped for $serviceType" }
         }
 
         override fun onServiceFound(serviceInfo: NsdServiceInfo) {
             if (nsdManager == null) return
             if (serviceInfo.serviceName == ownName) return
-            Log.d(TAG, "NSD service found: ${serviceInfo.serviceName}")
+            log.debug { "NSD service found: ${serviceInfo.serviceName}" }
             resolveQueue.add(serviceInfo)
             startNextResolve()
         }
 
         override fun onServiceLost(serviceInfo: NsdServiceInfo) {
             if (nsdManager == null) return
-            Log.d(TAG, "NSD service lost: ${serviceInfo.serviceName}")
+            log.debug { "NSD service lost: ${serviceInfo.serviceName}" }
             // NsdManager only populates serviceName here; host/port are null/0 — can't rebuild id.
             store.removeByName(serviceInfo.serviceName)
         }
@@ -92,7 +95,7 @@ actual class MdnsDiscovery(
 
     private fun makeResolveListener() = object : NsdManager.ResolveListener {
         override fun onResolveFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
-            Log.w(TAG, "NSD resolve failed for '${serviceInfo.serviceName}', errorCode=$errorCode")
+            log.warn { "NSD resolve failed for '${serviceInfo.serviceName}', errorCode=$errorCode" }
             onResolveComplete()
         }
 
@@ -109,13 +112,13 @@ actual class MdnsDiscovery(
             }
             val host = inetAddress?.hostAddress
             if (host == null) {
-                Log.w(TAG, "NSD resolved '${serviceInfo.serviceName}' but host is null, skipping")
+                log.warn { "NSD resolved '${serviceInfo.serviceName}' but host is null, skipping" }
                 onResolveComplete()
                 return
             }
             val port = serviceInfo.port
             if (port !in 1..65535) {
-                Log.w(TAG, "NSD invalid port $port for '${serviceInfo.serviceName}', skipping")
+                log.warn { "NSD invalid port $port for '${serviceInfo.serviceName}', skipping" }
                 onResolveComplete()
                 return
             }
@@ -124,7 +127,7 @@ actual class MdnsDiscovery(
                 host = host,
                 port = port,
             )
-            Log.d(TAG, "NSD peer discovered: $device")
+            log.debug { "NSD peer discovered: $device" }
             store.upsert(device)
             onResolveComplete()
         }
@@ -164,7 +167,7 @@ actual class MdnsDiscovery(
             serviceType = SERVICE_TYPE
             this.port = port
         }
-        Log.d(TAG, "Starting NSD: name=$deviceName, port=$port")
+        log.debug { "Starting NSD: name=$deviceName, port=$port" }
         makeRegistrationListener().also { fresh ->
             registrationListener = fresh
             nm.registerService(serviceInfo, NsdManager.PROTOCOL_DNS_SD, fresh)
@@ -178,7 +181,7 @@ actual class MdnsDiscovery(
             try {
                 nm.unregisterService(old)
             } catch (e: Exception) {
-                Log.w(TAG, "NSD unregisterService ($label) failed: ${e.message}")
+                log.warn { "NSD unregisterService ($label) failed: ${e.message}" }
             }
         }
     }
@@ -186,7 +189,7 @@ actual class MdnsDiscovery(
     @Synchronized
     actual override fun republish(name: String) {
         val nm = nsdManager ?: return
-        Log.d(TAG, "Republishing NSD as name=$name")
+        log.debug { "Republishing NSD as name=$name" }
         unregisterPreviousListener(nm, "republish")
         ownName = name
         val serviceInfo = NsdServiceInfo().apply {
@@ -203,13 +206,13 @@ actual class MdnsDiscovery(
     @Synchronized
     actual override fun stop() {
         val nm = nsdManager ?: return
-        Log.d(TAG, "Stopping NSD")
+        log.debug { "Stopping NSD" }
         unregisterPreviousListener(nm, "stop")
         registrationListener = null
         try {
             nm.stopServiceDiscovery(discoveryListener)
         } catch (e: Exception) {
-            Log.w(TAG, "NSD stopServiceDiscovery failed: ${e.message}")
+            log.warn { "NSD stopServiceDiscovery failed: ${e.message}" }
         }
         nsdManager = null
         ownName = null

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/logging/Logging.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/logging/Logging.kt
@@ -1,9 +1,12 @@
 package com.tubetoast.tether.logging
 
+import ru.pocketbyte.kydra.log.DefaultLoggerFactory
 import ru.pocketbyte.kydra.log.KydraLog
 import ru.pocketbyte.kydra.log.LogLevel
-import ru.pocketbyte.kydra.log.wrapper.initDefault
+import ru.pocketbyte.kydra.log.wrapper.filtered
+import ru.pocketbyte.kydra.log.wrapper.initOrIgnore
 
 actual fun initTetherLogging(debugEnabled: Boolean) {
-    KydraLog.initDefault(level = if (debugEnabled) LogLevel.DEBUG else LogLevel.INFO)
+    val level = if (debugEnabled) LogLevel.DEBUG else LogLevel.INFO
+    KydraLog.initOrIgnore(DefaultLoggerFactory.create().filtered(level))
 }

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/logging/Logging.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/logging/Logging.kt
@@ -1,0 +1,9 @@
+package com.tubetoast.tether.logging
+
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.LogLevel
+import ru.pocketbyte.kydra.log.wrapper.initDefault
+
+actual fun initTetherLogging(debugEnabled: Boolean) {
+    KydraLog.initDefault(level = if (debugEnabled) LogLevel.DEBUG else LogLevel.INFO)
+}

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/TetherForegroundService.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/TetherForegroundService.kt
@@ -9,7 +9,6 @@ import android.content.pm.ServiceInfo
 import android.os.Binder
 import android.os.Build
 import android.os.IBinder
-import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
@@ -20,9 +19,15 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.error
+import ru.pocketbyte.kydra.log.info
+import ru.pocketbyte.kydra.log.warn
+import ru.pocketbyte.kydra.log.withMessage
+import ru.pocketbyte.kydra.log.wrapper.withTag
 
-private const val TAG = "TetherFGService"
 private const val NOTIFICATION_ID = 1001
+private val log = KydraLog.withTag(default = "Tether.FGService")
 private const val CHANNEL_ID = "tether_foreground"
 internal const val ACTION_STOP = "com.tubetoast.tether.action.STOP"
 
@@ -60,21 +65,21 @@ class TetherForegroundService : LifecycleService() {
                 runCatching { fileServer.stop() }
                 throw e
             } catch (e: Exception) {
-                Log.e(TAG, "FileServer failed to start: ${e.message}", e)
+                log.error { e withMessage "FileServer failed to start" }
                 stopForeground(STOP_FOREGROUND_REMOVE)
                 stopSelf()
                 return@launch
             }
             runningFileServer = fileServer
-            Log.i(TAG, "FileServer started on port $port, downloads → ${downloadsDir.absolutePath}")
+            log.info { "FileServer started on port $port, downloads → ${downloadsDir.absolutePath}" }
 
             try {
                 mdnsDiscovery.start(deviceName, port)
                 container.nameRepublisher.start(lifecycleScope)
                 runningMdnsDiscovery = mdnsDiscovery
-                Log.i(TAG, "mDNS started: name=$deviceName port=$port")
+                log.info { "mDNS started: name=$deviceName port=$port" }
             } catch (e: Exception) {
-                Log.e(TAG, "mDNS failed to start: ${e.message}", e)
+                log.error { e withMessage "mDNS failed to start" }
                 fileServer.stop()
                 runningFileServer = null
                 stopForeground(STOP_FOREGROUND_REMOVE)
@@ -86,7 +91,7 @@ class TetherForegroundService : LifecycleService() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         super.onStartCommand(intent, flags, startId)
         if (intent?.action == ACTION_STOP) {
-            Log.i(TAG, "Stop requested via notification action")
+            log.info { "Stop requested via notification action" }
             stopForeground(STOP_FOREGROUND_REMOVE)
             stopSelf()
             return START_NOT_STICKY
@@ -106,17 +111,17 @@ class TetherForegroundService : LifecycleService() {
         runningMdnsDiscovery?.let { mdnsDiscovery ->
             try {
                 mdnsDiscovery.stop()
-                Log.i(TAG, "mDNS stopped")
+                log.info { "mDNS stopped" }
             } catch (e: Exception) {
-                Log.w(TAG, "mDNS stop failed: ${e.message}")
+                log.warn { "mDNS stop failed: ${e.message}" }
             }
         }
         runningFileServer?.let { fileServer ->
             try {
                 fileServer.stop()
-                Log.i(TAG, "FileServer stopped")
+                log.info { "FileServer stopped" }
             } catch (e: Exception) {
-                Log.w(TAG, "FileServer stop failed: ${e.message}")
+                log.warn { "FileServer stop failed: ${e.message}" }
             }
         }
         runningMdnsDiscovery = null

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/security/TrustedDeviceStore.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/security/TrustedDeviceStore.android.kt
@@ -7,6 +7,11 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.error
+import ru.pocketbyte.kydra.log.wrapper.withTag
+
+private val log = KydraLog.withTag(default = "Tether.TrustedDeviceStore")
 
 // Stored values are public keys, so confidentiality at rest is intentionally not provided.
 private val Context.trustedDevicesDataStore: androidx.datastore.core.DataStore<Preferences> by
@@ -38,7 +43,7 @@ actual open class TrustedDeviceStore(
         return try {
             value.split(",").map { it.trim().toByte() }.toByteArray()
         } catch (e: Exception) {
-            System.err.println("ERROR: corrupted trusted key for '$deviceId' — ${e.message}")
+            log.error { "corrupted trusted key for '$deviceId' — ${e.message}" }
             null
         }
     }

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.apple.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.apple.kt
@@ -3,14 +3,19 @@ package com.tubetoast.tether.discovery
 import com.tubetoast.tether.protocol.Device
 import kotlinx.cinterop.ObjCSignatureOverride
 import kotlinx.coroutines.flow.StateFlow
-import platform.Foundation.NSLog
 import platform.Foundation.NSNetService
 import platform.Foundation.NSNetServiceBrowser
 import platform.Foundation.NSNetServiceBrowserDelegateProtocol
 import platform.Foundation.NSNetServiceDelegateProtocol
 import platform.darwin.NSObject
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.debug
+import ru.pocketbyte.kydra.log.info
+import ru.pocketbyte.kydra.log.warn
+import ru.pocketbyte.kydra.log.wrapper.withTag
 
 private const val SERVICE_TYPE = "_tether._tcp."
+private val log = KydraLog.withTag(default = "Tether.MdnsDiscovery.Apple")
 
 // Thread-safety note: NSNetService and NSNetServiceBrowser must be created and used on
 // the thread that owns their run loop. All callbacks (didPublish, didFind, didResolve)
@@ -55,7 +60,7 @@ actual class MdnsDiscovery(
         service.publish()
         netService = service
 
-        NSLog("mDNS: publishing service %s on port %d", deviceName, port)
+        log.info { "publishing service $deviceName on port $port" }
 
         val browserDelegate = BrowserDelegate(this)
         this.browserDelegate = browserDelegate
@@ -65,20 +70,20 @@ actual class MdnsDiscovery(
         browser.searchForServicesOfType(SERVICE_TYPE, inDomain = "")
         this.browser = browser
 
-        NSLog("mDNS: started discovery for %s", SERVICE_TYPE)
+        log.info { "started discovery for $SERVICE_TYPE" }
     }
 
     actual override fun stop() {
         try {
             netService?.stop()
         } catch (e: Exception) {
-            NSLog("mDNS: failed to stop service — %s", e.message ?: "unknown error")
+            log.warn { "failed to stop service — ${e.message ?: "unknown error"}" }
         }
 
         try {
             browser?.stop()
         } catch (e: Exception) {
-            NSLog("mDNS: failed to stop browser — %s", e.message ?: "unknown error")
+            log.warn { "failed to stop browser — ${e.message ?: "unknown error"}" }
         }
 
         netService = null
@@ -90,7 +95,7 @@ actual class MdnsDiscovery(
         resolutionDelegates.clear()
         store.clear()
 
-        NSLog("mDNS: stopped")
+        log.info { "stopped" }
     }
 
     /**
@@ -100,11 +105,11 @@ actual class MdnsDiscovery(
      */
     actual override fun republish(name: String) {
         if (netService == null && browser == null) return
-        NSLog("mDNS: republishing as %s", name)
+        log.info { "republishing as $name" }
         try {
             netService?.stop()
         } catch (e: Exception) {
-            NSLog("mDNS: failed to stop service for republish — %s", e.message ?: "unknown error")
+            log.warn { "failed to stop service for republish — ${e.message ?: "unknown error"}" }
         }
         ownServiceName = name
 
@@ -120,17 +125,17 @@ actual class MdnsDiscovery(
         service.publish()
         netService = service
 
-        NSLog("mDNS: republished service %s on port %d", name, currentPort)
+        log.info { "republished service $name on port $currentPort" }
     }
 
     private fun onServiceFound(service: NSNetService) {
         val serviceName = service.name
         if (serviceName == ownServiceName) {
-            NSLog("mDNS: ignoring self-discovery for %s", serviceName)
+            log.debug { "ignoring self-discovery for $serviceName" }
             return
         }
 
-        NSLog("mDNS: found service %s, resolving...", serviceName)
+        log.debug { "found service $serviceName, resolving..." }
         val delegate = ResolutionDelegate(this, serviceName)
         resolutionDelegates.add(delegate)
         service.delegate = delegate
@@ -139,23 +144,23 @@ actual class MdnsDiscovery(
 
     private fun onServiceRemoved(service: NSNetService) {
         val serviceName = service.name
-        NSLog("mDNS: service removed %s", serviceName)
+        log.info { "service removed $serviceName" }
         store.removeByName(serviceName)
     }
 
     private fun onServiceResolved(service: NSNetService) {
         val serviceName = service.name
-        NSLog("mDNS: resolved service %s", serviceName)
+        log.debug { "resolved service $serviceName" }
 
         val port = service.port.toInt()
         if (port !in 1..65535) {
-            NSLog("mDNS: invalid port %d for %s, skipping", port, serviceName)
+            log.warn { "invalid port $port for $serviceName, skipping" }
             return
         }
 
         val host = service.hostName
         if (host.isNullOrEmpty()) {
-            NSLog("mDNS: could not get hostname for %s, skipping", serviceName)
+            log.warn { "could not get hostname for $serviceName, skipping" }
             return
         }
 
@@ -165,12 +170,12 @@ actual class MdnsDiscovery(
             port = port,
         )
 
-        NSLog("mDNS: peer discovered: %s@%s:%d", device.name, device.host, device.port)
+        log.info { "peer discovered: ${device.name}@${device.host}:${device.port}" }
         store.upsert(device)
     }
 
     private fun onServiceResolutionFailed(serviceName: String) {
-        NSLog("mDNS: failed to resolve service %s", serviceName)
+        log.warn { "failed to resolve service $serviceName" }
     }
 
     // Kotlin/Native maps ObjC "method:arg1:arg2:" to fun method(arg1, arg2).
@@ -179,18 +184,18 @@ actual class MdnsDiscovery(
     ) : NSObject(),
         NSNetServiceDelegateProtocol {
         override fun netServiceDidPublish(sender: NSNetService) {
-            NSLog("mDNS: service published: %s", sender.name)
+            log.info { "service published: ${sender.name}" }
             discovery.ownServiceName = sender.name
         }
 
         @ObjCSignatureOverride
         @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
         override fun netService(sender: NSNetService, didNotPublish: Map<Any?, *>) {
-            NSLog("mDNS: service publication failed: %s", sender.name)
+            log.warn { "service publication failed: ${sender.name}" }
         }
 
         override fun netServiceDidStop(sender: NSNetService) {
-            NSLog("mDNS: service stopped: %s", sender.name)
+            log.info { "service stopped: ${sender.name}" }
         }
 
         override fun netServiceDidResolveAddress(sender: NSNetService) {
@@ -234,11 +239,11 @@ actual class MdnsDiscovery(
             aNetServiceBrowser: NSNetServiceBrowser,
             didNotSearch: Map<Any?, *>,
         ) {
-            NSLog("mDNS: browser search failed")
+            log.warn { "browser search failed" }
         }
 
         override fun netServiceBrowserDidStopSearch(browser: NSNetServiceBrowser) {
-            NSLog("mDNS: browser stopped")
+            log.info { "browser stopped" }
         }
     }
 

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/logging/AppleLogging.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/logging/AppleLogging.kt
@@ -1,0 +1,7 @@
+@file:OptIn(kotlin.experimental.ExperimentalNativeApi::class)
+
+package com.tubetoast.tether.logging
+
+fun initLogging() {
+    initTetherLogging(debugEnabled = Platform.isDebugBinary)
+}

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/logging/Logging.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/logging/Logging.kt
@@ -1,9 +1,12 @@
 package com.tubetoast.tether.logging
 
+import ru.pocketbyte.kydra.log.DefaultLoggerFactory
 import ru.pocketbyte.kydra.log.KydraLog
 import ru.pocketbyte.kydra.log.LogLevel
-import ru.pocketbyte.kydra.log.wrapper.initDefault
+import ru.pocketbyte.kydra.log.wrapper.filtered
+import ru.pocketbyte.kydra.log.wrapper.initOrIgnore
 
 actual fun initTetherLogging(debugEnabled: Boolean) {
-    KydraLog.initDefault(level = if (debugEnabled) LogLevel.DEBUG else LogLevel.INFO)
+    val level = if (debugEnabled) LogLevel.DEBUG else LogLevel.INFO
+    KydraLog.initOrIgnore(DefaultLoggerFactory.create().filtered(level))
 }

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/logging/Logging.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/logging/Logging.kt
@@ -1,0 +1,9 @@
+package com.tubetoast.tether.logging
+
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.LogLevel
+import ru.pocketbyte.kydra.log.wrapper.initDefault
+
+actual fun initTetherLogging(debugEnabled: Boolean) {
+    KydraLog.initDefault(level = if (debugEnabled) LogLevel.DEBUG else LogLevel.INFO)
+}

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/network/FileServer.apple.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/network/FileServer.apple.kt
@@ -15,13 +15,19 @@ import kotlinx.cinterop.usePinned
 import kotlinx.coroutines.runBlocking
 import platform.Foundation.NSDocumentDirectory
 import platform.Foundation.NSFileManager
-import platform.Foundation.NSLog
 import platform.Foundation.NSSearchPathForDirectoriesInDomains
 import platform.Foundation.NSUserDomainMask
 import platform.posix.fclose
 import platform.posix.fflush
 import platform.posix.fopen
 import platform.posix.fwrite
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.error
+import ru.pocketbyte.kydra.log.info
+import ru.pocketbyte.kydra.log.withMessage
+import ru.pocketbyte.kydra.log.wrapper.withTag
+
+private val log = KydraLog.withTag(default = "Tether.FileServer")
 
 actual class FileServer(
     private val port: Int,
@@ -37,16 +43,24 @@ actual class FileServer(
         check(server == null) { "FileServer is already running" }
         val storage = AppleUploadStorage(downloadsDir)
         storage.ensureRoot()
-        val srv = embeddedServer(CIO, port = port) {
-            installFileServerRoutes(storage, trustedDeviceStore, deviceKeyPair.publicKey, tracker)
-        }.start(wait = false)
+        val srv = try {
+            embeddedServer(CIO, port = port) {
+                installFileServerRoutes(storage, trustedDeviceStore, deviceKeyPair.publicKey, tracker)
+            }.start(wait = false)
+        } catch (e: Exception) {
+            log.error { e withMessage "FileServer start failed on port $port" }
+            throw e
+        }
         server = srv
-        return runBlocking { srv.engine.resolvedConnectors() }.first().port
+        val resolvedPort = runBlocking { srv.engine.resolvedConnectors() }.first().port
+        log.info { "started on port $resolvedPort, downloads → $downloadsDir" }
+        return resolvedPort
     }
 
     actual fun stop() {
         server?.stop(gracePeriodMillis = 500, timeoutMillis = 1_000)
         server = null
+        log.info { "stopped" }
     }
 }
 
@@ -113,14 +127,6 @@ private class AppleUploadStorage(
         if (fm.fileExistsAtPath(destination)) {
             fm.removeItemAtPath(destination, error = null)
         }
-    }
-
-    override fun logInfo(message: String) {
-        NSLog("[FileServer] %s", message)
-    }
-
-    override fun logError(message: String) {
-        NSLog("[FileServer] ERROR: %s", message)
     }
 }
 

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/security/DeviceKeyPair.apple.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/security/DeviceKeyPair.apple.kt
@@ -11,7 +11,6 @@ import kotlinx.cinterop.usePinned
 import platform.Foundation.NSData
 import platform.Foundation.NSDocumentDirectory
 import platform.Foundation.NSFileManager
-import platform.Foundation.NSLog
 import platform.Foundation.NSSearchPathForDirectoriesInDomains
 import platform.Foundation.NSUserDomainMask
 import platform.Foundation.dataWithBytes
@@ -20,11 +19,15 @@ import platform.Foundation.writeToFile
 import platform.Security.SecRandomCopyBytes
 import platform.Security.kSecRandomDefault
 import platform.posix.memcpy
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.warn
+import ru.pocketbyte.kydra.log.wrapper.withTag
 
 // Placeholder until a real EC P-256 keypair lands via Keychain (#9 defers signature verification).
 // Until then the protocol treats these bytes as an opaque per-install identifier.
 private const val PUBLIC_KEY_BYTES = 32
 private const val FILE_PUBLIC = "device_public.key"
+private val log = KydraLog.withTag(default = "Tether.DeviceKeyPair")
 
 actual class DeviceKeyPair(
     configDir: String? = null,
@@ -43,7 +46,7 @@ actual class DeviceKeyPair(
         if (fileManager.fileExistsAtPath(publicPath)) {
             val existing = readFile(publicPath)
             if (existing != null && existing.size == PUBLIC_KEY_BYTES) return existing
-            NSLog("WARN: device key corrupted (size=%lu), regenerating", (existing?.size ?: 0).toULong())
+            log.warn { "device key corrupted (size=${existing?.size ?: 0}), regenerating" }
             fileManager.removeItemAtPath(publicPath, error = null)
         }
         val fresh = randomBytes(PUBLIC_KEY_BYTES)

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/security/TrustedDeviceStore.apple.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/security/TrustedDeviceStore.apple.kt
@@ -1,8 +1,12 @@
 package com.tubetoast.tether.security
 
 import com.tubetoast.tether.foundation.writeOrThrow
-import platform.Foundation.NSLog
 import platform.Foundation.NSUserDefaults
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.error
+import ru.pocketbyte.kydra.log.wrapper.withTag
+
+private val log = KydraLog.withTag(default = "Tether.TrustedDeviceStore")
 
 actual open class TrustedDeviceStore {
     private val defaults = NSUserDefaults.standardUserDefaults
@@ -20,7 +24,7 @@ actual open class TrustedDeviceStore {
         return try {
             value.split(",").map { it.trim().toByte() }.toByteArray()
         } catch (e: Exception) {
-            NSLog("ERROR: corrupted trusted key for '%s' — %s", deviceId, e.message ?: "unknown error")
+            log.error { "corrupted trusted key for '$deviceId' — ${e.message ?: "unknown error"}" }
             null
         }
     }

--- a/composeApp/src/appleTest/kotlin/com/tubetoast/tether/network/FileServerTest.kt
+++ b/composeApp/src/appleTest/kotlin/com/tubetoast/tether/network/FileServerTest.kt
@@ -2,6 +2,7 @@
 
 package com.tubetoast.tether.network
 
+import com.tubetoast.tether.logging.suppressTestLogs
 import com.tubetoast.tether.security.DeviceKeyPair
 import com.tubetoast.tether.security.TrustedDeviceStore
 import io.ktor.client.HttpClient
@@ -37,6 +38,7 @@ import platform.Foundation.dataWithContentsOfFile
 import platform.Foundation.stringWithContentsOfFile
 import platform.posix.memcpy
 import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -51,6 +53,11 @@ import kotlin.time.Duration.Companion.milliseconds
 @Suppress("ktlint:tether:no-run-blocking-in-tests")
 class FileServerTest {
     private val tempDirs = mutableListOf<String>()
+
+    @BeforeTest
+    fun setup() {
+        suppressTestLogs()
+    }
 
     @AfterTest
     fun cleanup() {

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/logging/Logging.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/logging/Logging.kt
@@ -1,0 +1,3 @@
+package com.tubetoast.tether.logging
+
+expect fun initTetherLogging(debugEnabled: Boolean)

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
@@ -25,8 +25,16 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.debug
+import ru.pocketbyte.kydra.log.error
+import ru.pocketbyte.kydra.log.info
+import ru.pocketbyte.kydra.log.withMessage
+import ru.pocketbyte.kydra.log.wrapper.withTag
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+
+private val log = KydraLog.withTag(default = "Tether.FileClient")
 
 class FileClient(
     private val client: HttpClient,
@@ -60,6 +68,7 @@ class FileClient(
         totalBytes: Long? = null,
         onProgress: ((bytesTransferred: Long, totalBytes: Long?) -> Unit)? = null,
     ): SendResult = tracker.withActiveTransfer {
+        log.info { "sending '$fileName'${totalBytes?.let { " ($it bytes)" } ?: ""} → ${device.host}:${device.port}" }
         try {
             sendInternal(device, channel, fileName, totalBytes, onProgress)
         } catch (e: CancellationException) {
@@ -125,6 +134,7 @@ class FileClient(
             parameter("name", fileName)
             setBody(channel.asOctetStreamContent(totalBytes))
         }
+        log.debug { "response status ${response.status} for '$fileName' → ${device.host}:${device.port}" }
         if (response.status == HttpStatusCode.OK) {
             val body = response.body<Map<String, String>>()
             SendResult.Success(body["savedPath"] ?: "")
@@ -135,6 +145,7 @@ class FileClient(
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
+        log.error { e withMessage "doSend failed for '$fileName' → ${device.host}:${device.port}" }
         SendResult.Failure(e.message ?: "unknown error")
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileServerRoutes.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileServerRoutes.kt
@@ -18,8 +18,14 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.readAvailable
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.error
+import ru.pocketbyte.kydra.log.info
+import ru.pocketbyte.kydra.log.wrapper.withTag
 
 internal const val UPLOAD_BUFFER_SIZE = 64 * 1024
+
+private val log = KydraLog.withTag(default = "Tether.FileServerRoutes")
 
 internal interface UploadStorage {
     fun ensureRoot()
@@ -29,10 +35,6 @@ internal interface UploadStorage {
     suspend fun writeBody(body: ByteReadChannel, destination: String): Long
 
     fun deleteIfExists(destination: String)
-
-    fun logInfo(message: String)
-
-    fun logError(message: String)
 }
 
 internal fun Application.installFileServerRoutes(
@@ -85,11 +87,11 @@ internal fun Application.installFileServerRoutes(
                         error("FileServer: incomplete upload — got $bytesWritten of $expected bytes")
                     }
                     uploadComplete = true
-                    storage.logInfo("received '$fileName' — $bytesWritten bytes → $destination")
+                    log.info { "received '$fileName' — $bytesWritten bytes → $destination" }
                     call.respond(HttpStatusCode.OK, mapOf("savedPath" to destination))
                 }
             } catch (e: Exception) {
-                storage.logError("upload failed for '$fileName' — ${e.message ?: "unknown error"}")
+                log.error { "upload failed for '$fileName' — ${e.message ?: "unknown error"}" }
                 try {
                     call.respond(
                         HttpStatusCode.InternalServerError,

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/logging/TestLogging.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/logging/TestLogging.kt
@@ -1,0 +1,11 @@
+package com.tubetoast.tether.logging
+
+import ru.pocketbyte.kydra.log.DefaultLoggerFactory
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.LogLevel
+import ru.pocketbyte.kydra.log.wrapper.filtered
+import ru.pocketbyte.kydra.log.wrapper.initOrIgnore
+
+fun suppressTestLogs() {
+    KydraLog.initOrIgnore(DefaultLoggerFactory.create().filtered(LogLevel.WARNING))
+}

--- a/composeApp/src/desktopCli/kotlin/com/tubetoast/tether/Main.kt
+++ b/composeApp/src/desktopCli/kotlin/com/tubetoast/tether/Main.kt
@@ -8,6 +8,8 @@ import com.tubetoast.tether.config.DeviceNameStore
 import com.tubetoast.tether.config.EphemeralDeviceNamePersistence
 import com.tubetoast.tether.di.DefaultDesktopAppConfig
 import com.tubetoast.tether.di.DesktopAppContainer
+import com.tubetoast.tether.logging.initTetherLogging
+import com.tubetoast.tether.logging.isDebugEnabled
 import com.tubetoast.tether.network.FileClient
 import com.tubetoast.tether.network.send
 import com.tubetoast.tether.protocol.Device
@@ -37,6 +39,7 @@ class TetherCommand :
         .int()
 
     override fun run() = runBlocking {
+        initTetherLogging(debugEnabled = isDebugEnabled())
         val container = DesktopAppContainer(
             DefaultDesktopAppConfig(port = port ?: 0, namePersistence = EphemeralDeviceNamePersistence()),
         )

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/DesktopBackend.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/DesktopBackend.kt
@@ -6,6 +6,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.warn
+import ru.pocketbyte.kydra.log.wrapper.withTag
+
+private val log = KydraLog.withTag(default = "Tether.DesktopBackend")
 
 internal sealed class BackendStartException(
     message: String,
@@ -46,17 +51,17 @@ internal suspend fun DesktopAppContainer.startBackendOrFail(): BackendHandle {
     nameRepublisher.start(backendScope)
     return BackendHandle(port) {
         runCatching { nameRepublisher.stop() }.onFailure {
-            System.err.println("WARN: nameRepublisher stop failed — ${it.message}")
+            log.warn { "nameRepublisher stop failed — ${it.message}" }
         }
         runCatching { backendScope.cancel() }
         runCatching { mdnsDiscovery.stop() }.onFailure {
-            System.err.println("WARN: mDNS stop failed — ${it.message}")
+            log.warn { "mDNS stop failed — ${it.message}" }
         }
         runCatching { server.stop() }.onFailure {
-            System.err.println("WARN: FileServer stop failed — ${it.message}")
+            log.warn { "FileServer stop failed — ${it.message}" }
         }
         runCatching { fileClient.close() }.onFailure {
-            System.err.println("WARN: FileClient close failed — ${it.message}")
+            log.warn { "FileClient close failed — ${it.message}" }
         }
     }
 }
@@ -66,7 +71,7 @@ internal fun registerShutdownHook(handle: BackendHandle) {
         Thread {
             val cleanup = Thread {
                 runCatching { handle.close() }.onFailure {
-                    System.err.println("WARN: backend cleanup failed — ${it.message}")
+                    log.warn { "backend cleanup failed — ${it.message}" }
                 }
             }
             cleanup.isDaemon = true

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/MainUi.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/MainUi.kt
@@ -8,6 +8,8 @@ import com.arkivanov.essenty.lifecycle.destroy
 import com.arkivanov.essenty.lifecycle.resume
 import com.tubetoast.tether.di.DefaultDesktopAppConfig
 import com.tubetoast.tether.di.DesktopAppContainer
+import com.tubetoast.tether.logging.initTetherLogging
+import com.tubetoast.tether.logging.isDebugEnabled
 import com.tubetoast.tether.presentation.DeviceListComponent
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.compose.resources.painterResource
@@ -15,6 +17,7 @@ import tether.composeapp.generated.resources.Res
 import tether.composeapp.generated.resources.icon
 
 fun main() = runBlocking {
+    initTetherLogging(debugEnabled = isDebugEnabled())
     val container = DesktopAppContainer(
         DefaultDesktopAppConfig(port = 0),
     )

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscoveryJmdns.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscoveryJmdns.kt
@@ -9,6 +9,11 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.debug
+import ru.pocketbyte.kydra.log.info
+import ru.pocketbyte.kydra.log.warn
+import ru.pocketbyte.kydra.log.wrapper.withTag
 import javax.jmdns.JmDNS
 import javax.jmdns.ServiceEvent
 import javax.jmdns.ServiceInfo
@@ -19,6 +24,7 @@ private const val SERVICE_TYPE = "_tether._tcp.local."
 private val IPV4_REGEX = Regex("""\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}""")
 internal const val REQUERY_INITIAL_INTERVAL_MS = 5_000L
 private const val REQUERY_MAX_INTERVAL_MS = 60_000L
+private val log = KydraLog.withTag(default = "Tether.MdnsDiscovery.JmDNS")
 
 /**
  * JmDNS-based discovery for non-macOS JVM hosts (Linux, Windows).
@@ -61,7 +67,7 @@ internal class MdnsDiscoveryJmdns(
             }
 
             override fun serviceRemoved(event: ServiceEvent) {
-                System.err.println("INFO: serviceRemoved '${event.name}'")
+                log.info { "serviceRemoved '${event.name}'" }
                 store.removeByName(event.name)
             }
 
@@ -70,7 +76,7 @@ internal class MdnsDiscoveryJmdns(
                 try {
                     val info: ServiceInfo = event.info
                     if (info.port !in 1..65535) {
-                        System.err.println("WARN: invalid port ${info.port} for '${event.name}', skipping")
+                        log.warn { "invalid port ${info.port} for '${event.name}', skipping" }
                         return
                     }
                     val ipv4 = resolveIPv4(info, event.name) ?: return
@@ -82,7 +88,7 @@ internal class MdnsDiscoveryJmdns(
                     )
                     store.upsert(device)
                 } catch (e: Exception) {
-                    System.err.println("WARN: serviceResolved error for '${event.name}' — ${e.message}")
+                    log.warn { "serviceResolved error for '${event.name}' — ${e.message}" }
                 }
             }
         }
@@ -126,12 +132,12 @@ internal class MdnsDiscoveryJmdns(
         try {
             instance.unregisterAllServices()
         } catch (e: Exception) {
-            System.err.println("WARN: unregisterAllServices (republish) failed — ${e.message}")
+            log.warn { "unregisterAllServices (republish) failed — ${e.message}" }
         }
         try {
             instance.registerService(ServiceInfo.create(SERVICE_TYPE, name, ownPort, ""))
         } catch (e: Exception) {
-            System.err.println("WARN: registerService (republish) failed — ${e.message}")
+            log.warn { "registerService (republish) failed — ${e.message}" }
         }
     }
 
@@ -143,12 +149,12 @@ internal class MdnsDiscoveryJmdns(
             try {
                 jmdns?.unregisterAllServices()
             } catch (e: Exception) {
-                System.err.println("WARN: unregisterAllServices failed — ${e.message}")
+                log.warn { "unregisterAllServices failed — ${e.message}" }
             }
             try {
                 jmdns?.close()
             } catch (e: Exception) {
-                System.err.println("WARN: jmdns close failed — ${e.message}")
+                log.warn { "jmdns close failed — ${e.message}" }
             }
         } finally {
             jmdns = null
@@ -162,7 +168,7 @@ internal class MdnsDiscoveryJmdns(
     private fun resolveIPv4(info: ServiceInfo, serviceName: String): String? {
         val ipv4 = info.getHostAddresses().firstOrNull { IPV4_REGEX.matches(it) }
         if (ipv4 == null) {
-            System.err.println("DEBUG: serviceResolved — no IPv4 yet for '$serviceName', skipping")
+            log.debug { "serviceResolved — no IPv4 yet for '$serviceName', skipping" }
         }
         return ipv4
     }

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/bonjour/MdnsDiscoveryBonjour.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/bonjour/MdnsDiscoveryBonjour.kt
@@ -18,9 +18,14 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.warn
+import ru.pocketbyte.kydra.log.wrapper.withTag
 import java.net.NetworkInterface
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
+
+private val log = KydraLog.withTag(default = "Tether.MdnsDiscovery.Bonjour")
 
 /**
  * JVM-on-macOS mDNS discovery backed by Apple's DNS-SD API ([DnsSd]).
@@ -194,7 +199,7 @@ internal class MdnsDiscoveryBonjour(
                 null,
             )
             if (error != DnsSd.NO_ERROR) {
-                System.err.println("WARN: DNSServiceResolve('$peerName') failed error=$error")
+                log.warn { "DNSServiceResolve('$peerName') failed error=$error" }
                 return null
             }
             return outRef.value
@@ -230,7 +235,7 @@ internal class MdnsDiscoveryBonjour(
                 null,
             )
             if (error != DnsSd.NO_ERROR) {
-                System.err.println("WARN: DNSServiceGetAddrInfo('$hostname') failed error=$error")
+                log.warn { "DNSServiceGetAddrInfo('$hostname') failed error=$error" }
                 return null
             }
             return outRef.value
@@ -387,7 +392,7 @@ internal class MdnsDiscoveryBonjour(
                         context: Pointer?,
                     ) {
                         if (errorCode != DnsSd.NO_ERROR) {
-                            System.err.println("WARN: DNSServiceRegister callback errorCode=$errorCode")
+                            log.warn { "DNSServiceRegister callback errorCode=$errorCode" }
                         }
                     }
                 }
@@ -407,7 +412,7 @@ internal class MdnsDiscoveryBonjour(
                     null,
                 )
                 if (error != DnsSd.NO_ERROR) {
-                    System.err.println("WARN: DNSServiceRegister failed error=$error; running browse-only")
+                    log.warn { "DNSServiceRegister failed error=$error; running browse-only" }
                     return null
                 }
                 return outRef.value
@@ -417,7 +422,7 @@ internal class MdnsDiscoveryBonjour(
                 try {
                     DnsSd.INSTANCE.DNSServiceRefDeallocate(ref)
                 } catch (e: Throwable) {
-                    System.err.println("WARN: Bonjour $label deallocate failed — ${e.message}")
+                    log.warn { "Bonjour $label deallocate failed — ${e.message}" }
                 }
             }
 

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/logging/Logging.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/logging/Logging.kt
@@ -1,0 +1,13 @@
+package com.tubetoast.tether.logging
+
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.LogLevel
+import ru.pocketbyte.kydra.log.wrapper.initDefault
+
+actual fun initTetherLogging(debugEnabled: Boolean) {
+    KydraLog.initDefault(level = if (debugEnabled) LogLevel.DEBUG else LogLevel.INFO)
+}
+
+fun isDebugEnabled(): Boolean =
+    System.getProperty("tether.log.debug")?.toBooleanStrictOrNull() == true ||
+        System.getenv("TETHER_LOG_DEBUG")?.toBooleanStrictOrNull() == true

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/logging/Logging.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/logging/Logging.kt
@@ -1,11 +1,14 @@
 package com.tubetoast.tether.logging
 
+import ru.pocketbyte.kydra.log.DefaultLoggerFactory
 import ru.pocketbyte.kydra.log.KydraLog
 import ru.pocketbyte.kydra.log.LogLevel
-import ru.pocketbyte.kydra.log.wrapper.initDefault
+import ru.pocketbyte.kydra.log.wrapper.filtered
+import ru.pocketbyte.kydra.log.wrapper.initOrIgnore
 
 actual fun initTetherLogging(debugEnabled: Boolean) {
-    KydraLog.initDefault(level = if (debugEnabled) LogLevel.DEBUG else LogLevel.INFO)
+    val level = if (debugEnabled) LogLevel.DEBUG else LogLevel.INFO
+    KydraLog.initOrIgnore(DefaultLoggerFactory.create().filtered(level))
 }
 
 fun isDebugEnabled(): Boolean =

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/security/TrustedDeviceStore.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/security/TrustedDeviceStore.desktop.kt
@@ -8,11 +8,15 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.error
+import ru.pocketbyte.kydra.log.wrapper.withTag
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 
 private val defaultConfigDir = File(System.getProperty("user.home"), ".config/tether")
+private val log = KydraLog.withTag(default = "Tether.TrustedDeviceStore")
 
 actual open class TrustedDeviceStore(
     private val configDir: File = defaultConfigDir,
@@ -41,7 +45,7 @@ actual open class TrustedDeviceStore(
                     key to value.jsonArray.map { it.jsonPrimitive.int.toByte() }.toByteArray()
                 }
         } catch (e: Exception) {
-            System.err.println("ERROR: failed to load trusted device store — ${e.message}")
+            log.error { "failed to load trusted device store — ${e.message}" }
             mutableMapOf()
         }
     }

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/network/FileClientTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/network/FileClientTest.kt
@@ -1,5 +1,6 @@
 package com.tubetoast.tether.network
 
+import com.tubetoast.tether.logging.suppressTestLogs
 import com.tubetoast.tether.protocol.Device
 import com.tubetoast.tether.protocol.SendResult
 import io.ktor.client.HttpClient
@@ -29,6 +30,7 @@ import java.io.IOException
 import java.nio.file.Files
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.io.path.writeBytes
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
@@ -38,6 +40,11 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 class FileClientTest {
+    @BeforeTest
+    fun setup() {
+        suppressTestLogs()
+    }
+
     private val device = Device(name = "test", host = "127.0.0.1", port = 8080)
 
     private fun TestScope.mockClient(

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/network/FileServerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/network/FileServerTest.kt
@@ -1,5 +1,6 @@
 package com.tubetoast.tether.network
 
+import com.tubetoast.tether.logging.suppressTestLogs
 import com.tubetoast.tether.security.DeviceKeyPair
 import com.tubetoast.tether.security.TrustedDeviceStore
 import io.ktor.client.HttpClient
@@ -24,6 +25,7 @@ import kotlinx.coroutines.withTimeout
 import java.io.File
 import java.nio.file.Files
 import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -37,6 +39,11 @@ import kotlin.time.Duration.Companion.milliseconds
 class FileServerTest {
     private val cleanupPaths = mutableListOf<File>()
     private var startedServer: FileServer? = null
+
+    @BeforeTest
+    fun setup() {
+        suppressTestLogs()
+    }
 
     @AfterTest
     fun teardown() {

--- a/composeApp/src/iosMain/kotlin/com/tubetoast/tether/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/com/tubetoast/tether/MainViewController.kt
@@ -9,6 +9,7 @@ import com.arkivanov.essenty.lifecycle.resume
 import com.arkivanov.essenty.lifecycle.stop
 import com.tubetoast.tether.di.DefaultIosAppConfig
 import com.tubetoast.tether.di.IosAppContainer
+import com.tubetoast.tether.logging.initLogging
 import com.tubetoast.tether.presentation.DeviceListComponent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -19,6 +20,7 @@ import kotlinx.coroutines.launch
 
 @Suppress("ktlint:standard:function-naming")
 fun MainViewController() = run {
+    initLogging()
     val container = IosAppContainer(DefaultIosAppConfig())
     val lifecycle = LifecycleRegistry()
     val context = DefaultComponentContext(lifecycle)

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/network/FileServer.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/network/FileServer.kt
@@ -9,7 +9,14 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.jvm.javaio.toInputStream
 import kotlinx.coroutines.runBlocking
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.error
+import ru.pocketbyte.kydra.log.info
+import ru.pocketbyte.kydra.log.withMessage
+import ru.pocketbyte.kydra.log.wrapper.withTag
 import java.io.File
+
+private val log = KydraLog.withTag(default = "Tether.FileServer")
 
 actual class FileServer(
     private val port: Int,
@@ -24,18 +31,26 @@ actual class FileServer(
         check(server == null) { "FileServer is already running" }
         val storage = JvmUploadStorage(downloadsDir)
         storage.ensureRoot()
-        val srv = embeddedServer(CIO, port = port) {
-            installFileServerRoutes(storage, trustedDeviceStore, deviceKeyPair.publicKey, tracker)
-        }.start(wait = false)
+        val srv = try {
+            embeddedServer(CIO, port = port) {
+                installFileServerRoutes(storage, trustedDeviceStore, deviceKeyPair.publicKey, tracker)
+            }.start(wait = false)
+        } catch (e: Exception) {
+            log.error { e withMessage "FileServer start failed on port $port" }
+            throw e
+        }
         server = srv
         // resolvedConnectors() returns the actual OS-assigned port when port=0 was specified,
         // eliminating the TOCTOU race that would exist if we probed with ServerSocket(0) first.
-        return runBlocking { srv.engine.resolvedConnectors() }.first().port
+        val resolvedPort = runBlocking { srv.engine.resolvedConnectors() }.first().port
+        log.info { "started on port $resolvedPort, downloads → ${downloadsDir.absolutePath}" }
+        return resolvedPort
     }
 
     actual fun stop() {
         server?.stop(gracePeriodMillis = 500, timeoutMillis = 1_000)
         server = null
+        log.info { "stopped" }
     }
 }
 
@@ -61,14 +76,6 @@ private class JvmUploadStorage(
             File(destination).delete()
         } catch (_: Exception) {
         }
-    }
-
-    override fun logInfo(message: String) {
-        println("[FileServer] $message")
-    }
-
-    override fun logError(message: String) {
-        System.err.println("[FileServer] ERROR: $message")
     }
 }
 

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/security/DeviceKeyPair.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/security/DeviceKeyPair.jvm.kt
@@ -1,5 +1,8 @@
 package com.tubetoast.tether.security
 
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.warn
+import ru.pocketbyte.kydra.log.wrapper.withTag
 import java.io.File
 import java.io.IOException
 import java.nio.file.Files
@@ -8,6 +11,8 @@ import java.security.KeyFactory
 import java.security.KeyPairGenerator
 import java.security.spec.PKCS8EncodedKeySpec
 import java.security.spec.X509EncodedKeySpec
+
+private val log = KydraLog.withTag(default = "Tether.DeviceKeyPair")
 
 actual class DeviceKeyPair(
     private val configDir: File = File(System.getProperty("user.home"), ".config/tether"),
@@ -41,7 +46,7 @@ actual class DeviceKeyPair(
         return when {
             publicValid && privateValid -> publicKeyFile.readBytes()
             !publicValid && !privateValid -> {
-                System.err.println("WARN: device key pair corrupted, regenerating in $configDir")
+                log.warn { "device key pair corrupted, regenerating in $configDir" }
                 publicKeyFile.delete()
                 privateKeyFile.delete()
                 generateAndPersist(publicKeyFile, privateKeyFile)

--- a/composeApp/src/jvmMain/resources/simplelogger.properties
+++ b/composeApp/src/jvmMain/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.defaultLogLevel=warn

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -15,6 +15,7 @@ Product-side docs (vision, audience, features) live in [`docs/product/`](../prod
 - [UI Style Guide](ui-style-guide.md) — token tables, `TetherTheme` rule, Tabler Icons usage, motion specs, accessibility checklist.
 - [UI Brand Mark](ui-brand-mark.md) — `•—•` geometry, animation states, where the mark appears, and design rationale (why a line, not a knot or arrow).
 - [Testing](testing.md) — структура тестов по source sets, стиль (`runTest`/виртуальное время), особенности Apple-таргетов.
+- [Logging](logging.md) — KydraLog как единый KMP-фасад; именование `Tether.<Subsystem>`, уровни, DEBUG-гейтинг по платформам, тестовая тишина.
 
 ## Writing style for these guides
 
@@ -37,4 +38,5 @@ ADRs in [`adr/`](adr/) capture the *why* behind one-time architectural choices. 
 - [Apple FileServer engine](adr/adr-apple-fileserver-engine.md) — chose Ktor CIO Native over hand-rolled HTTP for the Apple-side `FileServer.actual`.
 - [Channel encryption](adr/adr-channel-encryption.md) — chose TLS-with-paired-key-pinning + SecureTransport on Apple. Includes 2026-05-16 Amendment with implementation-plan corrections.
 - [Hotspot-first Discovery](adr/adr-hotspot-discovery.md) — chose layered mDNS + `/hello` rendezvous + HTTP-subnet-scan + UDP-broadcast over raw-multicast-as-primary or Wi-Fi Direct / NAN. Motivated primarily by phone-hotspot transfer.
+- [Logging — KydraLog](adr/adr-logging-kydra.md) — chose KydraLog as the single KMP logging facade; SLF4J handled via `slf4j-simple` on JVM; per-platform DEBUG gates.
 

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -15,7 +15,7 @@ Product-side docs (vision, audience, features) live in [`docs/product/`](../prod
 - [UI Style Guide](ui-style-guide.md) — token tables, `TetherTheme` rule, Tabler Icons usage, motion specs, accessibility checklist.
 - [UI Brand Mark](ui-brand-mark.md) — `•—•` geometry, animation states, where the mark appears, and design rationale (why a line, not a knot or arrow).
 - [Testing](testing.md) — структура тестов по source sets, стиль (`runTest`/виртуальное время), особенности Apple-таргетов.
-- [Logging](logging.md) — KydraLog как единый KMP-фасад; именование `Tether.<Subsystem>`, уровни, DEBUG-гейтинг по платформам, тестовая тишина.
+- [Logging](logging.md) — KydraLog как единый KMP-фасад; именование `Tether.<Subsystem>`, уровни, DEBUG-гейтинг по платформам, тестовая тишина, политика sensitive-данных.
 
 ## Writing style for these guides
 

--- a/docs/engineering/adr/adr-logging-kydra.md
+++ b/docs/engineering/adr/adr-logging-kydra.md
@@ -1,0 +1,113 @@
+# Logging — KydraLog as the single KMP façade, SLF4J bridged via slf4j-simple
+
+**Status:** Accepted — 2026-05-23
+**Issue:** [#74](https://github.com/khmelevartem/tether/issues/74)
+
+## Context
+
+Logging in Tether before this decision is three disjoint practices: `System.err.println("WARN: …")` on Desktop / shared JVM, `android.util.Log.*` on Android, `NSLog(…)` on Apple. Code that legitimately lives in `commonMain` ([`FileServer`](../../../composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileServer.kt), [`FileClient`](../../../composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt), [`FileServerRoutes`](../../../composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileServerRoutes.kt)) cannot reach any of those directly; the current workaround is to delegate through callback methods on per-platform implementations (`UploadStorage.logInfo` / `UploadStorage.logError`). Levels are encoded as string prefixes, so they cannot be filtered at runtime.
+
+Ktor on JVM logs through SLF4J. With no provider on the classpath the CLI prints `SLF4J(W): No SLF4J providers were found.` at startup — a visible artefact of the same gap.
+
+The parent living doc that codifies the resulting rules is [`logging.md`](../logging.md). This ADR records *why* the chosen façade is KydraLog and how the eight sub-decisions inside #74 were resolved.
+
+## Decision drivers
+
+| Driver | Why it matters for Tether |
+|---|---|
+| `commonMain`-side logging | `FileServer` / `FileClient` / `FileServerRoutes` live in `commonMain`; the `UploadStorage` callback workaround should die. |
+| KMP coverage for our exact target set | `androidTarget`, `jvm("desktop")`, `iosArm64`, `iosSimulatorArm64`, `macosArm64`. A façade that drops one is unusable. |
+| Native sinks per platform | Logcat / OSLog / stderr respectively. A façade that prints through stdout on Android is half a solution. |
+| Footprint and dependency weight | The app already carries Ktor + Compose + Decompose. The logger should not double the surface. |
+| Configurable level filtering at startup | DEBUG must be silenceable in release without a recompile-only switch. |
+| Active maintenance | A logger that stopped getting Kotlin / Native updates would lock our target list. |
+| Ktor SLF4J slot on JVM | Whatever we choose has to resolve the `No SLF4J providers were found` warning. |
+| Avoid building our own façade | Time-cost; an `expect/actual Logger` plus per-platform writers is well-trodden ground. |
+
+## Considered options
+
+### Option 1 — KydraLog (chosen)
+
+`ru.pocketbyte.kydra:kydra-log:3.0.0`. Single multiplatform artefact, per-target writer classes (`AndroidLogger`, `AppleLogger`, `PrintLogger`), filtering and tagging via decorator wrappers (`.filtered`, `.withTag`), explicit `KydraLog.initDefault(level = …)` on each platform's entry point, auto-init fallback when init is skipped. KMP targets published match ours.
+
+Closes the common-side gap (one façade callable from `commonMain`), the per-platform sink gap (writers route to Logcat / OSLog / stderr natively), and the level-filter gap (`LogLevel` enum, decorator-chain filtering).
+
+Costs: one extra dependency; the project's SLF4J slot is still empty after adding it (handled separately, see decision below); auto-init can mask a missing explicit `initDefault` call, so reviewers must check entry-point wiring.
+
+### Option 2 — Napier (`io.github.aakira:napier`)
+
+Multiplatform façade with the same shape (per-platform `Antilog`s, tagged loggers, log-level filter). Coverage of our target set is comparable. Activity has slowed in 2024-2025; last release on Maven Central is 2.7.1 (Apr 2023).
+
+Closes the same gaps as KydraLog. Costs: stale release cadence — newer Kotlin / Native bumps would land late or not at all; library does not expose a writer chain as flexible as KydraLog's decorator pattern, so per-tag filtering is harder.
+
+### Option 3 — Kermit (`co.touchlab:kermit`)
+
+Touchlab's multiplatform logger; production-grade, larger surface (CrashKit integration, custom log writers, severity per logger). KMP coverage matches.
+
+Closes the same gaps. Costs: dependency weight is noticeably higher than KydraLog or Napier; we'd pay for CrashKit and remote-log surfaces we don't use; default `Logger.withTag` API ties the call site to a Kermit type, harder to swap later than a thin wrapper would be. The issue explicitly names KydraLog as the target — Kermit would require justifying the rejection of that direction.
+
+### Option 4 — SLF4J everywhere (via a thin KMP `expect/actual` wrapper on top)
+
+JVM ships SLF4J as a real provider (e.g. `logback-classic`), Android wraps Logcat via `slf4j-android`, Apple-side we'd have to roll our own `expect/actual` over OSLog because no SLF4J binding exists for Kotlin/Native. End up with one façade name but two implementations: SLF4J on JVM-family, custom on Apple-family.
+
+Closes the SLF4J warning trivially (real provider present on JVM). Costs: the Apple-side custom binding is the same work as picking an existing KMP logger; KMP coverage of `slf4j-android` is JVM-only — we'd be writing the multiplatform glue ourselves on top.
+
+### Option 5 — Status quo with `expect/actual Logger` of our own
+
+No external dependency. `expect fun logger(tag: String): Logger` in `commonMain`; `actual` per source set wraps Logcat / OSLog / `println`. Filtering and tagging written by us.
+
+Closes the common-side gap minimally. Costs: maintenance — every level enum, every decorator, every filter is ours to keep working across Kotlin / Native upgrades; the existing KMP libraries are exactly this code, already vendored. The "don't write your own KMP logger" sentence in the issue ("своё писать не надо") rejects this explicitly.
+
+## Decision
+
+**Adopt KydraLog 3.0.0 as the single logging façade across all source sets.** The library closes every driver in the table, ships writers for every Tether target without expect/actual on our side, and lets `commonMain` log directly — which removes the `UploadStorage.logInfo` / `logError` callback workaround.
+
+The eight sub-decisions called out by #74 resolve as follows:
+
+1. **Gradle coordinate and writers.** `ru.pocketbyte.kydra:kydra-log:3.0.0` as a single dependency. Platform writers (`AndroidLogger`, `AppleLogger`, `PrintLogger`) are part of that artefact — no per-target sub-artefacts to wire.
+
+2. **Source-set placement.** The KydraLog dependency goes in `commonMain` only; the artefact resolves per-target through KMP metadata, and `DefaultLoggerFactory.create()` picks the right writer on each platform via expect/actual inside the library. No separate writer dependency per source set.
+
+3. **Logger naming.** `Tether.<Subsystem>[.<Implementation>]` as proposed in #74, locked in [`logging.md`](../logging.md). Names are tags passed to `KydraLog.withTag(default = "…")` at the call site; KydraLog's tag mechanism accepts arbitrary strings without truncation.
+
+4. **DEBUG gating.** Per-platform single source of truth, set at writer initialisation: Android — `ApplicationInfo.FLAG_DEBUGGABLE`; Apple — `Platform.isDebugBinary`; Desktop — JVM system property `tether.log.debug` *or* env var `TETHER_LOG_DEBUG`. Two knobs on Desktop because the UI is launched via Gradle (property is natural) and the CLI is launched via the wrapper script (env var is natural); both resolve to the same DEBUG-on flag in code. Per-tag overrides are explicitly out — adding them would dilute the rule that level is the contract, not the configuration.
+
+5. **Ktor SLF4J warning.** Add `org.slf4j:slf4j-simple` (matched to Ktor's pinned `slf4j-api` version, currently 2.0.x) to `jvmMain`'s runtime classpath, configured with `org.slf4j.simpleLogger.defaultLogLevel=warn`. This eliminates the `No SLF4J providers were found` warning, leaves Ktor's framework logs visible only at WARN+, and avoids the maintenance cost of writing an SLF4J→KydraLog bridge (Ktor framework logs are sparse enough that double-sinking them adds noise without value). `slf4j-nop` was rejected because suppressing Ktor's own WARN/ERROR output would hide real problems (CIO engine warnings we want to see). A custom bridge (`SLF4JServiceProvider` → KydraLog) was rejected as disproportionate for the volume of Ktor log traffic this project produces.
+
+6. **Test logging strategy.** Test source sets install a no-op or WARN-threshold KydraLog writer in shared test setup (one helper per source-set group: `commonTest`, `jvmTest`, `appleTest`). Tests that need to assert against log output install an in-memory writer themselves in `@BeforeTest`. Per-test config is rejected as boilerplate.
+
+7. **`UploadStorage.logInfo` / `logError` callback removal.** Removed in the same PR that wires KydraLog. With KydraLog reachable from `commonMain`, the callbacks have no remaining caller — leaving them as dead interface members would invite re-introduction. The issue allows deferral; we decline the deferral because the marginal scope is small (two interface methods plus their two `actual` implementations) and the value of closing the workaround in the same PR is high.
+
+8. **Writer initialisation timing.** Each platform initialises at the same lifecycle hook: Android `Application.onCreate()`, Apple `MainViewController` constructor delegating to a shared `appleMain` helper, Desktop UI `DesktopBackend` (first construction), Desktop CLI as the first statement in `Main.kt`'s `run`. KydraLog's auto-init covers pre-init logging paths so events are not lost during startup races; reviewers still flag pre-init log calls because the level filter isn't applied yet.
+
+## Costs accepted
+
+1. **One more runtime dependency** (`kydra-log`) plus `slf4j-simple` on the JVM side. Footprint impact on Android APK / iOS framework size is on the order of 30-80 KB combined — measured against the existing Ktor + Compose + Decompose surface this is noise, but it is a non-zero ongoing maintenance dependency.
+2. **`slf4j-simple` is a different sink from KydraLog.** Ktor framework logs go to stderr through SLF4J's simple formatter; subsystem logs go through KydraLog's `PrintLogger`. Operators reading CLI stderr see two formats interleaved. Bridging them would be a non-trivial custom `SLF4JServiceProvider` — rejected above as disproportionate. Side effect: the doc reader should know that "all logs unified" means "all subsystem logs unified", with Ktor's own framework chatter remaining a thin second channel.
+3. **KydraLog's auto-init can hide a missing explicit `initDefault` call.** If a coder forgets to wire startup init, logs still flow at the default level — masking the configuration bug. Mitigated by the entry-point checklist in `logging.md` and reviewer attention; not enforced by the type system.
+4. **KydraLog has a smaller community than Kermit.** If KydraLog's release cadence stalls on a future Kotlin major bump, we'd carry a vendored patch or migrate. The Revisit triggers below cover this.
+5. **DEBUG gating is per-platform-mechanism, not one cross-platform knob.** A developer enabling DEBUG locally has three different switches to remember (build flag on Android, build config on Apple, env var / property on Desktop). The alternative — a runtime config file — was rejected as adding a new persistence surface for a developer convenience.
+
+## Consequences
+
+- The `UploadStorage` interface in [`FileServerRoutes.kt`](../../../composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileServerRoutes.kt) loses its `logInfo` / `logError` members; `JvmUploadStorage` ([`FileServer.kt`](../../../composeApp/src/jvmMain/kotlin/com/tubetoast/tether/network/FileServer.kt)) and `AppleUploadStorage` ([`FileServer.apple.kt`](../../../composeApp/src/appleMain/kotlin/com/tubetoast/tether/network/FileServer.apple.kt)) lose their `override`s. Callers in `FileServerRoutes` go through `KydraLog.withTag("Tether.FileServerRoutes")` instead.
+- `commonMain` gains real INFO/ERROR coverage in `FileServer` start/stop, `FileServerRoutes` upload paths, and `FileClient.doSend` — events that today are invisible until a platform wrapper re-emits them.
+- `gradle/libs.versions.toml` gains a `kydraLog` version entry and matching `kydra-log` library entry; a `slf4j-simple` entry is added under the JVM group.
+- Future subsystems (Decompose Components per [`presentation-layer.md`](../presentation-layer.md)) inherit the façade automatically — no separate logging work item.
+- `./gradlew :composeApp:runDesktopCli -q` no longer prints `SLF4J(W): No SLF4J providers were found` (slf4j-simple provider present on JVM classpath).
+- The acceptance grep in [`logging.md`](../logging.md) becomes a standing check; any future re-introduction of raw `println` / `Log.*` / `NSLog` is a reviewable diff hunk.
+
+## Revisit if
+
+- **KydraLog releases stop covering current Kotlin / Native versions** (a Kotlin major bump ships without a corresponding KydraLog release within two minor versions). Trigger: evaluate Kermit; the migration cost is bounded because all logger access is through `KydraLog.withTag` calls localised to one line per subsystem.
+- **Operators need structured (JSON / key=value) logs** for log aggregation (Loki, CloudWatch). KydraLog writers emit strings; structured output would need either a custom writer or a different façade. Out of scope today.
+- **Ktor framework logs become load-bearing** for production support (e.g. we need INFO from the CIO engine in user-submitted logs). Trigger: replace `slf4j-simple` with a custom `SLF4JServiceProvider` that forwards into KydraLog, unifying the two sink formats. Until that pressure exists, the asymmetry is cheaper than the bridge.
+- **iOS-as-sender background networking** ([ios-background-networking.md](../../knowledge/ios-background-networking.md)) ships. Background tasks log into OSLog from a different process state; verify `AppleLogger`'s OSLog subsystem still routes correctly and tighten the writer init if it does not.
+
+## References
+
+- [logging.md](../logging.md) — the living doc this ADR underpins.
+- [KydraLog README & skill](https://github.com/PocketByte/kotlin-kydra-log/blob/master/.claude/skills/kydra-log/SKILL.md) — initialisation API, writer list, decorator chain.
+- [SLF4J 2.0 provider mechanism](https://www.slf4j.org/manual.html#swapping) — context for the `slf4j-simple` choice.
+- Related ADRs: [adr-network-stack.md](adr-network-stack.md) (Ktor framework that owns the SLF4J slot we fill), [adr-presentation-and-navigation.md](adr-presentation-and-navigation.md) (future Decompose components inherit this façade).
+- Issue [#74](https://github.com/khmelevartem/tether/issues/74) — full call-site inventory and DoD.

--- a/docs/engineering/dependency-injection.md
+++ b/docs/engineering/dependency-injection.md
@@ -122,6 +122,8 @@ If a component is supposed to be a singleton, it is created exactly once in the 
 
 The composition root is the only place that knows lifecycles. Everywhere else, you receive what's already alive.
 
+The logging façade ([`KydraLog`](logging.md)) is the documented exception: a process-global cross-cutting infra singleton initialised once per platform entry point, accessed directly (`KydraLog.withTag(...)`) without passing through the graph. Rationale and trade-offs in [`adr/adr-logging-kydra.md`](adr/adr-logging-kydra.md).
+
 ### 4. Don't instantiate dependencies inside composables
 
 ❌

--- a/docs/engineering/logging.md
+++ b/docs/engineering/logging.md
@@ -1,0 +1,89 @@
+# Logging
+
+Tether logs through one Kotlin Multiplatform façade — [KydraLog](https://github.com/PocketByte/kotlin-kydra-log) — so that `commonMain` code can log directly and every platform writes to its native sink (Logcat on Android, OSLog on Apple, stderr on JVM). Why this façade and not another: [adr-logging-kydra.md](adr/adr-logging-kydra.md).
+
+The rest of this doc is the contract any new logging call site must respect.
+
+## Goal
+
+A reader debugging a cross-platform issue sees the same logger names and the same level semantics in Logcat, Console.app / Xcode, and Desktop stderr. The CLI starts without spurious framework warnings. Release builds do not leak DEBUG. Tests do not leak any log noise into CI output.
+
+## Logger names
+
+Every named logger uses the prefix `Tether.` followed by a dot-separated path that identifies the subsystem and, when more than one implementation of the same subsystem exists per platform, the implementation:
+
+- One name per source-set-shared subsystem (`Tether.FileServer`, `Tether.FileClient`).
+- When the same subsystem has parallel implementations whose logs must be distinguishable at a glance, the implementation joins the path (`Tether.MdnsDiscovery.JmDNS`, `Tether.MdnsDiscovery.Bonjour`).
+- Platform-only subsystems carry the platform when no common-side sibling exists (`Tether.FGService` lives only on Android — no need to qualify; `Tether.MdnsDiscovery.Android` qualifies because cross-platform peers exist).
+
+The name is the **tag** passed to the underlying writer. On Android it appears in Logcat's tag column, on Apple in the OSLog subsystem column, on Desktop as the prefix in the printed line. Truncate nothing in source — Logcat's 23-char tag limit is no longer enforced on modern Android, and a long-but-greppable name is more useful than a short cryptic one.
+
+## Levels
+
+Four levels, present-tense semantics:
+
+- **ERROR** — an operation we promised the caller has failed and the user-visible outcome is degraded. Always logged. Includes a short message; stack traces go through the same call.
+- **WARNING** — something the system recovered from, or a configuration that will bite later if not addressed. Always logged.
+- **INFO** — lifecycle events the operator wants to see in production support cases: service start/stop, peer paired, transfer started/finished with byte count.
+- **DEBUG** — per-step internal state useful for engineering only. Off by default in every configuration except explicit local opt-in.
+
+VERBOSE is not used. If a DEBUG call site is too chatty for routine debugging, split the subsystem's logger and gate the chatty half with a separate tag filter, do not introduce a fifth level.
+
+The level encodes the **operational meaning**, not the size of the message. A two-line ERROR is still ERROR; a multi-paragraph DEBUG is still DEBUG.
+
+## DEBUG gating
+
+DEBUG is off by default. Per platform:
+
+- **Android** — DEBUG is enabled when the running build is `debuggable` (`ApplicationInfo.FLAG_DEBUGGABLE`). Release APKs go to INFO. No env var on Android; the build flag is the single source of truth.
+- **Apple (iOS + macOS)** — DEBUG is enabled when the Kotlin/Native binary is built in `DEBUG` configuration (`Platform.isDebugBinary`). Release framework goes to INFO.
+- **Desktop (JVM)** — DEBUG is enabled when the JVM system property `tether.log.debug` is set (e.g. `-Dtether.log.debug=true`) **or** the environment variable `TETHER_LOG_DEBUG` is non-empty. Both knobs exist because the CLI is launched via the wrapper shell script (env var is natural there) and the Compose UI is launched via Gradle (system property is natural there).
+
+The single-source-of-truth rule: each platform has exactly one gating mechanism resolved at writer initialisation. Per-tag overrides are *not* supported — if a subsystem needs a different default, raise its WARNING-or-higher signal in code, do not invent a new level threshold.
+
+## Writer initialisation
+
+Each platform initialises KydraLog exactly once at process start, before any subsystem can log:
+
+- **Android** — `Application.onCreate()`.
+- **Apple** — the `MainViewController` constructor on iOS and the equivalent entry point on macOS, both delegating to one shared `initLogging()` in `appleMain`.
+- **Desktop UI** — `DesktopBackend` initialisation (before subsystems are constructed).
+- **Desktop CLI** — first statement in `Main.kt`'s `run` block, before any Clikt-managed work.
+
+`commonMain` code never calls `KydraLog.init*`. Initialisation is platform-side; common-side code only obtains tagged logger handles.
+
+If a subsystem logs before initialisation runs, KydraLog's auto-init path catches it with the platform default — events are not lost. Reviewers should still flag pre-init logging in PRs because the level filter is not yet applied at that point.
+
+## Forbidden idioms in production code
+
+These idioms were the pre-KydraLog status quo and must not return:
+
+- `System.err.println(...)` / `System.out.println(...)` / `println(...)` for diagnostic output. The only `println` survivors in `composeApp/src` live in [`desktopCli/.../Main.kt`](../../composeApp/src/desktopCli/kotlin/com/tubetoast/tether/Main.kt) where `output: (String) -> Unit` / `errorOutput: (String) -> Unit` are **product output channels** of the CLI, not logging. They are injected by tests; replacing them with a logger breaks CLI UX and test seeds.
+- `android.util.Log.*` directly. Always goes through KydraLog so the tag namespace and level filter apply.
+- `platform.Foundation.NSLog(...)` directly. Same reason.
+- Encoding the level inside the message string (`"WARN: ..."`, `"DEBUG: ..."`). The level is a writer parameter, never a literal.
+
+A grep is the standing acceptance check:
+
+```bash
+rg "System\.(err|out)\.println" composeApp/src --glob '!**/desktopCli/**'
+rg "android\.util\.Log" composeApp/src
+rg "NSLog" composeApp/src
+```
+
+All three should return no production hits. Test source sets may print freely.
+
+## Test logging
+
+Test source sets (`commonTest`, `jvmTest`, `androidUnitTest`, `desktopTest`, `appleTest`) must not produce log output during `./gradlew allTests`. The writer initialised in test setup is a no-op writer or a WARNING-threshold writer — chosen at test-helper level, not per test. A test that needs to assert against logged content uses an in-memory writer it installs itself in `@BeforeTest`.
+
+## DEBUG content discipline
+
+DEBUG carries operational metadata, never payload contents. For file transfer: file name, byte count, peer host:port, response status are DEBUG-eligible. The transferred bytes themselves are not. The contract is enforced at write-site, not at writer level — there is no PII filter; reviewers reject diff hunks that violate it.
+
+## What this doc does *not* commit to
+
+- The exact KydraLog version. Pinned in [`gradle/libs.versions.toml`](../../gradle/libs.versions.toml).
+- The full enumeration of logger names. New subsystems add their own following the convention above; the canonical list is whatever `rg 'KydraLog\.withTag|logger\(' composeApp/src` returns at HEAD.
+- The Ktor framework log level. Ktor logs through SLF4J on JVM; the binding choice and its threshold are recorded in the ADR — concrete level may be tuned without amending this doc.
+- Future structured-logging (key=value, JSON) output. KydraLog writers emit plain strings today; introducing structured output is a separate decision.

--- a/docs/engineering/logging.md
+++ b/docs/engineering/logging.md
@@ -77,9 +77,21 @@ All three should return no production hits. Test source sets may print freely.
 
 Test source sets (`commonTest`, `jvmTest`, `androidUnitTest`, `desktopTest`, `appleTest`) must not produce log output during `./gradlew allTests`. The writer initialised in test setup is a no-op writer or a WARNING-threshold writer — chosen at test-helper level, not per test. A test that needs to assert against logged content uses an in-memory writer it installs itself in `@BeforeTest`.
 
-## DEBUG content discipline
+## Sensitive data
 
-DEBUG carries operational metadata, never payload contents. For file transfer: file name, byte count, peer host:port, response status are DEBUG-eligible. The transferred bytes themselves are not. The contract is enforced at write-site, not at writer level — there is no PII filter; reviewers reject diff hunks that violate it.
+Logs from this app land on the same device the user runs it on — Logcat on Android, OSLog on Apple, stderr on Desktop. There is no central aggregation. The threat model is therefore narrow: a bug report or screen share exfiltrates whatever was in the log at that moment, and a separate process with log-read permission can see it. Logs are not a network exfiltration channel.
+
+Three categories never appear in any log line at any level:
+
+- **Payload bytes** — file content, stream chunks, hex dumps, `toString()` of binary buffers.
+- **Private cryptographic material** — raw bytes, base64, PEM.
+- **Auth tokens, session IDs, nonces** — including short prefixes (`token=abc1...`); a prefix is enough to scope an attack. Public keys and their fingerprints are fine — they are identifying but not exfiltratable.
+
+Local-identifier values — file names, absolute paths, peer device names (user-set), peer host:port — may appear at any level for operator correlation. Reviewer judgement, not a hard rule: keep them out of WARN/ERROR when an alternative correlator (logger tag, opaque id, fingerprint) carries the same information. Authors should remember that logs surfaced via bug reports leak whatever they contain.
+
+Exception messages reaching the log are inspected for embedded values before they go in. A library `IllegalArgumentException` may carry a secret in its message; log a synthetic summary and keep the original on the return path only.
+
+The contract is enforced at the write-site; there is no runtime filter. Reviewers reject diff hunks that violate the three never categories.
 
 ## What this doc does *not* commit to
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,8 @@
 [versions]
 agp = "8.11.2"
 clikt = "4.4.0"
+kydraLog = "3.0.0"
+slf4jSimple = "2.0.17"
 decompose = "3.2.2"
 essenty = "2.2.1"
 android-compileSdk = "36"
@@ -29,6 +31,8 @@ slf4j = "1.7.36"
 
 [libraries]
 clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
+kydra-log = { module = "ru.pocketbyte.kydra:kydra-log", version.ref = "kydraLog" }
+slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4jSimple" }
 jmdns = { module = "org.jmdns:jmdns", version.ref = "jmdns" }
 jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,6 @@ ktor = "3.1.3"
 ktlint = "1.3.1"
 ktlint-gradle = "14.2.0"
 material3 = "1.10.0-alpha05"
-slf4j = "1.7.36"
 
 [libraries]
 clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
@@ -69,7 +68,6 @@ compose-rules-ktlint = { module = "io.nlopez.compose.rules:ktlint", version.ref 
 ktlint-rule-engine-core = { module = "com.pinterest.ktlint:ktlint-rule-engine-core", version.ref = "ktlint" }
 ktlint-cli-ruleset-core = { module = "com.pinterest.ktlint:ktlint-cli-ruleset-core", version.ref = "ktlint" }
 ktlint-rule-engine = { module = "com.pinterest.ktlint:ktlint-rule-engine", version.ref = "ktlint" }
-slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 decompose-core = { module = "com.arkivanov.decompose:decompose", version.ref = "decompose" }
 decompose-extensions-compose = { module = "com.arkivanov.decompose:extensions-compose", version.ref = "decompose" }
 essenty-lifecycle-coroutines = { module = "com.arkivanov.essenty:lifecycle-coroutines", version.ref = "essenty" }


### PR DESCRIPTION
**Что / зачем.** Единый KMP-логгер (KydraLog) вместо трёх разных платформенных практик — `System.err.println` с префиксами на JVM/Desktop, `android.util.Log` на Android, `NSLog` на Apple. Common-код теперь логирует напрямую без callback-обходов (`UploadStorage.logInfo/logError` упразднены).

**👀 Sanity-check.**
- Init у KydraLog — `initOrIgnore` во всех трёх actuals. Это сознательное решение: Robolectric пересоздаёт `TetherApp` на каждый тест-класс, второй `initDefault` бросает `IllegalStateException`; `initOrIgnore` тихо no-op, продакшен-семантика та же (первый init выигрывает).
- `desktopCli/.../Main.kt` `println` / `System.err::println` намеренно оставлены — это инжектированные `output`/`errorOutput` каналы продуктового вывода CLI, не логирование (явно в issue Out of scope).
- Ktor SLF4J-warning убран `slf4j-simple` биндингом на JVM (уровень WARN). Альтернативы (`slf4j-nop`, кастомный bridge) отклонены в ADR.
- DEBUG включается per-платформа: Android — `FLAG_DEBUGGABLE`; Apple — `Platform.isDebugBinary`; Desktop — JVM property `tether.log.debug` или env `TETHER_LOG_DEBUG`.
- Тесты замолчены через `suppressTestLogs()` + идемпотентный init.

**Scope.**
- 📎 задето: `docs/engineering/logging.md` (новый living doc), `docs/engineering/adr/adr-logging-kydra.md` (новый ADR), `docs/engineering/README.md` (index).

Closes #74