### PR TITLE
retro from #227: tighten document re-entry + architect artifact warrant

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -77,7 +77,15 @@ If during convergence you realise the palette was incomplete or the answers reve
 
 ### Step 5 — Decide artifact scope
 
-You now know whether you need:
+**Artifact-warrant test, first.** Before picking a layer, audit your converged design against existing siblings — the relevant spec, ux brief, neighbouring living docs, parent / sibling ADRs, the issue body itself. For each rule you'd put on paper ask: «is this already covered, in equivalent shape, somewhere a future coder will reach?». What survives the cut is the warrant for a new artifact.
+
+Possible outcomes:
+
+- **≥ 2–3 paragraphs of net-new content survive** — a new or extended artifact is warranted; pick a layer below.
+- **< 2 paragraphs survive, or only single-sentence rules** — no new artifact. Either add the surviving rules as one-line additions to the relevant existing engineering doc, or surface the converged-decision summary in the issue body / PR description, and finish. **A document whose every section retells siblings is worse than no document** — the next reader has to distinguish new info from retelling, which is harder than reading the siblings directly. This applies even when the design work was non-trivial; the work lives in the converged decision and in the resulting code review, not in restating settled material.
+
+If the test passes, pick the layer:
+
 - **just a living doc** — the mechanism is the new normal; no alternative-versus-alternative history worth recording (e.g. introducing a new module without a contested choice);
 - **a living doc + an ADR** — the choice was contested and the rejected branches have value for future readers («why didn't we use X?» will be asked);
 - **an ADR amending an existing one** — the original decision still holds but a new constraint forces an addendum (use `## Amendment YYYY-MM-DD` section, don't rewrite);

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -77,12 +77,12 @@ If during convergence you realise the palette was incomplete or the answers reve
 
 ### Step 5 — Decide artifact scope
 
-**Artifact-warrant test, first.** Before picking a layer, audit your converged design against existing siblings — the relevant spec, ux brief, neighbouring living docs, parent / sibling ADRs, the issue body itself. For each rule you'd put on paper ask: «is this already covered, in equivalent shape, somewhere a future coder will reach?». What survives the cut is the warrant for a new artifact.
+**Layer-fit test, first.** Before picking an engineering-layer artifact, ask of every rule from your converged design: **does this rule belong on the engineering layer, or on the layer that already owns it?** Product framing belongs in the spec, interaction model in the ux brief, issue-specific scope in the issue body, code-level invariants in code. An engineering doc that restates any of those is misplaced — regardless of length. A short doc holding one genuinely engineering rule is fine; a long doc retelling spec / ux / issue is not.
 
 Possible outcomes:
 
-- **≥ 2–3 paragraphs of net-new content survive** — a new or extended artifact is warranted; pick a layer below.
-- **< 2 paragraphs survive, or only single-sentence rules** — no new artifact. Either add the surviving rules as one-line additions to the relevant existing engineering doc, or surface the converged-decision summary in the issue body / PR description, and finish. **A document whose every section retells siblings is worse than no document** — the next reader has to distinguish new info from retelling, which is harder than reading the siblings directly. This applies even when the design work was non-trivial; the work lives in the converged decision and in the resulting code review, not in restating settled material.
+- **Some rule lives on the engineering layer and is not yet captured** — a new or extended artifact is warranted, even if the artifact ends up a single paragraph. Pick a layer below.
+- **Every rule already belongs on another layer** — no new engineering artifact. Either extend the right-layer artifact (spec / ux brief / sibling living doc) or surface the converged-decision summary in the issue body / PR description, and finish. Misrouted retelling in `docs/engineering/` wastes the reader's time and creates a drift surface — the next reader has to distinguish what's truly engineering-layer from what's retold from elsewhere.
 
 If the test passes, pick the layer:
 

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -77,14 +77,17 @@ If during convergence you realise the palette was incomplete or the answers reve
 
 ### Step 5 — Decide artifact scope
 
-**Layer-fit test, first.** Before picking an engineering-layer artifact, ask of every rule from your converged design: **does this rule belong on the engineering layer, or on the layer that already owns it?** Product framing belongs in the spec, interaction model in the ux brief, issue-specific scope in the issue body, code-level invariants in code. An engineering doc that restates any of those is misplaced — regardless of length. A short doc holding one genuinely engineering rule is fine; a long doc retelling spec / ux / issue is not.
+**Route each rule from your converged design to the layer that owns it:**
 
-Possible outcomes:
+- product framing → the spec
+- interaction model → the ux brief
+- issue-specific scope or follow-up → the issue body / PR description
+- code-level invariant → the code itself
+- engineering-layer rule (mechanism, library coordinate, lifecycle invariant, cross-platform contract) → a `docs/engineering/` artifact
 
-- **Some rule lives on the engineering layer and is not yet captured** — a new or extended artifact is warranted, even if the artifact ends up a single paragraph. Pick a layer below.
-- **Every rule already belongs on another layer** — no new engineering artifact. Either extend the right-layer artifact (spec / ux brief / sibling living doc) or surface the converged-decision summary in the issue body / PR description, and finish. Misrouted retelling in `docs/engineering/` wastes the reader's time and creates a drift surface — the next reader has to distinguish what's truly engineering-layer from what's retold from elsewhere.
+A new or extended `docs/engineering/` artifact is warranted only if at least one rule routes to the last category and is not already captured by a sibling. If every rule routes elsewhere, extend the right-layer artifact (or just record the decision in the issue / PR description) — no engineering artifact in this pass. Length is not the test; layer fit is. A single-paragraph engineering doc with one genuine rule is fine.
 
-If the test passes, pick the layer:
+When the engineering artifact is warranted, pick its flavor:
 
 - **just a living doc** — the mechanism is the new normal; no alternative-versus-alternative history worth recording (e.g. introducing a new module without a contested choice);
 - **a living doc + an ADR** — the choice was contested and the rejected branches have value for future readers («why didn't we use X?» will be asked);

--- a/.claude/skills/document/SKILL.md
+++ b/.claude/skills/document/SKILL.md
@@ -22,7 +22,7 @@ Issue number `<N>`.
 Skill идемпотентен по issue. На каждом вызове первым делом проверь `gh pr list --search "issue:#<N>" --state open`:
 
 - **PR нет** → стартуй Step 1.
-- **PR есть и открыт** → ты в pull-request feedback итерации. Прочитай существующие human-комменты на PR (`gh api repos/<owner>/<repo>/pulls/<PR>/comments` + `gh pr view <PR> --comments`). Прогон **обязан** включать на свежем diff'е (`docs/` + `.claude/`): Step 4 (consistency pass) → Step 5 (review wave). Из дисциплины ничего пропускать нельзя.
+- **PR есть и открыт** → ты в pull-request feedback итерации. Прочитай **все** human-комменты на PR (`gh api repos/<owner>/<repo>/pulls/<PR>/comments` + `gh pr view <PR> --comments`) и для каждого определи статус: адресован в коммитах после него — или нет. **Дата создания не определяет актуальность** — фильтровать комменты по `created_at > <дата-прошлого-прогона>` запрещено, потому что неадресованный коммент остаётся актуальным независимо от того, насколько он старый. **Counted is not read** — выдача `length`/счётчика без выгрузки `body` каждого коммента не считается прочтением; пока неадресованные комменты не отработаны, consistency wave (Step 4) и review wave (Step 5) не запускаются, иначе обе пройдут впустую на diff'е, который надо переделать. Прогон **обязан** включать на свежем diff'е (`docs/` + `.claude/`): Step 4 (consistency pass) → Step 5 (review wave).
 
 Шаг 6 (commit + present + push) в re-entry упрощается: коммит идёт в существующую ветку, force-push не нужен, новый PR не создавать.
 


### PR DESCRIPTION
**Что / зачем.** Два системных пробела всплыли в работе по #227.

1. `/document` re-entry прочёл счётчик комментариев, не тело — inline-комменты из `reviews[]` пропустились. `/implement` иммунен потому, что требует per-comment классификации («адресован / нет») — паттерн перенесён в `/document` + добавлено явное «counted is not read».
2. `architect` сгенерировал `docs/engineering/file-transfer.md` — каждая секция оказалась retelling-ом ux-brief / spec / issue body. Step 5 «Decide artifact scope» спрашивает *какой слой*, но не *warrant'ит ли вообще создание*. Добавлен artifact-warrant test до выбора слоя: net-new < 2-3 параграфов после sibling-aware cut → артефакт не создаётся.

**Scope.**
- 📎 задето: `.claude/skills/document/SKILL.md`, `.claude/agents/architect.md`.
- ❌ не трогал: `/implement` (per-comment классификация уже структурно защищает от «counted is not read» trap'а).

Retro по PR #227 / issue #226 (#226 уже закрыт merge'ем #227).