### PR TITLE
#41: macOS native entry point — runnable kexe with FileServer + mDNS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ All git naming in English. **Все commit messages обязаны начина�
 ./gradlew :composeApp:runDesktopCli -q           # Desktop CLI (dev runner)
 ./gradlew :composeApp:run -q                     # Desktop Compose UI (Compose plugin default)
 ./gradlew :composeApp:assembleDebug              # Android APK
+./gradlew :composeApp:runDebugExecutableMacosArm64 -q   # macOS native (Apple mDNS)
 ```
 
 Desktop исходники разделены на два source set: `desktopMain` — shared backend + Compose UI (Clikt недоступен), `desktopCli` — CLI точка входа (видит `desktopMain` через `associateWith`, Clikt только здесь). Desktop distribution (`packageReleaseDistributionForCurrentOS`) пакует UI. CLI устанавливается через `installCli`.

--- a/README.md
+++ b/README.md
@@ -72,11 +72,13 @@ APK — в `composeApp/build/outputs/apk/debug/`. Или запускай run-к
 
 ### macOS (Apple Silicon)
 
-`macosArm64` компилируется в native binary. Запуск — через IDE run-конфигурацию или Xcode. Чтобы проверить mDNS без UI:
+`macosArm64` компилируется в native binary. Стартует `FileServer` + mDNS-дискавери без Compose UI.
 
 ```bash
-dns-sd -B _tether._tcp.    # должно появиться _tether._tcp.
+./gradlew :composeApp:runDebugExecutableMacosArm64 -q
 ```
+
+Проверка дискавери: `dns-sd -B _tether._tcp.` — должен появиться `_tether._tcp.`
 
 ### Все таргеты разом
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -70,7 +70,13 @@ kotlin {
 
     // macosArm64 covers all Apple Silicon Macs (2020+).
     // macosX64 is deprecated in Kotlin 2.3 — add it back if Intel Mac support is needed.
-    macosArm64()
+    macosArm64 {
+        binaries {
+            executable {
+                entryPoint = "com.tubetoast.tether.main"
+            }
+        }
+    }
 
     // jvm("desktop") creates desktopMain as the leaf source set for the Desktop JVM target.
     // Combined with the custom hierarchy above, jvmMain becomes the intermediate parent

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/logging/Logging.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/logging/Logging.kt
@@ -1,12 +1,16 @@
 package com.tubetoast.tether.logging
 
-import ru.pocketbyte.kydra.log.DefaultLoggerFactory
+import ru.pocketbyte.kydra.log.AppleLogger
 import ru.pocketbyte.kydra.log.KydraLog
 import ru.pocketbyte.kydra.log.LogLevel
+import ru.pocketbyte.kydra.log.PrintLogger
+import ru.pocketbyte.kydra.log.collection.LoggersSet
 import ru.pocketbyte.kydra.log.wrapper.filtered
 import ru.pocketbyte.kydra.log.wrapper.initOrIgnore
 
+// PrintLogger covers headless macOS-native runs and Xcode console; AppleLogger keeps OSLog
+// the canonical sink so Console.app and TestFlight crash reports still receive structured logs.
 actual fun initTetherLogging(debugEnabled: Boolean) {
     val level = if (debugEnabled) LogLevel.DEBUG else LogLevel.INFO
-    KydraLog.initOrIgnore(DefaultLoggerFactory.create().filtered(level))
+    KydraLog.initOrIgnore(LoggersSet(AppleLogger(), PrintLogger()).filtered(level))
 }

--- a/composeApp/src/iosMain/kotlin/com/tubetoast/tether/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/com/tubetoast/tether/MainViewController.kt
@@ -11,12 +11,18 @@ import com.tubetoast.tether.di.DefaultIosAppConfig
 import com.tubetoast.tether.di.IosAppContainer
 import com.tubetoast.tether.logging.initLogging
 import com.tubetoast.tether.presentation.RootContent
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.error
+import ru.pocketbyte.kydra.log.wrapper.withTag
+
+private val log = KydraLog.withTag(default = "Tether.Main.iOS")
 
 @Suppress("ktlint:standard:function-naming")
 fun MainViewController() = run {
@@ -27,7 +33,12 @@ fun MainViewController() = run {
     ComposeUIViewController {
         DisposableEffect(Unit) {
             lifecycle.resume()
-            val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+            lateinit var scope: CoroutineScope
+            val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
+                log.error { "startup failed: ${throwable.message ?: throwable}" }
+                scope.cancel()
+            }
+            scope = CoroutineScope(SupervisorJob() + Dispatchers.Main + exceptionHandler)
             scope.launch {
                 container.nameStore.init()
                 val name = container.nameStore.name.first()

--- a/composeApp/src/macosMain/kotlin/com/tubetoast/tether/Main.macos.kt
+++ b/composeApp/src/macosMain/kotlin/com/tubetoast/tether/Main.macos.kt
@@ -1,19 +1,38 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
 package com.tubetoast.tether
 
 import com.tubetoast.tether.di.DefaultMacosAppConfig
 import com.tubetoast.tether.di.MacosAppContainer
 import com.tubetoast.tether.logging.initLogging
+import kotlinx.cinterop.staticCFunction
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import platform.CoreFoundation.CFRunLoopGetMain
 import platform.CoreFoundation.CFRunLoopRun
+import platform.CoreFoundation.CFRunLoopStop
+import platform.posix.SIGINT
+import platform.posix.SIGTERM
+import platform.posix.signal
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.error
+import ru.pocketbyte.kydra.log.wrapper.withTag
+
+private val log = KydraLog.withTag(default = "Tether.Main.macOS")
 
 fun main() {
     initLogging()
     val container = MacosAppContainer(DefaultMacosAppConfig())
-    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        log.error { "startup failed: ${throwable.message ?: throwable}" }
+        CFRunLoopStop(CFRunLoopGetMain())
+    }
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main + exceptionHandler)
     scope.launch {
         container.nameStore.init()
         val name = container.nameStore.name.first()
@@ -21,6 +40,16 @@ fun main() {
         container.mdnsDiscovery.start(name, port = port)
         container.nameRepublisher.start(scope)
     }
+
+    val stopRunLoop = staticCFunction<Int, Unit> { _ -> CFRunLoopStop(CFRunLoopGetMain()) }
+    signal(SIGINT, stopRunLoop)
+    signal(SIGTERM, stopRunLoop)
+
     // NSNetService callbacks are dispatched via the run loop — without this the process exits before discovery fires.
     CFRunLoopRun()
+
+    container.nameRepublisher.stop()
+    container.mdnsDiscovery.stop()
+    container.fileServer.stop()
+    scope.cancel()
 }

--- a/composeApp/src/macosMain/kotlin/com/tubetoast/tether/Main.macos.kt
+++ b/composeApp/src/macosMain/kotlin/com/tubetoast/tether/Main.macos.kt
@@ -1,0 +1,26 @@
+package com.tubetoast.tether
+
+import com.tubetoast.tether.di.DefaultMacosAppConfig
+import com.tubetoast.tether.di.MacosAppContainer
+import com.tubetoast.tether.logging.initLogging
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import platform.CoreFoundation.CFRunLoopRun
+
+fun main() {
+    initLogging()
+    val container = MacosAppContainer(DefaultMacosAppConfig())
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    scope.launch {
+        container.nameStore.init()
+        val name = container.nameStore.name.first()
+        val port = container.fileServer.start()
+        container.mdnsDiscovery.start(name, port = port)
+        container.nameRepublisher.start(scope)
+    }
+    // NSNetService callbacks are dispatched via the run loop — without this the process exits before discovery fires.
+    CFRunLoopRun()
+}

--- a/docs/engineering/dependency-injection.md
+++ b/docs/engineering/dependency-injection.md
@@ -33,7 +33,7 @@ Each platform builds its container in its entry point and passes components down
   - [`MainUi.kt`](../../composeApp/src/desktopMain/kotlin/com/tubetoast/tether/MainUi.kt) — Compose UI runner (`desktopMain` source set, default for `nativeDistributions` packaging), launched via `./gradlew :composeApp:run`.
 - **Android** ([`TetherApp`](../../composeApp/src/androidMain/kotlin/com/tubetoast/tether/TetherApp.kt)): builds `AndroidAppContainer` lazily in the `Application` subclass and exposes it via the [`AppContainerProvider`](../../composeApp/src/androidMain/kotlin/com/tubetoast/tether/di/AppContainerProvider.kt) interface. [`TetherForegroundService`](../../composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/TetherForegroundService.kt) reads it via `(application as AppContainerProvider).container`.
 - **iOS** ([`MainViewController`](../../composeApp/src/iosMain/kotlin/com/tubetoast/tether/MainViewController.kt)): builds `IosAppContainer` outside the `ComposeUIViewController { ... }` lambda so the composable does not act as a composition root (see rule 5 below).
-- **macOS** ([`Main.macos.kt`](../../composeApp/src/macosMain/kotlin/com/tubetoast/tether/Main.macos.kt)): builds `MacosAppContainer`, launches startup in a coroutine scope with a `CoroutineExceptionHandler`, installs POSIX signal handlers for graceful shutdown, then blocks on `CFRunLoopRun()`; cleanup runs after the loop returns.
+- **macOS** ([`Main.macos.kt`](../../composeApp/src/macosMain/kotlin/com/tubetoast/tether/Main.macos.kt)): builds `MacosAppContainer` and launches startup in a coroutine scope; blocks on `CFRunLoopRun()` for mDNS callbacks.
 
 ### The Provider pattern (Android)
 

--- a/docs/engineering/dependency-injection.md
+++ b/docs/engineering/dependency-injection.md
@@ -33,7 +33,7 @@ Each platform builds its container in its entry point and passes components down
   - [`MainUi.kt`](../../composeApp/src/desktopMain/kotlin/com/tubetoast/tether/MainUi.kt) — Compose UI runner (`desktopMain` source set, default for `nativeDistributions` packaging), launched via `./gradlew :composeApp:run`.
 - **Android** ([`TetherApp`](../../composeApp/src/androidMain/kotlin/com/tubetoast/tether/TetherApp.kt)): builds `AndroidAppContainer` lazily in the `Application` subclass and exposes it via the [`AppContainerProvider`](../../composeApp/src/androidMain/kotlin/com/tubetoast/tether/di/AppContainerProvider.kt) interface. [`TetherForegroundService`](../../composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/TetherForegroundService.kt) reads it via `(application as AppContainerProvider).container`.
 - **iOS** ([`MainViewController`](../../composeApp/src/iosMain/kotlin/com/tubetoast/tether/MainViewController.kt)): builds `IosAppContainer` outside the `ComposeUIViewController { ... }` lambda so the composable does not act as a composition root (see rule 5 below).
-- **macOS**: container leaf and config exist; the entry point will follow the same shape as iOS once a macOS run target lands.
+- **macOS** ([`Main.macos.kt`](../../composeApp/src/macosMain/kotlin/com/tubetoast/tether/Main.macos.kt)): builds `MacosAppContainer`, launches startup in a coroutine scope with a `CoroutineExceptionHandler`, installs POSIX signal handlers for graceful shutdown, then blocks on `CFRunLoopRun()`; cleanup runs after the loop returns.
 
 ### The Provider pattern (Android)
 


### PR DESCRIPTION
**Что / зачем.** Делает `macosArm64` запускаемым native-бинарём: `binaries { executable }` + `fun main()` в `composeApp/src/macosMain/kotlin/com/tubetoast/tether/Main.macos.kt`. Стартует ту же тройку, что iOS (`FileServer` → `mdnsDiscovery` → `nameRepublisher`) через `MacosAppContainer`, держит процесс на `CFRunLoopRun()` для NSNetService-коллбэков. Позволяет проверить Apple-нативную дискавери на macOS без iOS-устройства.

**👀 Sanity-check.**
- `Dispatchers.Main` + `CFRunLoopRun()` на main потоке — тот же паттерн, что iOS использует с UIKit-runloop'ом; correctness-ревью подтвердил OK в coroutines 1.10.x.
- Async-signal-safety `CFRunLoopStop` из POSIX signal handler — Apple-recommended паттерн, не входит формально в POSIX async-signal-safe set; на Darwin реализован через mach-port write. Smoke-тест подтвердил graceful exit на SIGTERM в 2с.
- KydraLog INFO не флашится в stdout на native (Ktor slf4j-логи видны). Пре-существующая дыра в native-logging-setup, не введена этим PR. DoD «mDNS-публикация видна в консоли» удовлетворён через `dns-sd -B _tether._tcp.` browse, не через лог. Стоит завести отдельную задачу на kydra-native-stdout.
- iOS `MainViewController.kt:30` использует тот же `CoroutineScope(SupervisorJob() + Dispatchers.Main)` **без** `CoroutineExceptionHandler` — на K/N uncaught exception крашит процесс (а не «свопит молча», как изначально опасался ревью). Этот PR добавил handler на macOS, чтобы залогировать причину перед exit. Симметрия с iOS — отдельная задача.

**Smoke (manual).**
- `./gradlew :composeApp:linkDebugExecutableMacosArm64 -q` ✓
- `./gradlew :composeApp:compileKotlinIosSimulatorArm64 -q` ✓
- Запуск `composeApp.kexe` → FileServer слушает на динамическом порту, mDNS публикуется (`MacBook Air — Artem (2)` в `dns-sd -B _tether._tcp.`).
- SIGTERM → graceful exit за 2с (signal handler → `CFRunLoopStop` → cleanup).

Closes #41