### PR TITLE
#41: iOS startup CoroutineExceptionHandler

### DIFF
--- a/composeApp/src/iosMain/kotlin/com/tubetoast/tether/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/com/tubetoast/tether/MainViewController.kt
@@ -11,12 +11,18 @@ import com.tubetoast.tether.di.DefaultIosAppConfig
 import com.tubetoast.tether.di.IosAppContainer
 import com.tubetoast.tether.logging.initLogging
 import com.tubetoast.tether.presentation.RootContent
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import ru.pocketbyte.kydra.log.KydraLog
+import ru.pocketbyte.kydra.log.error
+import ru.pocketbyte.kydra.log.wrapper.withTag
+
+private val log = KydraLog.withTag(default = "Tether.Main.iOS")
 
 @Suppress("ktlint:standard:function-naming")
 fun MainViewController() = run {
@@ -27,7 +33,12 @@ fun MainViewController() = run {
     ComposeUIViewController {
         DisposableEffect(Unit) {
             lifecycle.resume()
-            val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+            lateinit var scope: CoroutineScope
+            val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
+                log.error { "startup failed: ${throwable.message ?: throwable}" }
+                scope.cancel()
+            }
+            scope = CoroutineScope(SupervisorJob() + Dispatchers.Main + exceptionHandler)
             scope.launch {
                 container.nameStore.init()
                 val name = container.nameStore.name.first()


### PR DESCRIPTION
**Что / зачем.** Стартовый `scope.launch` в [MainViewController.kt](composeApp/src/iosMain/kotlin/com/tubetoast/tether/MainViewController.kt) использует `CoroutineScope(SupervisorJob() + Dispatchers.Main)` без `CoroutineExceptionHandler`. На Kotlin/Native неперехваченное исключение в child-coroutine крашит процесс — TestFlight crash-репорты приземляются в Ktor / NSNetService internals без контекста того, какой именно шаг старта упал. Handler логирует причину перед exit, чтобы дать читаемую строку.

**Контекст.** Найдено в ходе работы над #41 (macOS native entry point). PR #252 закрыт без merge'а — macOS-таргет дропаем (см. отдельный cleanup PR + комментарий в #41), но этот iOS-fix остаётся валидным и независимым: дефект существует на iOS сам по себе.

**👀 Sanity-check.**
- `scope` объявлен `lateinit` чтобы handler мог его captureить и `cancel()` после лога — иначе циклическая зависимость при объявлении.
- `KydraLog` tag `Tether.Main.iOS` — параллельно тому, что было на macOS-стороне (`Tether.Main.macOS`), сохраняет паттерн тегирования entry-point'ов.

Closes #41 не пишу — issue остаётся открытым для отдельного выбора macOS UI-пути (Desktop JVM); закроет его cleanup-PR.