### PR TITLE
#253: бриф пользователю после разведки, перед вопросами

### DIFF
--- a/.claude/skills/document/SKILL.md
+++ b/.claude/skills/document/SKILL.md
@@ -70,6 +70,10 @@ cd .claude/worktrees/docs-<N>-<short-slug>
 
 All subsequent agent dispatches happen with this as cwd.
 
+### Briefing back to the user
+
+После прочтения issue и разведки, **перед** любым вопросом пользователю (D1, Open questions от sub-agent'ов, classification-неоднозначности) выдай в чат короткий бриф 3–6 строк: что делаем, зачем (мотивация / контекст из issue), предварительный набор слоёв (spec / ux-brief / tech-doc / ADR / knowledge / .claude prompt). Если в этом же сообщении задаёшь вопросы — к каждому приложи 1–2 строки контекста (что говорит issue, какие варианты на столе), чтобы пользователь отвечал, не уходя на GitHub перечитывать тело. Бриф один на прогон; в re-entry не повторяй.
+
 ## Step 2 — Layer classification
 
 Decide which artifact layers this issue needs. Read the issue body, comments, linked spec/feature (if any), and `docs/product/features/README.md` / `docs/engineering/README.md` to see what already exists.

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -95,6 +95,10 @@ cd .claude/worktrees/feature-<N>-<short-slug>
 
 All subsequent agent dispatches happen with this as cwd. Skipping this step means `spec-writer` would edit main checkout.
 
+### Briefing back to the user
+
+После прочтения issue и разведки, **перед** любым вопросом пользователю (gate-вопросы, Open questions от sub-agent'ов, classification-неоднозначности) выдай в чат короткий бриф 3–6 строк: что делаем, зачем (мотивация / контекст из issue), классификация (track + затрагиваемые слои/платформы). Если в этом же сообщении задаёшь вопросы — к каждому приложи 1–2 строки контекста (что говорит issue, какие варианты на столе), чтобы пользователь отвечал, не уходя на GitHub перечитывать тело. Бриф один на прогон; в re-entry не повторяй.
+
 ## Step 2 — Resolve early gates
 
 ### Spec / UX brief / AC ambiguity


### PR DESCRIPTION
Closes #253

## Что / зачем

В Step 1 обоих скиллов добавлена подсекция `### Briefing back to the user`: после прочтения issue и worktree setup, перед любым вопросом пользователю — короткий бриф 3–6 строк (что делаем / зачем / классификация-слои или track) плюс 1–2 строки контекста к каждому вопросу. Пользователь отвечает на gate-вопросы осознанно, не уходя на GitHub перечитывать тело issue.

## 👀 Sanity-check

- Целочисленная нумерация Step'ов сохранена (никаких 1.5) — подсекция под `###`, не отдельный шаг
- В формулировке явно: бриф один на прогон, в re-entry не повторяется
