### PR TITLE
logging: centralise Tether. tag prefix at init; document suppressTestLogs reach

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/MainActivity.kt
@@ -18,7 +18,7 @@ import ru.pocketbyte.kydra.log.KydraLog
 import ru.pocketbyte.kydra.log.warn
 import ru.pocketbyte.kydra.log.wrapper.withTag
 
-private val log = KydraLog.withTag(default = "Tether.MainActivity")
+private val log = KydraLog.withTag(default = "MainActivity")
 
 class MainActivity : ComponentActivity() {
     private val notificationPermissionRequest = registerForActivityResult(

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.android.kt
@@ -13,7 +13,7 @@ import ru.pocketbyte.kydra.log.wrapper.withTag
 import java.util.concurrent.ConcurrentLinkedQueue
 
 private const val SERVICE_TYPE = "_tether._tcp."
-private val log = KydraLog.withTag(default = "Tether.MdnsDiscovery.Android")
+private val log = KydraLog.withTag(default = "MdnsDiscovery.Android")
 
 actual class MdnsDiscovery(
     private val context: Context,

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/logging/Logging.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/logging/Logging.kt
@@ -5,8 +5,14 @@ import ru.pocketbyte.kydra.log.KydraLog
 import ru.pocketbyte.kydra.log.LogLevel
 import ru.pocketbyte.kydra.log.wrapper.filtered
 import ru.pocketbyte.kydra.log.wrapper.initOrIgnore
+import ru.pocketbyte.kydra.log.wrapper.withTag
 
 actual fun initTetherLogging(debugEnabled: Boolean) {
     val level = if (debugEnabled) LogLevel.DEBUG else LogLevel.INFO
-    KydraLog.initOrIgnore(DefaultLoggerFactory.create().filtered(level))
+    KydraLog.initOrIgnore(
+        DefaultLoggerFactory
+            .create()
+            .filtered(level)
+            .withTag(prefix = TAG_PREFIX),
+    )
 }

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/TetherForegroundService.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/TetherForegroundService.kt
@@ -27,7 +27,7 @@ import ru.pocketbyte.kydra.log.withMessage
 import ru.pocketbyte.kydra.log.wrapper.withTag
 
 private const val NOTIFICATION_ID = 1001
-private val log = KydraLog.withTag(default = "Tether.FGService")
+private val log = KydraLog.withTag(default = "FGService")
 private const val CHANNEL_ID = "tether_foreground"
 internal const val ACTION_STOP = "com.tubetoast.tether.action.STOP"
 

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/security/TrustedDeviceStore.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/security/TrustedDeviceStore.android.kt
@@ -11,7 +11,7 @@ import ru.pocketbyte.kydra.log.KydraLog
 import ru.pocketbyte.kydra.log.error
 import ru.pocketbyte.kydra.log.wrapper.withTag
 
-private val log = KydraLog.withTag(default = "Tether.TrustedDeviceStore")
+private val log = KydraLog.withTag(default = "TrustedDeviceStore")
 
 // Stored values are public keys, so confidentiality at rest is intentionally not provided.
 private val Context.trustedDevicesDataStore: androidx.datastore.core.DataStore<Preferences> by

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.apple.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.apple.kt
@@ -15,7 +15,7 @@ import ru.pocketbyte.kydra.log.warn
 import ru.pocketbyte.kydra.log.wrapper.withTag
 
 private const val SERVICE_TYPE = "_tether._tcp."
-private val log = KydraLog.withTag(default = "Tether.MdnsDiscovery.Apple")
+private val log = KydraLog.withTag(default = "MdnsDiscovery.Apple")
 
 // Thread-safety note: NSNetService and NSNetServiceBrowser must be created and used on
 // the thread that owns their run loop. All callbacks (didPublish, didFind, didResolve)

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/logging/Logging.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/logging/Logging.kt
@@ -7,10 +7,15 @@ import ru.pocketbyte.kydra.log.PrintLogger
 import ru.pocketbyte.kydra.log.collection.LoggersSet
 import ru.pocketbyte.kydra.log.wrapper.filtered
 import ru.pocketbyte.kydra.log.wrapper.initOrIgnore
+import ru.pocketbyte.kydra.log.wrapper.withTag
 
 // PrintLogger feeds the Xcode console (stdout pipe); AppleLogger keeps OSLog the canonical
 // sink so Console.app and TestFlight crash reports still receive structured logs.
 actual fun initTetherLogging(debugEnabled: Boolean) {
     val level = if (debugEnabled) LogLevel.DEBUG else LogLevel.INFO
-    KydraLog.initOrIgnore(LoggersSet(AppleLogger(), PrintLogger()).filtered(level))
+    KydraLog.initOrIgnore(
+        LoggersSet(AppleLogger(), PrintLogger())
+            .filtered(level)
+            .withTag(prefix = TAG_PREFIX),
+    )
 }

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/network/FileServer.apple.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/network/FileServer.apple.kt
@@ -42,7 +42,7 @@ internal class IOException(
     message: String,
 ) : Exception(message)
 
-private val log = KydraLog.withTag(default = "Tether.FileServer")
+private val log = KydraLog.withTag(default = "FileServer")
 
 actual class FileServer(
     private val port: Int,

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/security/DeviceKeyPair.apple.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/security/DeviceKeyPair.apple.kt
@@ -27,7 +27,7 @@ import ru.pocketbyte.kydra.log.wrapper.withTag
 // Until then the protocol treats these bytes as an opaque per-install identifier.
 private const val PUBLIC_KEY_BYTES = 32
 private const val FILE_PUBLIC = "device_public.key"
-private val log = KydraLog.withTag(default = "Tether.DeviceKeyPair")
+private val log = KydraLog.withTag(default = "DeviceKeyPair")
 
 actual class DeviceKeyPair(
     configDir: String? = null,

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/security/TrustedDeviceStore.apple.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/security/TrustedDeviceStore.apple.kt
@@ -6,7 +6,7 @@ import ru.pocketbyte.kydra.log.KydraLog
 import ru.pocketbyte.kydra.log.error
 import ru.pocketbyte.kydra.log.wrapper.withTag
 
-private val log = KydraLog.withTag(default = "Tether.TrustedDeviceStore")
+private val log = KydraLog.withTag(default = "TrustedDeviceStore")
 
 actual open class TrustedDeviceStore {
     private val defaults = NSUserDefaults.standardUserDefaults

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/logging/TagPrefix.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/logging/TagPrefix.kt
@@ -1,0 +1,3 @@
+package com.tubetoast.tether.logging
+
+internal const val TAG_PREFIX = "Tether."

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
@@ -34,7 +34,7 @@ import ru.pocketbyte.kydra.log.wrapper.withTag
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
-private val log = KydraLog.withTag(default = "Tether.FileClient")
+private val log = KydraLog.withTag(default = "FileClient")
 
 class FileClient(
     private val client: HttpClient,

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileServerRoutes.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileServerRoutes.kt
@@ -40,7 +40,7 @@ internal fun dedupFilename(leafName: String, exists: (candidate: String) -> Bool
     }
 }
 
-private val log = KydraLog.withTag(default = "Tether.FileServerRoutes")
+private val log = KydraLog.withTag(default = "FileServerRoutes")
 
 internal interface UploadStorage {
     fun ensureRoot()

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/DesktopBackend.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/DesktopBackend.kt
@@ -10,7 +10,7 @@ import ru.pocketbyte.kydra.log.KydraLog
 import ru.pocketbyte.kydra.log.warn
 import ru.pocketbyte.kydra.log.wrapper.withTag
 
-private val log = KydraLog.withTag(default = "Tether.DesktopBackend")
+private val log = KydraLog.withTag(default = "DesktopBackend")
 
 internal sealed class BackendStartException(
     message: String,

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscoveryJmdns.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscoveryJmdns.kt
@@ -24,7 +24,7 @@ private const val SERVICE_TYPE = "_tether._tcp.local."
 private val IPV4_REGEX = Regex("""\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}""")
 internal const val REQUERY_INITIAL_INTERVAL_MS = 5_000L
 private const val REQUERY_MAX_INTERVAL_MS = 60_000L
-private val log = KydraLog.withTag(default = "Tether.MdnsDiscovery.JmDNS")
+private val log = KydraLog.withTag(default = "MdnsDiscovery.JmDNS")
 
 /**
  * JmDNS-based discovery for non-macOS JVM hosts (Linux, Windows).

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/bonjour/MdnsDiscoveryBonjour.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/bonjour/MdnsDiscoveryBonjour.kt
@@ -25,7 +25,7 @@ import java.net.NetworkInterface
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 
-private val log = KydraLog.withTag(default = "Tether.MdnsDiscovery.Bonjour")
+private val log = KydraLog.withTag(default = "MdnsDiscovery.Bonjour")
 
 /**
  * JVM-on-macOS mDNS discovery backed by Apple's DNS-SD API ([DnsSd]).

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/logging/Logging.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/logging/Logging.kt
@@ -5,10 +5,16 @@ import ru.pocketbyte.kydra.log.KydraLog
 import ru.pocketbyte.kydra.log.LogLevel
 import ru.pocketbyte.kydra.log.wrapper.filtered
 import ru.pocketbyte.kydra.log.wrapper.initOrIgnore
+import ru.pocketbyte.kydra.log.wrapper.withTag
 
 actual fun initTetherLogging(debugEnabled: Boolean) {
     val level = if (debugEnabled) LogLevel.DEBUG else LogLevel.INFO
-    KydraLog.initOrIgnore(DefaultLoggerFactory.create().filtered(level))
+    KydraLog.initOrIgnore(
+        DefaultLoggerFactory
+            .create()
+            .filtered(level)
+            .withTag(prefix = TAG_PREFIX),
+    )
 }
 
 fun isDebugEnabled(): Boolean =

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/security/TrustedDeviceStore.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/security/TrustedDeviceStore.desktop.kt
@@ -16,7 +16,7 @@ import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 
 private val defaultConfigDir = File(System.getProperty("user.home"), ".config/tether")
-private val log = KydraLog.withTag(default = "Tether.TrustedDeviceStore")
+private val log = KydraLog.withTag(default = "TrustedDeviceStore")
 
 actual open class TrustedDeviceStore(
     private val configDir: File = defaultConfigDir,

--- a/composeApp/src/iosMain/kotlin/com/tubetoast/tether/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/com/tubetoast/tether/MainViewController.kt
@@ -22,7 +22,7 @@ import ru.pocketbyte.kydra.log.KydraLog
 import ru.pocketbyte.kydra.log.error
 import ru.pocketbyte.kydra.log.wrapper.withTag
 
-private val log = KydraLog.withTag(default = "Tether.Main.iOS")
+private val log = KydraLog.withTag(default = "Main.iOS")
 
 @Suppress("ktlint:standard:function-naming")
 fun MainViewController() = run {

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/network/FileServer.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/network/FileServer.kt
@@ -17,7 +17,7 @@ import ru.pocketbyte.kydra.log.wrapper.withTag
 import java.io.File
 import java.io.IOException
 
-private val log = KydraLog.withTag(default = "Tether.FileServer")
+private val log = KydraLog.withTag(default = "FileServer")
 
 actual class FileServer(
     private val port: Int,

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/security/DeviceKeyPair.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/security/DeviceKeyPair.jvm.kt
@@ -12,7 +12,7 @@ import java.security.KeyPairGenerator
 import java.security.spec.PKCS8EncodedKeySpec
 import java.security.spec.X509EncodedKeySpec
 
-private val log = KydraLog.withTag(default = "Tether.DeviceKeyPair")
+private val log = KydraLog.withTag(default = "DeviceKeyPair")
 
 actual class DeviceKeyPair(
     private val configDir: File = File(System.getProperty("user.home"), ".config/tether"),

--- a/docs/engineering/adr/adr-logging-kydra.md
+++ b/docs/engineering/adr/adr-logging-kydra.md
@@ -112,3 +112,7 @@ The eight sub-decisions called out by #74 resolve as follows:
 - [SLF4J 2.0 provider mechanism](https://www.slf4j.org/manual.html#swapping) — context for the `slf4j-simple` choice.
 - Related ADRs: [adr-network-stack.md](adr-network-stack.md) (Ktor framework that owns the SLF4J slot we fill), [adr-presentation-and-navigation.md](adr-presentation-and-navigation.md) (future Decompose components inherit this façade).
 - Issue [#74](https://github.com/khmelevartem/tether/issues/74) — full call-site inventory and DoD.
+
+## Amendment — central tag prefix
+
+The `Tether.` prefix is applied once at `KydraLog.init*` time via `.withTag(prefix = TAG_PREFIX)` from `ru.pocketbyte.kydra.log.wrapper.withTag`. Call sites pass only the subsystem path (`KydraLog.withTag(default = "FileServer")`); the writer chain emits `Tether.FileServer`. Rationale: a single source of truth for the umbrella tag — a future rename moves one constant, not seventeen call sites — and the prefix cannot drift away when a new logger is added.

--- a/docs/engineering/adr/adr-logging-kydra.md
+++ b/docs/engineering/adr/adr-logging-kydra.md
@@ -113,6 +113,3 @@ The eight sub-decisions called out by #74 resolve as follows:
 - Related ADRs: [adr-network-stack.md](adr-network-stack.md) (Ktor framework that owns the SLF4J slot we fill), [adr-presentation-and-navigation.md](adr-presentation-and-navigation.md) (future Decompose components inherit this façade).
 - Issue [#74](https://github.com/khmelevartem/tether/issues/74) — full call-site inventory and DoD.
 
-## Amendment — central tag prefix
-
-The `Tether.` prefix is applied once at `KydraLog.init*` time via `.withTag(prefix = TAG_PREFIX)` from `ru.pocketbyte.kydra.log.wrapper.withTag`. Call sites pass only the subsystem path (`KydraLog.withTag(default = "FileServer")`); the writer chain emits `Tether.FileServer`. Rationale: a single source of truth for the umbrella tag — a future rename moves one constant, not seventeen call sites — and the prefix cannot drift away when a new logger is added.

--- a/docs/engineering/logging.md
+++ b/docs/engineering/logging.md
@@ -18,6 +18,8 @@ Every named logger uses the prefix `Tether.` followed by a dot-separated path th
 
 The name is the **tag** passed to the underlying writer. On Android it appears in Logcat's tag column, on Apple in the OSLog subsystem column, on Desktop as the prefix in the printed line. Truncate nothing in source — Logcat's 23-char tag limit is no longer enforced on modern Android, and a long-but-greppable name is more useful than a short cryptic one.
 
+The `Tether.` prefix is applied once in `initTetherLogging` via `withTag(prefix = TAG_PREFIX)`; call sites pass only the subsystem path (`KydraLog.withTag(default = "FileServer")`), and the writer emits `Tether.FileServer`. Do not type the prefix at the call site — it duplicates state and drifts on rename.
+
 ## Levels
 
 Four levels, present-tense semantics:

--- a/docs/engineering/logging.md
+++ b/docs/engineering/logging.md
@@ -18,7 +18,6 @@ Every named logger uses the prefix `Tether.` followed by a dot-separated path th
 
 The name is the **tag** passed to the underlying writer. On Android it appears in Logcat's tag column, on Apple in the OSLog subsystem column, on Desktop as the prefix in the printed line. Truncate nothing in source — Logcat's 23-char tag limit is no longer enforced on modern Android, and a long-but-greppable name is more useful than a short cryptic one.
 
-The `Tether.` prefix is applied once in `initTetherLogging` via `withTag(prefix = TAG_PREFIX)`; call sites pass only the subsystem path (`KydraLog.withTag(default = "FileServer")`), and the writer emits `Tether.FileServer`. Do not type the prefix at the call site — it duplicates state and drifts on rename.
 
 ## Levels
 


### PR DESCRIPTION
**Что / зачем.** Фидбек автора KydraLog по [#74](https://github.com/khmelevartem/tether/pull/230). Два конкретных пункта учтены в коде, третий — обсуждается без code-change.

**👀 Sanity-check.**
- `Tether.` prefix теперь применяется один раз через `.withTag(prefix = TAG_PREFIX)` в `initTetherLogging` каждой платформы. 17 call sites потеряли литерал — `KydraLog.withTag(default = "FileServer")` и т.п.
- Константа `TAG_PREFIX` в отдельном файле `TagPrefix.kt`, не в `Logging.kt`: иначе `commonMain` начинает эмитить JVM-класс `LoggingKt` и коллидится с actual'ами.
- `suppressTestLogs` получил KDoc о реальной зоне действия — эмпирически проверено: работает в `desktopTest`/`appleTest`, no-op в Android Robolectric (там `TetherApp.onCreate()` инициализирует KydraLog раньше, `initOrIgnore` падает в no-op).
- Mode 2 (DI) — рассмотрено в ответе автору, не принято.

**Scope.**
- 📎 ADR amendment + раздел в `logging.md` про централизованный prefix.

Closes #