### PR TITLE
#277: close sprint-07, plan sprint-08

### DIFF
--- a/docs/sprints/sprint-07.md
+++ b/docs/sprints/sprint-07.md
@@ -4,12 +4,20 @@
 
 ## Состав
 
-| # | Issue | Название | Тип | Размер |
-| - | ----- | -------- | --- | ------ |
-| 1 | [#190](https://github.com/khmelevartem/tether/issues/190) | Common transfer state-machine: BatchSender и TransferComponent с тестами | feature | M |
-| 2 | [#201](https://github.com/khmelevartem/tether/issues/201) | Device list: реализовать четырёхкейсовый row contract (paired × reachable) | feature | M |
-| 3 | [#41](https://github.com/khmelevartem/tether/issues/41) | macOS native entry point — запускаемое приложение для macosArm64 | feature | S |
-| 4 | [#91](https://github.com/khmelevartem/tether/issues/91) | Передача файла на Android-эмулятор зависает по таймауту | bug | S |
+**Итог:** 3/4 задач закрыты, ось state-machine и Android-bug закрыты в плановом окне; device-list row contract вынесен и переблокирован.
+
+| # | Issue | Название | Тип | Размер | Итог |
+| - | ----- | -------- | --- | ------ | ---- |
+| 1 | [#190](https://github.com/khmelevartem/tether/issues/190) | Common transfer state-machine: BatchSender и TransferComponent с тестами | feature | M | ✅ closed ([PR #263](https://github.com/khmelevartem/tether/pull/263)) |
+| 2 | [#201](https://github.com/khmelevartem/tether/issues/201) | Device list: реализовать четырёхкейсовый row contract (paired × reachable) | feature | M | ❌ переделан и заблокирован на ещё не сделанные задачи по логике |
+| 3 | [#41](https://github.com/khmelevartem/tether/issues/41) | macOS native entry point — запускаемое приложение для macosArm64 | feature | S | ✅ closed ([PR #259](https://github.com/khmelevartem/tether/pull/259), [PR #260](https://github.com/khmelevartem/tether/pull/260)) — драгнут в Desktop JVM, нативный target dropped |
+| 4 | [#91](https://github.com/khmelevartem/tether/issues/91) | Передача файла на Android-эмулятор зависает по таймауту | bug | S | ✅ closed ([PR #268](https://github.com/khmelevartem/tether/pull/268)) |
+
+## Доп. результаты
+
+- [#261](https://github.com/khmelevartem/tether/issues/261) — `/close-issue`: post-factum size estimate + проверка понимания принципов перед merge. Усиливает retro-фазу: больше нельзя смержить без явного size/Тип на закрытой задаче.
+- [#272](https://github.com/khmelevartem/tether/issues/272) — CLAUDE.md: вынести orchestrator-only и discipline-блоки, сжать common commands. Чистка перегруженного root-инструкции.
+- [#270](https://github.com/khmelevartem/tether/issues/270) и логирование: централизация `Tether.` tag prefix + удаление `suppressTestLogs` cargo. Подняли качество tooling вокруг runtime-диагностики (фоном к #91).
 
 ## Следствия
 

--- a/docs/sprints/sprint-08.md
+++ b/docs/sprints/sprint-08.md
@@ -1,0 +1,26 @@
+## Цель спринта
+
+Прицельный заход на file-transfer: общий UI-слой передачи (TransferScreen, dialogs, PeerCard expansion) поверх state-machine из #190, плюс закрытие двух concurrent-upload рейсов в FileServer. После спринта появляется видимый transfer-флоу на всех платформах, а receiver больше не теряет данные при параллельных upload'ах в одну папку.
+
+## Состав
+
+| # | Issue | Название | Тип | Размер |
+| - | ----- | -------- | --- | ------ |
+| 1 | [#191](https://github.com/khmelevartem/tether/issues/191) | Transfer UI: TransferScreen, dialogs и DeviceList pending-banner с превью | feature | L |
+| 2 | [#258](https://github.com/khmelevartem/tether/issues/258) | FileServer: closed concurrent-upload races (silent overwrite + abort vs concurrent write) | bug | M |
+| 3 | [#244](https://github.com/khmelevartem/tether/issues/244) | Визуальное воплощение BrandMark — от скелета к дизайну | feature | M |
+| 4 | [#274](https://github.com/khmelevartem/tether/issues/274) | Промоутить command→skill: close-issue, retro, check-review, sprint-pick | infra | M |
+| 5 | [#247](https://github.com/khmelevartem/tether/issues/247) | Translate all docs and .claude/ content to English | infra | L |
+
+## Следствия
+
+- После #191 разблокируется sender-wiring волна #192 / #193 / #194 и receiver UI #195 — все они становятся тонкими потребителями экранов и dialogs из этого спринта.
+- После #258 FileServer пригоден для конкурентных folder-send нагрузок: исчезает silent overwrite и abort-vs-write race, появляются тесты на параллельные upload'ы.
+- После #274 четыре multi-step процедуры (close-issue, retro, check-review, sprint-pick) запускаются по фразе-триггеру, литеральный slash остаётся как fallback.
+- После #247 долгоживущие артефакты унифицированы по языку; русский остаётся только в чате, что снижает трение при работе агентов и моделей.
+
+## Порядок мерджа
+
+#258 → #244 → #191 → #274 → #247
+
+#258 первым — изолированный backend-фикс. #244 правит BrandMark composable, который потребляет #191 → удобнее зайти раньше. #191 несёт основную UI-массу. #274 двигает файлы внутри `.claude/` — лучше до массового перевода. #247 последним: затрагивает почти все долгоживущие `.md`, любой merge после него — тяжёлый rebase.


### PR DESCRIPTION
## Summary

- Закрывает sprint-07 по факту: 3/4 задач закрыты (#190, #41, #91), #201 переделан и заблокирован на ещё не сделанные задачи по логике. Добавлены колонка Итог и секция «Доп. результаты» (#261, #272, плюс фоновая логирующая чистка #269/#270).
- Заводит sprint-08 с прицелом на file-transfer: #191 (Transfer UI) + #258 (FileServer concurrent races), одна сторонняя фича #244 (BrandMark визуал), две infra по выбору пользователя — #274 (command→skill промоут) и #247 (translate docs/.claude/ to English).
- Зафиксирован порядок мерджа: #258 → #244 → #191 → #274 → #247 (последним — #247, чтобы массовый перевод не превратился в тяжёлый rebase для остальных).

Closes #277.

## Test plan

- [x] `docs/sprints/sprint-07.md` обновлён колонкой Итог + секцией «Доп. результаты», цель и «Следствия» оставлены как исторический срез
- [x] `docs/sprints/sprint-08.md` создан в формате «Цель / Состав / Следствия / Порядок мерджа»
- [ ] Merge в `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)