### PR TITLE
#242: prepare-commit-msg restores subject on any non-`#<N>:` first line

### DIFF
--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -84,13 +84,14 @@ echo "✅ Pre-push hook installed at $PUSH_HOOK_FILE"
 # prepare-commit-msg: restore commit subject lost during `git rebase --continue`
 #
 # Symptom: after resolving a conflict and running `git rebase --continue`,
-# the resulting commit has only the `Co-Authored-By` trailer as its subject,
-# the original subject line is gone. Reproducible in Claude Code's environment,
-# likely caused by a GIT_EDITOR that truncates COMMIT_EDITMSG.
+# COMMIT_EDITMSG loses its subject line — the first meaningful line is either
+# a trailer or plain body text, never the original `#<N>: ...` subject.
+# Reproducible in Claude Code's environment, likely caused by a GIT_EDITOR
+# that truncates COMMIT_EDITMSG.
 #
-# Fix: when we detect this corruption (first meaningful line is a known trailer),
-# restore the message from `$GIT_DIR/rebase-merge/message`, which git itself
-# populates with the original commit message before invoking the editor.
+# Fix: when the first meaningful line of COMMIT_EDITMSG does not match our
+# commit convention `#<N>: ...`, restore from `$GIT_DIR/rebase-merge/message`,
+# which git populates with the original commit message before invoking the editor.
 # ---------------------------------------------------------------------------
 PREPARE_HOOK_FILE="$HOOK_DIR/prepare-commit-msg"
 
@@ -102,14 +103,14 @@ COMMIT_MSG_FILE="$1"
 GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
 REBASE_MSG="$GIT_DIR/rebase-merge/message"
 
-# Only act during an in-progress rebase that has a saved original message
 [ -f "$REBASE_MSG" ] || exit 0
 
-# First meaningful line (skip comments and blanks)
-FIRST_LINE=$(grep -v '^#' "$COMMIT_MSG_FILE" | grep -v '^[[:space:]]*$' | head -1)
+# Strip git template comments ("# " or bare "#") and blank lines.
+# Our commit subjects start with "#<digits>:" and survive this filter.
+FIRST_LINE=$(grep -vE '^#([[:space:]]|$)' "$COMMIT_MSG_FILE" | grep -v '^[[:space:]]*$' | head -1)
 
-# If the subject looks like a trailer, the original subject was lost — restore it.
-if echo "$FIRST_LINE" | grep -qiE '^(Co-Authored-By|Signed-off-by|Reviewed-by|Acked-by|Tested-by|Helped-by|Reported-by):'; then
+# Restore unless the first meaningful line already matches `#<N>: ...`.
+if ! echo "$FIRST_LINE" | grep -qE '^#[0-9]+:'; then
   cp "$REBASE_MSG" "$COMMIT_MSG_FILE"
   echo "ℹ️  prepare-commit-msg: restored subject from rebase-merge/message" >&2
 fi


### PR DESCRIPTION
**Что / зачем.** Хук восстанавливал subject из `rebase-merge/message` только когда первая значимая строка COMMIT_EDITMSG — known trailer (`Co-Authored-By:` и т.п.). Если subject терялся в форме «первая строка — обычный body-текст» (как в PR #235), хук молча пропускал коммит, и subject уезжал в historу как есть. Теперь триггер — «первая значимая строка не совпадает с конвенцией `#<N>: ...`».

Заодно фильтр template-комментов сузился с `^#` до `^# ` / `^#$`, чтобы наш subject `#42: ...` сам не отфильтровывался при чтении первой строки.

**👀 Sanity-check.**
- `scripts/install-hooks.sh` — единственный источник правды для хуков; правка идёт в heredoc, после `bash scripts/install-hooks.sh` развёртывается в `.git/hooks/prepare-commit-msg`.
- Проверено вручную на 4 кейсах: (1) первая строка — body-текст → restore; (2) первая строка — trailer → restore; (3) корректный `#42: ...` subject → no-op; (4) `#42: ...` + git template comments → no-op.

Closes #242