### PR TITLE
retro from #273: cite external sources; defensive-summary at link sites; canon-self-application

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -24,7 +24,7 @@ You're called when a Tether subsystem needs a converged technical choice — new
 
 1. **Read writing-style and ADR conventions:**
    - `docs/engineering/README.md` — writing style for living docs (rule-first, code examples on abstract types, don't restate code).
-   - `docs/engineering/long-lived-artifacts.md` — discipline for all long-lived prose. Note §External claims cite their source: any claim about an external tool / 3rd-party API / library / platform SDK must link to authoritative docs; use `WebFetch` to verify, do not write from memory.
+   - `docs/engineering/long-lived-artifacts.md` — discipline for all long-lived prose.
    - `docs/engineering/adr/README.md` — Decision-vs-State rule, parent-living-doc requirement, append-only history.
    - `docs/engineering/_template.md` — starter skeleton for living docs.
    - `docs/engineering/adr/_template.md` — starter skeleton for ADRs.

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -24,6 +24,7 @@ You're called when a Tether subsystem needs a converged technical choice — new
 
 1. **Read writing-style and ADR conventions:**
    - `docs/engineering/README.md` — writing style for living docs (rule-first, code examples on abstract types, don't restate code).
+   - `docs/engineering/long-lived-artifacts.md` — discipline for all long-lived prose. Note §External claims cite their source: any claim about an external tool / 3rd-party API / library / platform SDK must link to authoritative docs; use `WebFetch` to verify, do not write from memory.
    - `docs/engineering/adr/README.md` — Decision-vs-State rule, parent-living-doc requirement, append-only history.
    - `docs/engineering/_template.md` — starter skeleton for living docs.
    - `docs/engineering/adr/_template.md` — starter skeleton for ADRs.

--- a/.claude/agents/ux-expert.md
+++ b/.claude/agents/ux-expert.md
@@ -23,7 +23,7 @@ You're called when a FEATURE issue's scope includes user-facing UI (screen, comp
 
 1. **Read the feature spec.** It's the source of truth for *what / why*; your job is the *how-it-feels*.
 2. **Read product context** where relevant: `docs/product/vision.md`, `docs/product/audience.md`.
-3. **Apply long-lived-artifact discipline** to brief prose — see [`docs/engineering/long-lived-artifacts.md`](../../docs/engineering/long-lived-artifacts.md).
+3. **Apply long-lived-artifact discipline** to brief prose — see [`docs/engineering/long-lived-artifacts.md`](../../docs/engineering/long-lived-artifacts.md). Specifically §External claims cite their source: any claim about Android Material / iOS HIG / macOS HIG / Desktop OS conventions must link to the authoritative platform doc, not be written from memory.
 
 ## Core principles
 

--- a/.claude/agents/ux-expert.md
+++ b/.claude/agents/ux-expert.md
@@ -23,7 +23,7 @@ You're called when a FEATURE issue's scope includes user-facing UI (screen, comp
 
 1. **Read the feature spec.** It's the source of truth for *what / why*; your job is the *how-it-feels*.
 2. **Read product context** where relevant: `docs/product/vision.md`, `docs/product/audience.md`.
-3. **Apply long-lived-artifact discipline** to brief prose — see [`docs/engineering/long-lived-artifacts.md`](../../docs/engineering/long-lived-artifacts.md). Specifically §External claims cite their source: any claim about Android Material / iOS HIG / macOS HIG / Desktop OS conventions must link to the authoritative platform doc, not be written from memory.
+3. **Apply long-lived-artifact discipline** to brief prose — see [`docs/engineering/long-lived-artifacts.md`](../../docs/engineering/long-lived-artifacts.md).
 
 ## Core principles
 

--- a/.claude/skills/document/SKILL.md
+++ b/.claude/skills/document/SKILL.md
@@ -142,7 +142,9 @@ Mechanical fixes (rename, add missing link, add missing index row) — apply dir
 
 ## Step 5 — Review wave
 
-Dispatch in parallel on the staged diff (no PR yet — agents review the local working tree via `git diff main...HEAD`). Scope covers `docs/` and `.claude/` changes:
+Dispatch in parallel on the staged diff (no PR yet — agents review the local working tree via `git diff main...HEAD`). Scope covers `docs/` and `.claude/` changes.
+
+**If the PR establishes or extends canon** (new rule in a living doc, new section in `docs/engineering/long-lived-artifacts.md`, new ADR, new policy in any agent / skill / command) — tell each reviewer in their dispatch prompt: «this PR establishes / extends rule X; apply X to every reference to it that appears in this diff, not only to the rule's own body». A rule's first PR is the one most likely to violate it in adjacent prose — the writer's attention is on the rule, and the references get defensive summaries glued next to them.
 
 - `review-dod` — DoD criteria from the issue are covered by produced artifacts.
 - `review-guides` — conformance to CLAUDE.md §Code style and [`docs/engineering/long-lived-artifacts.md`](../../../docs/engineering/long-lived-artifacts.md) for all touched prose. For `docs/engineering/` artifacts additionally apply `docs/engineering/README.md` writing-style rules (rule-first, code examples on abstract types, no restating code). For `docs/product/features/<slug>/spec.md` apply `docs/product/features/_template.md`. For ADRs apply `docs/engineering/adr/_template.md` shape. For `.claude/` prompt edits apply sibling-skill/agent/command tone consistency.

--- a/.claude/skills/document/SKILL.md
+++ b/.claude/skills/document/SKILL.md
@@ -144,7 +144,7 @@ Mechanical fixes (rename, add missing link, add missing index row) — apply dir
 
 Dispatch in parallel on the staged diff (no PR yet — agents review the local working tree via `git diff main...HEAD`). Scope covers `docs/` and `.claude/` changes.
 
-**If the PR establishes or extends canon** (new rule in a living doc, new section in `docs/engineering/long-lived-artifacts.md`, new ADR, new policy in any agent / skill / command) — tell each reviewer in their dispatch prompt: «this PR establishes / extends rule X; apply X to every reference to it that appears in this diff, not only to the rule's own body». A rule's first PR is the one most likely to violate it in adjacent prose — the writer's attention is on the rule, and the references get defensive summaries glued next to them.
+If the PR establishes or extends canon, tell each reviewer to apply the new rule to the diff itself.
 
 - `review-dod` — DoD criteria from the issue are covered by produced artifacts.
 - `review-guides` — conformance to CLAUDE.md §Code style and [`docs/engineering/long-lived-artifacts.md`](../../../docs/engineering/long-lived-artifacts.md) for all touched prose. For `docs/engineering/` artifacts additionally apply `docs/engineering/README.md` writing-style rules (rule-first, code examples on abstract types, no restating code). For `docs/product/features/<slug>/spec.md` apply `docs/product/features/_template.md`. For ADRs apply `docs/engineering/adr/_template.md` shape. For `.claude/` prompt edits apply sibling-skill/agent/command tone consistency.

--- a/docs/engineering/long-lived-artifacts.md
+++ b/docs/engineering/long-lived-artifacts.md
@@ -34,8 +34,6 @@ A short summary attached to the link («see X (covers A / B / C)», «see X — 
 
 ## External claims cite their source
 
-When prose describes the behaviour of an external tool, 3rd-party API, library, platform SDK, or specification (Claude Code, `gh`, Gradle, Kotlin Multiplatform, Android / iOS / macOS platform APIs, Ktor, Compose, …) — link to the authoritative doc next to the claim. Do not write from memory.
+When prose describes the behaviour of an external tool, 3rd-party API, library, platform SDK, or specification — link to the authoritative doc next to the claim. Do not write from memory. External tools change; memory drifts; an unverified claim becomes permanently wrong and propagates through every artifact that references it.
 
-External tools change; memory drifts; a rule built on an unverified claim becomes permanently wrong and propagates through every artifact that references it. The reader (human or agent) cannot tell verified claims from unverified ones without the citation.
-
-If the authoritative doc does not say what you need — say so explicitly («not specified by Anthropic; this is a project convention») rather than presenting a project-invented rule as the tool's behaviour.
+If the authoritative doc does not cover what you need — say so explicitly rather than presenting a project-invented rule as the tool's behaviour.

--- a/docs/engineering/long-lived-artifacts.md
+++ b/docs/engineering/long-lived-artifacts.md
@@ -29,3 +29,13 @@ When writing: prefer the product invariant («pairing keyed by stable device ide
 A long-lived artifact references rules / tokens / tables from another artifact — link (`see docs/engineering/X.md §Y`), do not embed.
 
 Any copy desynchronises at the source's first change; the reader acts on a stale version and gets boxed into a frozen-checklist mindset instead of holistically applying the canon. If an artifact is unreadable without an inline copy, the referencing side's formulation is weak — rewrite it; do not prop it up with a copy.
+
+A short summary attached to the link («see X (covers A / B / C)», «see X — about the four rules of Y») is the same class as inline-copy: it duplicates the linked doc's structure right next to the link, and it desynchronises the same way. Trust the link; if the reader needs more than the link text to decide whether to click, the link text itself is weak — rewrite it.
+
+## External claims cite their source
+
+When prose describes the behaviour of an external tool, 3rd-party API, library, platform SDK, or specification (Claude Code, `gh`, Gradle, Kotlin Multiplatform, Android / iOS / macOS platform APIs, Ktor, Compose, …) — link to the authoritative doc next to the claim. Do not write from memory.
+
+External tools change; memory drifts; a rule built on an unverified claim becomes permanently wrong and propagates through every artifact that references it. The reader (human or agent) cannot tell verified claims from unverified ones without the citation.
+
+If the authoritative doc does not say what you need — say so explicitly («not specified by Anthropic; this is a project convention») rather than presenting a project-invented rule as the tool's behaviour.


### PR DESCRIPTION
## Что / зачем

Three rule additions and two cross-references driven by review signals on #273 (which closed #272).

**#273 surfaced two systemic gaps:**

1. **Project-invented rules for external tools.** First iteration of `.claude/AUTHORING.md` defined skill-vs-command criteria from memory instead of from Anthropic docs. User pushed back («не выдумывай, ресерч Anthropic»), research via `claude-code-guide` rewrote the criteria from `code.claude.com/skills`.

2. **A new rule's first PR violated the rule.** PR #273 establishes «link over inline-copy»; the same PR initially shipped five defensive summaries glued next to links to that rule (review-guides table, review-guides check #8, engineering/README index, spec-writer, ux-expert, .claude/README). `review-guides` caught all five.

## Changes

- `docs/engineering/long-lived-artifacts.md` — new section **§External claims cite their source**. When prose describes behaviour of an external tool / 3rd-party API / library / platform SDK, link to authoritative docs; do not write from memory. «Not specified» is an acceptable answer.
- `docs/engineering/long-lived-artifacts.md` §Link over inline-copy — extended: a defensive summary glued next to a link («see X — covers A/B/C») is the same class as inline-copy.
- `.claude/skills/document/SKILL.md` Step 5 — when a PR establishes / extends canon, reviewers are explicitly told to apply the new rule to references to it, not only to the rule's own body.
- `.claude/agents/architect.md` + `.claude/agents/ux-expert.md` «Always do before writing» — one-line cross-refs to §External claims cite their source so the rule lives at point-of-write, not only in the discipline doc.

## 👀 Sanity-check

- Item lives in `long-lived-artifacts.md`, not in `engineering/README.md §Writing style` — chosen because the original incident was `.claude/AUTHORING.md` (outside engineering scope); the rule is universal.
- No changes to `/implement` SKILL.md — its inner-loop reviewer wave will pick up the canon-self-application instruction via shared `review-guides` definition. If we see the same self-violation pattern in code PRs, separate retro.

Closes-relation: follow-up to #272 / PR #273.