### PR TITLE
Translate all docs and .claude/ content to English

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -70,7 +70,7 @@ Bad: «what library should we use?» (that's your job to propose). Good: «we're
 
 Surface the palette **next to** the questions so the user can converge on a choice across iterations, not by accepting your pre-shaped plan. Mark the option you'd recommend and why, but don't make the others vestigial.
 
-Stop and wait for answers. Do NOT proceed to Step 4 with unanswered questions or vague answers («что-нибудь» / «как считаешь нужным»).
+Stop and wait for answers. Do NOT proceed to Step 4 with unanswered questions or vague answers ("anything" / "whatever you think best").
 
 ### Step 4 — Converge
 
@@ -140,7 +140,7 @@ Re-read both artifacts and self-check:
 - ADR: Decision is a choice, not state. Every rejected option has one line. Parent living doc exists and is linked.
 - Index entries: tone matches siblings.
 
-Run `git diff docs/engineering/` and present to the orchestrator/user. Ask: «Готово. Замечания или коммитим?»
+Run `git diff docs/engineering/` and present to the orchestrator/user. Ask: "Done. Any feedback, or shall we commit?"
 
 Do not commit. The orchestrator decides when to commit.
 

--- a/.claude/agents/bug-reproducer.md
+++ b/.claude/agents/bug-reproducer.md
@@ -5,7 +5,7 @@ tools: Bash, Read, Grep, Glob
 model: sonnet
 ---
 
-You verify the root cause of a bug before anyone writes a fix. The issue body usually contains candidate explanations — "Гипотезы о причинах" / "Возможные причины" — but those are **unverified guesses**, not facts. Your job is to turn one of them into a confirmed cause, or to discover that none of them match and the bug is something else.
+You verify the root cause of a bug before anyone writes a fix. The issue body usually contains candidate explanations — "Hypotheses about causes" / "Possible causes" — but those are **unverified guesses**, not facts. Your job is to turn one of them into a confirmed cause, or to discover that none of them match and the bug is something else.
 
 The cost of skipping this step: a correctly-looking fix that does not actually solve the user's problem, discovered only at manual verification several sessions later.
 
@@ -18,8 +18,8 @@ gh issue view <N> --json title,body,comments
 ```
 
 Identify:
-- "Воспроизведение" / "Steps to reproduce" — the user's recipe
-- "Гипотезы" / "Possible causes" / "Candidate explanations" — list to verify
+- "Reproduction" / "Steps to reproduce" — the user's recipe
+- "Hypotheses" / "Possible causes" / "Candidate explanations" — list to verify
 - Any logs, screenshots, version info attached
 
 ## Procedure
@@ -28,7 +28,7 @@ Identify:
 
 Run the user's steps locally. Use `/smoke-test` blocks if the bug is in a smoke-covered path, or the manual scenario otherwise. Decide:
 
-- **REPRODUCED** — observed the same symptom locally. **Capture the observation harness** (exact commands, log greps, packet-capture filters, hardware/env configuration) used to detect the symptom. The harness becomes the contract for post-fix verification: «после фикса 0 событий через тот же grep / tcpdump / screenshot diff». Without the captured harness, the cause is not considered confirmed — the next session has no way to prove the symptom is gone except by repeating discovery.
+- **REPRODUCED** — observed the same symptom locally. **Capture the observation harness** (exact commands, log greps, packet-capture filters, hardware/env configuration) used to detect the symptom. The harness becomes the contract for post-fix verification: "after the fix, 0 events via the same grep / tcpdump / screenshot diff". Without the captured harness, the cause is not considered confirmed — the next session has no way to prove the symptom is gone except by repeating discovery.
 - **CANNOT REPRODUCE** — bug does not manifest in your environment. Document what you tried and what differs (OS version, device, build flavor, network setup). Stop here and escalate — going forward without reproduction is guessing.
 
 ### 2. Per-hypothesis experiment

--- a/.claude/agents/review-architecture.md
+++ b/.claude/agents/review-architecture.md
@@ -86,15 +86,15 @@ Also check the **Revisit if** section of every ADR governing the touched area. I
 
 ### 6. Trade-off vs violation
 
-`[REQUIRED]` — нарушение принципа: несимметрия слоёв, развернутое направление зависимости, абстракция против документированного правила, пропущенный source set. Принцип нарушен — фикс однозначен, выбор уровня не у автора.
+`[REQUIRED]` — a principle violation: layer asymmetry, reversed dependency direction, an abstraction contradicting a documented rule, a missing source set. The principle is violated — the fix is unambiguous; the author has no choice of level.
 
-`[QUESTION]` — обмен между двумя валидными shape'ами, где оба удовлетворяют принципам, но имеют разные ergonomic / robustness / maintainability profile'ы. Особенно в build-tooling / `.claude/` / CI / Gradle subprojects слое, где выбор часто упирается в «удобство для будущих контрибьюторов» vs «защита от опечатки». Не флагай как `[REQUIRED]` — это policy-выбор, не correctness. Назови два варианта явно, опиши trade-off, оставь решение пользователю.
+`[QUESTION]` — a trade-off between two valid shapes where both satisfy principles but have different ergonomic / robustness / maintainability profiles. Especially in the build-tooling / `.claude/` / CI / Gradle subprojects layer, where the choice often comes down to "convenience for future contributors" vs "protection against a typo". Do not flag as `[REQUIRED]` — this is a policy choice, not a correctness issue. Name both variants explicitly, describe the trade-off, and leave the decision to the user.
 
-Сигналы что находка — trade-off, а не violation:
-- Оба варианта работают и тесты зелёные;
-- Принцип, который нарушается, сам формулируется как «лучше» / «чище» / «менее хрупко», а не как абсолют («запрещено», «никогда», «всегда»);
-- В смежных модулях / прошлых PR живут оба shape'а;
-- Стоимость переключения значительная (ломает ergonomics для всех будущих модулей ради одного edge case).
+Signals that a finding is a trade-off, not a violation:
+- Both variants work and tests are green;
+- The principle being "violated" is itself phrased as "better" / "cleaner" / "less fragile", not as an absolute ("forbidden", "never", "always");
+- Both shapes coexist in adjacent modules / past PRs;
+- The switching cost is significant (breaks ergonomics for all future modules for the sake of one edge case).
 
 ### 7. Scope of the architectural change
 

--- a/.claude/agents/review-dod.md
+++ b/.claude/agents/review-dod.md
@@ -21,7 +21,7 @@ If the issue references a feature spec in `docs/product/features/` — read it; 
 
 ## What to check
 
-1. **Extract every acceptance criterion** from the issue body (DoD / Acceptance Criteria / "Сделать" / "Краевые случаи" sections) and from the feature spec if present. Treat both as a single combined checklist.
+1. **Extract every acceptance criterion** from the issue body (DoD / Acceptance Criteria / "To do" / "Edge cases" sections) and from the feature spec if present. Treat both as a single combined checklist.
 2. **For each criterion, classify against the diff:**
    - `DONE` — the diff visibly implements it (point to file:line)
    - `MISSING` — no trace in the diff

--- a/.claude/agents/review-tests.md
+++ b/.claude/agents/review-tests.md
@@ -20,7 +20,7 @@ Skip and return `PHASE: Tests — N/A` if PR_TYPE is `DOCS` or pure `INFRA` (no 
 ### 1. For each test added
 
 - **Does it actually test the behavior it names?** If you mentally invert the production logic, does this test fail? If the test would pass on a stub returning the expected output regardless of inputs — it's not a test, it's a tautology.
-- **Edge cases from the issue.** Open the issue's "Краевые случаи" / "Edge cases" / "Non-functional" sections. Every listed case must be covered or have an explicit reason it cannot be.
+- **Edge cases from the issue.** Open the issue's "Edge cases" / "Non-functional" sections. Every listed case must be covered or have an explicit reason it cannot be.
 - **Fakes vs mocks.** Per `testing.md`, prefer fakes over mocks. Mocks coupling to call order are a smell.
 - **Test isolation.** Tests must not depend on each other. No shared mutable static state between tests. CI-runnable.
 
@@ -34,7 +34,7 @@ For BUGFIX specifically: there MUST be a test that fails on the pre-fix code and
 
 Tests are not `[OPTIONAL]`. A scenario is `[REQUIRED]` if:
 - (a) it can be automated in the existing test infrastructure, AND
-- (b) it's in scope: DoD item, "Краевые случаи" from issue, or behavior the PR introduces/changes.
+- (b) it's in scope: DoD item, "Edge cases" from issue, or behavior the PR introduces/changes.
 
 The only legitimate reasons for `[OPTIONAL]`:
 - Scenario cannot be automated without disproportionate infrastructure (real disk-full, hardware-only, real network drop) — say so explicitly.
@@ -59,7 +59,7 @@ Default fix for a CI-red test is in the code. Flag as `[REQUIRED]` any PR change
 
 ### 7. Coroutine test API — `runTest` + `TestDispatcher`, not `runBlocking`
 
-Per `testing.md§Стиль`: coroutine tests use `runTest` + `TestDispatcher`, not `runBlocking`. Flag `runBlocking` in any new or modified test as `[REQUIRED]`. The only legitimate exception per `testing.md§Реальное время vs виртуальное` is waiting on events from external native APIs running on real threads outside the test's `CoroutineScope` (JmDNS, NsdManager, real Ktor server engine) — and even then the test must explain in a comment WHY virtual time cannot substitute.
+Per `testing.md §Style`: coroutine tests use `runTest` + `TestDispatcher`, not `runBlocking`. Flag `runBlocking` in any new or modified test as `[REQUIRED]`. The only legitimate exception per `testing.md §Real time vs virtual time` is waiting on events from external native APIs running on real threads outside the test's `CoroutineScope` (JmDNS, NsdManager, real Ktor server engine) — and even then the test must explain in a comment WHY virtual time cannot substitute.
 
 "Pre-existing file-wide convention" is NOT a valid excuse. A documented rule violation is drift, not convention; flag it as `[REQUIRED]` even if the orchestrator's prompt pre-classifies it as out of scope. The PR either fixes the drift in this PR or files a tracked follow-up before merge.
 

--- a/.claude/agents/review-visual.md
+++ b/.claude/agents/review-visual.md
@@ -5,71 +5,71 @@ tools: Bash, Read, Grep, Glob
 model: opus
 ---
 
-Ты сам рендеришь PNG-превью Compose-композаблов через Roborazzi (свежий запуск гарантирует актуальность скриншотов относительно текущего diff'а) и сверяешь их с двумя источниками правды:
+You render PNG previews of Compose composables yourself via Roborazzi (a fresh run guarantees screenshots are current relative to the diff) and compare them against two sources of truth:
 
-1. **Locked visual identity** Tether'а — `docs/engineering/adr/adr-visual-identity.md`, `docs/engineering/ui-style-guide.md`, `docs/engineering/ui-brand-mark.md`. Применяется к каждому PNG, независимо от того, есть ли у фичи UX-бриф.
-2. **UX-бриф фичи** — `docs/product/features/<slug>/ux-brief.md`. Применяется к каждому PNG, если бриф найден.
+1. **Tether's locked visual identity** — `docs/engineering/adr/adr-visual-identity.md`, `docs/engineering/ui-style-guide.md`, `docs/engineering/ui-brand-mark.md`. Applied to every PNG, regardless of whether the feature has a UX brief.
+2. **The feature's UX brief** — `docs/product/features/<slug>/ux-brief.md`. Applied to every PNG if the brief is found.
 
-Ты не судишь продуктовые решения и не пересматриваешь сам канон — только флагуешь расхождение между каноном/брифом и тем, что реально отображается на скриншоте.
+You do not judge product decisions and do not revisit the canon itself — you only flag discrepancies between the canon/brief and what actually appears on the screenshot.
 
-**Граница с `review-design-system`.** Источники правды у вас одни и те же (`ui-style-guide.md` / `adr-visual-identity.md` / `ui-brand-mark.md`); различаются плоскости enforcement'а. `review-design-system` читает Compose-код и ловит расхождения с каноном статически по исходникам. Ты смотришь Roborazzi-PNG и ловишь расхождения, видимые только на отрендеренном результате.
+**Boundary with `review-design-system`.** Both agents share the same sources of truth (`ui-style-guide.md` / `adr-visual-identity.md` / `ui-brand-mark.md`); what differs is the enforcement plane. `review-design-system` reads Compose source and catches deviations from the canon statically. You look at Roborazzi PNGs and catch deviations that are only visible in the rendered result.
 
-**Tiebreaker для серой зоны.** Если дефект виден и в коде, и на скриншоте — `review-design-system` фиксирует source-side причину, ты фиксируешь visual-side следствие. Дубль findings — допустим; ничейная зона — недопустима, поэтому при сомнении флагуй у себя.
+**Tiebreaker for the grey zone.** If a defect is visible both in the code and in the screenshot — `review-design-system` records the source-side cause, you record the visual-side consequence. Duplicate findings are acceptable; a no-man's-land is not — so when in doubt, flag on your side.
 
 ## When to run
 
 **Skip conditions — check in order; output the first that matches and stop:**
 
-1. Diff не трогает `composeApp/src/**`:
+1. Diff does not touch `composeApp/src/**`:
    ```
    PHASE: Visual-conformance — N/A (no Compose changes)
    ```
 
-2. В diff'е нет изменённых `@Preview`-функций:
+2. No `@Preview` functions changed in the diff:
    ```
    PHASE: Visual-conformance — N/A (no changed @Preview functions in diff)
    ```
 
-3. `./gradlew :composeApp:recordRoborazziDebug -q` упал (см. шаг 0 процедуры). Это значит сборка / тесты сломаны — это поймает другой ревьюер; здесь:
+3. `./gradlew :composeApp:recordRoborazziDebug -q` failed (see step 0 of the procedure). This means the build/tests are broken — another reviewer will catch it; here:
    ```
    PHASE: Visual-conformance — N/A [UNVERIFIABLE] (recordRoborazziDebug failed; <last 10 lines of error>)
    ```
 
-**Narrow-checklist condition (не skip).** Нет UX-брифа для фичи — visual-identity baseline всё равно прогоняется по каждому PNG; brief-conformance checklist пропускается. В output добавь строку `[NOTE] no UX brief for feature <slug> — brief-conformance checklist skipped, visual-identity baseline applied`.
+**Narrow-checklist condition (not a skip).** No UX brief for the feature — the visual-identity baseline is still run against every PNG; the brief-conformance checklist is skipped. Add a line to the output: `[NOTE] no UX brief for feature <slug> — brief-conformance checklist skipped, visual-identity baseline applied`.
 
 ## Procedure
 
 ### 0. Render PNGs (own responsibility)
 
-Если diff трогает `composeApp/src/**` и пройдены skip 1-2, запусти:
+If the diff touches `composeApp/src/**` and skip conditions 1–2 have not triggered, run:
 
 ```bash
 ./gradlew :composeApp:recordRoborazziDebug -q
 ```
 
-Вызывай Bash с `timeout: 600000` (10 минут) — cold-build с Robolectric SDK fetch и Compose-компиляцией штатно превышает дефолтный 2-минутный таймаут.
+Call Bash with `timeout: 600000` (10 minutes) — a cold build with Robolectric SDK fetch and Compose compilation routinely exceeds the default 2-minute timeout.
 
-PNG'и в `composeApp/build/outputs/roborazzi/` после этого соответствуют текущему HEAD'у. Render-before-review — твоя зона ответственности; не считай существующие PNG'и достоверными без перерендера. Если запуск упал по таймауту — повтори с большим таймаутом, прежде чем уходить в skip-4; skip-4 — только для реальных build/test failures, не для срезанного по времени Bash.
+The PNGs in `composeApp/build/outputs/roborazzi/` then correspond to the current HEAD. Render-before-review is your responsibility; do not treat existing PNGs as authoritative without re-rendering. If the run timed out — retry with a larger timeout before falling back to skip 3; skip 3 is only for real build/test failures, not for a Bash call cut off by time.
 
 ### 1. Discover the UX brief
 
-Агент получает либо номер PR (из `/code-review`), либо номер issue (из `/implement` до создания PR).
+The agent receives either a PR number (from `/code-review`) or an issue number (from `/implement` before the PR is created).
 
-**PR mode** — вход: PR number `<PR>`:
+**PR mode** — input: PR number `<PR>`:
 ```bash
 gh pr view <PR> --json closingIssuesReferences,body
 ```
-Для каждого referenced issue: `gh issue view <N>` — ищи ссылку на спеку или директорию `docs/product/features/`.
+For each referenced issue: `gh issue view <N>` — look for a link to the spec or the `docs/product/features/` directory.
 
-**Pre-PR / local mode** — вход: issue number `<N>`:
+**Pre-PR / local mode** — input: issue number `<N>`:
 ```bash
 gh issue view <N>
 ```
-Ищи ссылку на спеку или директорию `docs/product/features/` в теле issue.
+Look for a link to the spec or the `docs/product/features/` directory in the issue body.
 
-В обоих режимах: если явной ссылки нет — `glob docs/product/features/**/ux-brief.md` и сопоставь по теме из заголовка/тела и изменённых путей.
+In both modes: if no explicit link is found — `glob docs/product/features/**/ux-brief.md` and match by topic from the title/body and changed paths.
 
-Если бриф не найден → применяй narrow-checklist condition (visual-identity baseline всё равно прогоняется; brief-checklist пропускается с пометкой `[NOTE]`).
+If the brief is not found → apply the narrow-checklist condition (visual-identity baseline is still run; brief-checklist is skipped with a `[NOTE]`).
 
 ### 2. Diff-aware filter — select PNGs to review
 
@@ -83,60 +83,60 @@ gh pr diff <PR>
 git diff main...HEAD
 ```
 
-Из diff'а извлеки имена всех функций, к которым прибавлена или изменена аннотация `@Preview` (или тело которых изменено, если `@Preview` уже была). Это рабочий набор.
+From the diff, extract the names of all functions to which a `@Preview` annotation was added or changed (or whose body was changed if `@Preview` was already present). This is the working set.
 
-PNG-файлы именуются по шаблону `<FQN>_<PreviewName>.png`. Сопоставь рабочий набор превью с файлами в `composeApp/build/outputs/roborazzi/`:
+PNG files are named using the pattern `<FQN>_<PreviewName>.png`. Match the working set of previews against files in `composeApp/build/outputs/roborazzi/`:
 
 ```bash
 ls composeApp/build/outputs/roborazzi/
 ```
 
-Рассматривай только PNG, соответствующие рабочему набору. Если пересечение пустое — применяй skip condition 4.
+Only consider PNGs that correspond to the working set. If the intersection is empty — apply skip condition 4.
 
 ### 3. Read and compare
 
-Для каждого отобранного PNG:
+For each selected PNG:
 
-1. Читай PNG через `Read` tool (multimodal) — это даёт визуальное содержимое скриншота.
-2. Прогоняй два чеклиста подряд: **A** (visual-identity baseline, всегда) и **B** (brief-conformance, только если бриф найден).
+1. Read the PNG via the `Read` tool (multimodal) — this gives you the visual contents of the screenshot.
+2. Run both checklists in sequence: **A** (visual-identity baseline, always) and **B** (brief-conformance, only if the brief was found).
 
-#### A. Visual-identity baseline (всегда)
+#### A. Visual-identity baseline (always)
 
-Источники канона — единственная правда:
+Canon sources — the sole truth:
 
-- `docs/engineering/adr/adr-visual-identity.md` — палитра (`accent`/`peerIdentity`/`surface`/...), single-interactive-accent rule, обоснования (drop M3, no shadow, sharp corners, Inter), explicit out-of-scope (что НЕ канон).
+- `docs/engineering/adr/adr-visual-identity.md` — palette (`accent`/`peerIdentity`/`surface`/...), single-interactive-accent rule, rationale (drop M3, no shadow, sharp corners, Inter), explicit out-of-scope (what is NOT canon).
 - `docs/engineering/ui-style-guide.md` — token tables, spacing scale, shape scale, typography ladder, iconography rule (Tabler stroke-only), shadow ban, accessibility minimums.
-- `docs/engineering/ui-brand-mark.md` — геометрия и состояния `•—•`.
+- `docs/engineering/ui-brand-mark.md` — geometry and states of `•—•`.
 
-**Прочитай их полностью до анализа PNG'ей** (Read tool) — список правил живёт там, не здесь. 
+**Read them fully before analysing PNGs** (Read tool) — the list of rules lives there, not here.
 
-Затем по каждому PNG сверь увиденное с тем, что зафиксировано в источниках. Любое расхождение с явным правилом канона → `[REQUIRED]` со ссылкой на конкретное правило (`<doc> §<heading>`). Сомнительное (нет однозначной формулировки, но визуально настораживает) → `[ATTENTION]`.
+Then for each PNG, compare what you see against what is recorded in the sources. Any discrepancy with an explicit canon rule → `[REQUIRED]` with a reference to the specific rule (`<doc> §<heading>`). Questionable (no unambiguous wording, but visually concerning) → `[ATTENTION]`.
 
-#### B. Brief-conformance (если бриф найден)
+#### B. Brief-conformance (if the brief was found)
 
-Из брифа найди секцию, описывающую состояние, которое рендерит данный Preview (по имени Preview или по названию состояния — loading / empty / populated / error / …).
+From the brief, find the section describing the state that the given Preview renders (by Preview name or state name — loading / empty / populated / error / …).
 
-   **B.1. Layout-region completeness.** Все ли элементы, перечисленные в layout-регионах брифа для этого состояния, видны на скриншоте? Пропущенный элемент → `[REQUIRED]`.
+   **B.1. Layout-region completeness.** Are all elements listed in the brief's layout regions for this state visible in the screenshot? A missing element → `[REQUIRED]`.
 
-   **B.2. Visual layout / выравнивание.** Элементы расположены так, как описывает бриф (выравнивание, порядок, иерархия, видимые отступы между группами)? Артефакты вёрстки — обрезанный текст, неправильное центрирование, перекрытия — → `[REQUIRED]`. Это то, что в коде не видно: статический ревью говорит «токены правильные», ты говоришь «но на экране оно съехало».
+   **B.2. Visual layout / alignment.** Are elements positioned as the brief describes (alignment, order, hierarchy, visible spacing between groups)? Layout artefacts — clipped text, incorrect centring, overlaps — → `[REQUIRED]`. This is what cannot be seen in code: a static review says "tokens are correct", you say "but on screen it has shifted".
 
-   **B.3. Copy character-match.** Видимые текстовые строки (заголовки, кнопки, лейблы, плейсхолдеры) совпадают с брифом посимвольно (с поправкой на string-resource indirection)? Расхождение → `[REQUIRED]`.
+   **B.3. Copy character-match.** Do visible text strings (headings, buttons, labels, placeholders) match the brief character-for-character (accounting for string-resource indirection)? Discrepancy → `[REQUIRED]`.
 
-   **B.4. State correctness.** Визуальный сигнал соответствует ожидаемому состоянию? (Spinner при loading, пустой список при empty, список устройств при populated, сообщение об ошибке при error.) Несоответствие → `[REQUIRED]`.
+   **B.4. State correctness.** Does the visual signal match the expected state? (Spinner for loading, empty list for empty, device list for populated, error message for error.) Mismatch → `[REQUIRED]`.
 
-   **B.5. Surprise UI.** Есть ли элементы, которых нет в брифе? Каждый такой элемент → `[ATTENTION]` (не блокирует, если не противоречит брифу явно).
+   **B.5. Surprise UI.** Are there elements not mentioned in the brief? Each such element → `[ATTENTION]` (does not block unless it explicitly contradicts the brief).
 
 ### 4. What you do NOT check
 
-- Корректность самого брифа или самого канона — это `ux-expert` / архитектурное решение в ADR. Если решение выглядит неверным: `[UNVERIFIABLE] brief/ADR says X — flagged for owner`, не блокируй PR.
-- Source-side нарушения канона — `review-design-system`. Ты проверяешь только то, что видно на скриншоте; код за PNG'ом — не твой scope. На практике одно и то же нарушение обычно поднимут оба ревьюера с разных сторон — это норма (см. tiebreaker во введении).
-- Дублирование composable-кода → `review-reuse`.
-- Платформенные дельты за пределами брифа (iOS / macOS / Desktop поведение) → `review-platform`. Ты смотришь Android-rendered PNG как канонический агентный артефакт; реальная Apple-проверка — за `/smoke-test`.
-- Покрытие тестами → `review-tests`.
+- Correctness of the brief or the canon itself — that is for `ux-expert` / architectural decision in ADR. If the decision looks wrong: `[UNVERIFIABLE] brief/ADR says X — flagged for owner`, do not block the PR.
+- Source-side canon violations — `review-design-system`. You only check what is visible in the screenshot; the code behind the PNG is not your scope. In practice the same violation will usually be raised by both reviewers from different angles — that is expected (see tiebreaker in the introduction).
+- Composable code duplication → `review-reuse`.
+- Platform deltas beyond the brief (iOS / macOS / Desktop behaviour) → `review-platform`. You look at the Android-rendered PNG as the canonical agent artefact; real Apple verification is for `/smoke-test`.
+- Test coverage → `review-tests`.
 
 ## Output
 
-Группируй findings по PNG'у; внутри каждого PNG — сначала identity, потом brief.
+Group findings by PNG; within each PNG — identity first, then brief.
 
 ```
 PHASE: Visual-conformance
@@ -152,4 +152,4 @@ PHASE: Visual-conformance
 DECISION: BLOCK | APPROVE
 ```
 
-`APPROVE` только если ноль `[REQUIRED]`.
+`APPROVE` only if zero `[REQUIRED]`.

--- a/.claude/agents/spec-writer.md
+++ b/.claude/agents/spec-writer.md
@@ -57,7 +57,7 @@ Create `docs/product/features/<slug>/spec.md` from the template (creating the pe
 
 ### Step 4 — Show diff and confirm
 
-Run `git diff docs/product/features/` and present the result to the user. Ask: «Спека готова. Замечания или коммитим?»
+Run `git diff docs/product/features/` and present the result to the user. Ask: "Spec is ready. Any feedback, or shall we commit?"
 
 Do not commit. The user or the parent orchestrator decides when to commit (typically as part of the implementation PR, since spec + first implementation often land together — see CLAUDE.md "doc-as-spec" rule).
 

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -11,7 +11,7 @@ You write tests. Your job is to make broken code fail. A test that passes regard
 
 1. **Confirm worktree** (`pwd && git rev-parse --short HEAD`).
 2. **Read `docs/engineering/testing.md`** — test placement, fakes convention, what to mock, naming.
-3. **Read the issue** if a number was given (`gh issue view <N>`) — extract "Краевые случаи" and DoD-relevant scenarios.
+3. **Read the issue** if a number was given (`gh issue view <N>`) — extract "Edge cases" and DoD-relevant scenarios.
 4. **Read existing tests in the same module** — match conventions; don't introduce a new style.
 
 ## Rules

--- a/.claude/commands/check-review.md
+++ b/.claude/commands/check-review.md
@@ -1,82 +1,82 @@
-просмотри последние комментарии к ПР, над которым ты работаешь. оцени, какие из них валидны, исправь валидные. если есть невалидные, ответь на них, почему так считаешь. запушь изменения.
+Review the latest comments on the PR you are working on. Assess which of them are valid, fix the valid ones. If there are invalid ones, reply to them explaining why you consider them invalid. Push the changes.
 
-## Важно: точечная правка vs структурное замечание
+## Important: pointwise fix vs structural finding
 
-Перед тем как править, классифицируй замечание.
+Before fixing, classify the finding.
 
-- **Точечное** — относится к конкретной строке / файлу / формулировке. Пример: «опечатка», «эта проверка должна быть строгое равенство», «здесь не хватает теста». Чинится локально.
-- **Структурное** — указывает на принцип, который нарушается в данном месте. Пример: «фичи разделены по платформам, это неправильно», «эта функция не должна знать о слое X», «нейминг противоречит конвенции».
+- **Pointwise** — refers to a specific line / file / wording. Examples: "typo", "this check should be strict equality", "a test is missing here". Fixed locally.
+- **Structural** — points to a principle being violated at that location. Examples: "features are split by platform, that's wrong", "this function shouldn't know about layer X", "naming contradicts the convention".
 
-Если замечание **структурное** — не ограничивайся починкой указанной точки. **Сделай re-audit всего изменённого в PR и смежных файлов на ту же ошибку**. Каждое нарушение того же принципа — кандидат на починку в этом же заходе. Без re-audit'а ты с большой вероятностью отдашь PR обратно с теми же ошибками в других местах, и пользователь поймает их повторно.
+If the finding is **structural** — don't limit yourself to fixing only the cited point. **Re-audit everything changed in the PR and adjacent files for the same mistake**. Every violation of the same principle is a candidate for fixing in this same pass. Without a re-audit you will very likely return the PR with the same errors in other places, and the user will catch them again.
 
-**Re-audit должен покрывать все оси, не только ту, что в замечании.** Если ревьюер указал на расхождение между двумя артефактами (ADR vs practical doc, principle doc vs реализация, новая спека vs смежные доки) — проверь **все возможные оси согласованности** между ними (нейминг, scope, lifecycle, тайминг, формулировки), а не только конкретную ось из замечания. Узкий re-audit (по словам из текста замечания) часто оставляет другие расхождения того же класса, и они приходят следующим раундом ревью.
+**The re-audit must cover all axes, not only the one cited in the finding.** If the reviewer pointed to a divergence between two artifacts (ADR vs practical doc, principle doc vs implementation, new spec vs adjacent docs) — check **all possible consistency axes** between them (naming, scope, lifecycle, timing, wording), not just the specific axis from the finding. A narrow re-audit (limited to the words in the finding's text) often leaves other divergences of the same class, and they come back in the next review round.
 
-**Несколько комментариев → один принцип.** Когда два или больше комментариев формулируются разной лексикой, но указывают в одну сторону (например, на источник identity, layering, scope storage) — презумпция: это **один принцип на нескольких сайтах**, а не независимые соображения. Назови принцип явно, потом сделай по нему один re-audit, потом примени всюду. Раздельная интерпретация связанных комментариев — типичный путь к компромиссному решению, которое возвращается следующим раундом ревью.
+**Multiple comments → one principle.** When two or more comments are worded differently but point in the same direction (e.g., to the source of identity, layering, scope storage) — the presumption is: this is **one principle at multiple sites**, not independent considerations. Name the principle explicitly, then do one re-audit for it, then apply the fix everywhere. Interpreting related comments separately is a typical path to a compromise solution that comes back in the next review round.
 
-Сигналы того, что замечание структурное:
-- слова «не правильно», «нельзя», «не должно», «принцип», «всегда / никогда»
-- объяснение через категорию, а не через конкретику (не «вот эта строка», а «такие строки»)
-- ссылка на гайд / спеку / другой пример проекта
-- та же претензия повторяется на других строках/файлах в этом же ревью
+Signals that a finding is structural:
+- words like "wrong", "must not", "should not", "principle", "always / never"
+- explanation through a category, not a specific instance (not "this exact line", but "lines like this")
+- reference to a guide / spec / another project example
+- the same complaint repeated on other lines/files in the same review
 
-Если сомневаешься — спроси автора замечания: «Это конкретно про X, или есть ли ещё места, где надо применить тот же принцип?» — лучше задать вопрос, чем пройтись по PR три раза.
+If in doubt — ask the author of the finding: "Is this specifically about X, or are there other places where the same principle should be applied?" — it is better to ask than to go through the PR three times.
 
-**Желание оставить то, что ревьюер поставил под сомнение, — сигнал спросить.** Если комментарий из категории «зачем X / почему так», и у тебя есть оправдание сохранить X (KDoc, комментарий, переименование) — почти всегда ревьюер хотел снять X совсем, а не оправдать. Защита status quo через документирование — не тот ответ, который от тебя ждут. До того, как закрепить компромисс — задай прямой вопрос автору.
+**Wanting to keep what the reviewer questioned is a signal to ask.** If a comment is of the "why X / why like this" variety, and you have a justification for keeping X (KDoc, comment, renaming) — almost always the reviewer wanted to remove X entirely, not justify it. Defending the status quo through documentation is not the answer expected of you. Before locking in a compromise — ask the author directly.
 
-## Важно: оценивай пользу фикса сам, не верь меткам приоритета
+## Important: evaluate the value of a fix yourself, don't trust priority labels
 
-Не пропускай комментарий только потому, что ревьюер пометил его «optional» / «non-blocking» / «nice to have» / «follow-up» / «не блокер». Это его оценка приоритета — не твоя оценка ценности.
+Do not skip a comment just because the reviewer tagged it "optional" / "non-blocking" / "nice to have" / "follow-up" / "not a blocker". That is the reviewer's assessment of priority — not your assessment of value.
 
-Перед тем как согласиться вынести «опциональный» пункт за скоуп, ответь себе:
-- покрывает ли фикс пункт из DoD текущей задачи (issue body, acceptance criteria, нефункциональные требования, краевые случаи)?
-- ловит ли он класс багов, которые трудно поймать другим способом (regression risk, тонкое поведение)?
-- скоуп фикса умеренный — десятки строк, без новых компонентов / контрактов / зависимостей / новых платформ?
+Before agreeing to move an "optional" item out of scope, ask yourself:
+- Does the fix cover an item from the DoD of the current task (issue body, acceptance criteria, non-functional requirements, edge cases)?
+- Does it catch a class of bugs that are hard to catch any other way (regression risk, subtle behavior)?
+- Is the fix scope moderate — tens of lines, no new components / contracts / dependencies / new platforms?
 
-Если хотя бы на один из вопросов ответ «да», и общий объём не выходит за разумное расширение — **делай в этом же PR**. Тэг «optional» не отменяет полезности фикса и не освобождает от него.
+If at least one of these questions is answered "yes", and the overall volume does not exceed a reasonable extension — **do it in this same PR**. The "optional" tag does not cancel the value of the fix or exempt you from it.
 
-«Скоуп критично расширяется» = новый таргет / новый компонент / правка публичного контракта / необходимость менять смежные слои / непредсказуемый объём из-за раскрытия скрытого бага. Объём в строках — не главный критерий; главный — связность с текущей задачей.
+"Scope grows critically" = new target / new component / changing a public contract / needing to change adjacent layers / unpredictable volume due to revealing a hidden bug. Volume in lines is not the main criterion; the main criterion is relevance to the current task.
 
-Особенно осторожно: когда ревьюер сам сослался на пункт DoD или edge case из issue, метка «optional» в этом случае часто означает «не блокер для меня лично», но строго говоря это **gap в DoD**, и закрывать его обязан исполнитель текущей задачи, а не следующий ревью или будущий контрибьютор. Не перекладывай свой DoD на чужой backlog.
+Especially careful: when the reviewer themselves referenced a DoD item or edge case from the issue, the "optional" tag in that case often means "not a blocker for me personally", but strictly speaking this is a **gap in the DoD**, and closing it is the responsibility of the current task's assignee, not the next review or a future contributor. Do not offload your DoD onto someone else's backlog.
 
-## Важно: ответы на комментарии
+## Important: responding to comments
 
-**ВСЕГДА** отвечай **в треде исходного комментария**, никогда отдельным top-level комментом к PR. Связь «предложение → реакция» должна быть видна в одном месте — иначе ревьюер не понимает, что именно ты ответил, и тред остаётся «висящим».
+**ALWAYS** reply **in the thread of the original comment**, never as a separate top-level PR comment. The link "suggestion → reaction" must be visible in one place — otherwise the reviewer doesn't understand what exactly you replied to, and the thread remains "hanging".
 
-Любой inline review comment (в том числе прикреплённый к review-сабмишену) живёт в `pulls/PR/comments` и отвечается через `in_reply_to`:
+Any inline review comment (including one attached to a review submission) lives in `pulls/PR/comments` and is replied to via `in_reply_to`:
 
 ```bash
-# 1. Найти COMMENT_ID нужного комментария в треде
+# 1. Find the COMMENT_ID of the needed comment in the thread
 gh api repos/OWNER/REPO/pulls/PR/comments \
   --jq '.[] | {id, user: .user.login, path, line, in_reply_to_id, body}'
 
-# 2. Ответить в том же треде (in_reply_to можно указывать на любой комментарий
-#    треда — GitHub привяжет ответ к корню автоматически)
+# 2. Reply in the same thread (in_reply_to can point to any comment
+#    in the thread — GitHub will attach the reply to the root automatically)
 gh api repos/OWNER/REPO/pulls/PR/comments \
   -X POST \
   -F in_reply_to=COMMENT_ID \
-  -F body="текст ответа"
+  -F body="reply text"
 ```
 
-Объяснения и обоснования пиши именно там — ревьюер получит нотификацию и увидит ответ в контексте кода. `issues/PR/comments` — это top-level conversation, не тред: для ответов на ревью **не использовать**.
+Write explanations and justifications there — the reviewer will get a notification and see the reply in the context of the code. `issues/PR/comments` is the top-level conversation, not a thread: **do not use it** for replying to reviews.
 
-У review body (общий текст ревью без привязки к строке) отдельного thread-API нет, поэтому **редактируй сам review body и дописывай свою реакцию в конец** — так при чтении ревью сразу видно, что на него ответили:
+A review body (general review text not attached to a line) has no separate thread API, so **edit the review body itself and append your reaction at the end** — that way, when reading the review it is immediately visible that a reply was made:
 
 ```bash
-# Получить текущий body ревью
+# Get the current review body
 gh api repos/OWNER/REPO/pulls/PR/reviews/REVIEW_ID --jq '.body'
 
-# Обновить body — оригинал + разделитель + реакция
+# Update the body — original + separator + reaction
 gh api repos/OWNER/REPO/pulls/PR/reviews/REVIEW_ID \
   -X PUT \
-  -F body="$(printf '%s\n\n---\n\n%s' "ОРИГИНАЛЬНЫЙ_ТЕКСТ_РЕВЬЮ" "текст реакции")"
+  -F body="$(printf '%s\n\n---\n\n%s' "ORIGINAL_REVIEW_TEXT" "reaction text")"
 ```
 
-Формат:
+Format:
 
 ```
-ревью
+review
 ---
-реакция на ревью
+reaction to the review
 ```
 
-Не отвечай на review body через top-level `issues/PR/comments` — связь с ревью теряется.
+Do not reply to a review body via top-level `issues/PR/comments` — the link to the review is lost.

--- a/.claude/commands/close-issue.md
+++ b/.claude/commands/close-issue.md
@@ -1,163 +1,163 @@
-Завершить задачу <issue number> и смержить PR.
+Complete task <issue number> and merge the PR.
 
-Работай строго по шагам. Каждый шаг — это точка остановки: если что-то не выполнено, сообщи об этом явно и жди от пользователя подтверждения или исправления. Не переходи к следующему шагу без явного ОК.
-
----
-
-## Шаг 0 — Подтянуть main
-
-Запусти `/rebase` — подтянет `origin/main` и оценит семантическое пересечение с текущей работой. Если шаг сообщил о значимом пересечении — поправь работу под новый контекст до того, как начинать AC, smoke, ревью.
+Work strictly step by step. Each step is a stop point: if something is not done, report it explicitly and wait for the user's confirmation or correction. Do not proceed to the next step without an explicit OK.
 
 ---
 
-## Шаг 1 — Acceptance Criteria
+## Step 0 — Pull main
 
-Получи список acceptance criteria:
-- из issue (раздел DoD / Acceptance Criteria)
-- из feature-спека в `docs/product/features/`, если там есть файл для этой задачи
+Run `/rebase` — it will pull `origin/main` and assess semantic overlap with the current work. If the step reports significant overlap — adjust the work to the new context before starting AC, smoke, review.
 
-**Если ни DoD, ни feature-спека нет** (типично для инфраструктурных и мета-задач) — извлеки цели из тела issue, сформулируй проверяемый чек-лист сам и явно покажи его пользователю с пометкой «AC извлечены из тела issue, подтверди или скорректируй». Не переходи к следующему шагу, пока пользователь не подтвердил.
+---
 
-Для каждого критерия явно укажи статус: ✅ выполнен / ❌ не выполнен / ❓ невозможно проверить автоматически.
+## Step 1 — Acceptance Criteria
 
-Если есть ❌ — стоп. Не продолжай до устранения.
+Obtain the list of acceptance criteria:
+- from the issue (DoD / Acceptance Criteria section)
+- from the feature spec in `docs/product/features/`, if there is a file for this task
 
-**Проверка warnings.** Флаг `-q` скрывает Gradle/KGP warnings. Запусти один прогон без него и убедись, что новых предупреждений нет:
+**If neither a DoD nor a feature spec exists** (typical for infrastructure and meta tasks) — extract the goals from the issue body, formulate a verifiable checklist yourself, and explicitly show it to the user with the note "AC extracted from issue body, confirm or adjust". Do not proceed to the next step until the user has confirmed.
+
+For each criterion, explicitly state the status: ✅ done / ❌ not done / ❓ impossible to verify automatically.
+
+If there are ❌ items — stop. Do not continue until they are resolved.
+
+**Checking warnings.** The `-q` flag hides Gradle/KGP warnings. Run one pass without it and verify that no new warnings have appeared:
 
 ```bash
 ./gradlew allTests 2>&1 | grep -i "warning\|warn" | grep -v "^w: KLIB"
 ```
 
-Предупреждения вида `w: KLIB resolver: The same 'unique_name=...'` — существующие, игнорируй. Остальные — разбери перед мержем.
+Warnings of the form `w: KLIB resolver: The same 'unique_name=...'` are pre-existing — ignore them. All others — investigate before merging.
 
 ---
 
-## Шаг 2 — Ручные тесты
+## Step 2 — Manual tests
 
-### 2.1 Smoke-test — на усмотрение
+### 2.1 Smoke-test — at your discretion
 
-В репо есть скилл `/smoke-test` (см. `.claude/skills/smoke-test/`). Сам реши, надо ли его прогнать перед запросом подтверждения и какие блоки имеют смысл для этой задачи.
+The repo has a `/smoke-test` skill (see `.claude/skills/smoke-test/`). Decide yourself whether to run it before requesting confirmation and which blocks make sense for this task.
 
-Ориентир: какие части скилла реально пересекаются с тем, что менялось в PR. Менялся FileServer/CLI — гонять Desktop-блоки. Менялся Android FGS / mDNS — гонять Android-блок. Менялись нативные source sets — compile-блок. DOCS-only / `.claude/` / комментарии — обычно ничего гонять не нужно.
+Guideline: which parts of the skill genuinely intersect with what changed in the PR. If FileServer/CLI changed — run the Desktop blocks. If Android FGS / mDNS changed — run the Android block. If native source sets changed — the compile block. DOCS-only / `.claude/` / comments — usually nothing needs to be run.
 
-Если прогонял — приложи verdict (🟢/🟡/🔴) и список блоков к запросу подтверждения на 2.2.
+If you ran it — attach the verdict (🟢/🟡/🔴) and the list of blocks to the confirmation request in 2.2.
 
-### 2.2 Подтверждение от пользователя
+### 2.2 User confirmation
 
-Спроси пользователя явно:
+Ask the user explicitly:
 
-> Все ручные проверки пройдены? Если нет — что осталось?
+> Are all manual checks done? If not — what remains?
 
-**Это жёсткий stop-point.** Не переходи к шагу 2.3, пока пользователь не ответил явным «ОК / прошли / да». Собственный успешный smoke не считается за подтверждение — он лишь повышает уверенность пользователя при ответе.
+**This is a hard stop-point.** Do not proceed to step 2.3 until the user has replied with an explicit "OK / done / yes". A successful smoke run of your own does not count as confirmation — it only increases the user's confidence when answering.
 
-### 2.3 Проверка понимания
+### 2.3 Comprehension check
 
-Один вопрос пользователю на понимание принципов, реально применённых в этой задаче: архитектура / код / механизм / библиотека / платформенная особенность. Цель — тренажёр для собеседований Senior Android / KMP, не аудит готовности к merge.
+One question to the user to check understanding of principles actually applied in this task: architecture / code / mechanism / library / platform behavior. The goal is interview prep for Senior Android / KMP, not a merge-readiness audit.
 
-**Источник вопроса:**
-- Сначала открой [чеклист подготовки к собеседованию](../../docs/interview-prep-checklist.md) и найди невыполненный пункт (`- [ ]`), тематически совпадающий с тем, что менялось в PR. Если совпадение есть — задавай по нему.
-- Если ни один невыполненный пункт не совпадает с контекстом задачи — сформулируй свой вопрос по фактической реализации (что конкретно сделано в PR и почему именно так).
+**Source of the question:**
+- First open the [interview prep checklist](../../docs/interview-prep-checklist.md) and find an uncompleted item (`- [ ]`) that thematically matches what changed in the PR. If there is a match — ask based on it.
+- If no uncompleted item matches the context of the task — formulate your own question based on the actual implementation (what was specifically done in the PR and why).
 
-**Формат:**
-- Ровно один вопрос за прогон, не серия. Не «расскажи про X и Y и Z».
-- Открытый вопрос, не yes/no. Требуется развёрнутый ответ.
+**Format:**
+- Exactly one question per run, not a series. Not "tell me about X and Y and Z".
+- Open-ended question, not yes/no. A detailed answer is required.
 
-**После ответа пользователя:**
-- Оцени корректность: что верно, что упущено, что неточно или неверно. Без снисхождения и без агрессии — как технический собеседующий, дающий честную обратную связь.
-- Если ответ был по пункту из чеклиста — отметь его как выполненный (`- [ ]` → `- [x]`) прямо в `docs/interview-prep-checklist.md` через Edit. Если вопрос был свой (не из чеклиста) — впиши его в раздел «Дополнительные вопросы из задач» в конце чеклиста как `- [x] <вопрос>` через Edit.
+**After the user's answer:**
+- Assess correctness: what is right, what is missing, what is imprecise or wrong. Without leniency and without aggression — like a technical interviewer giving honest feedback.
+- If the answer was based on an item from the checklist — mark it as completed (`- [ ]` → `- [x]`) directly in `docs/interview-prep-checklist.md` via Edit. If the question was your own (not from the checklist) — add it to the "Additional questions from tasks" section at the end of the checklist as `- [x] <question>` via Edit.
 
-**Это не stop-point по содержанию ответа** — слабый ответ не блокирует merge. Пользователь сам решает, идти дальше или дополнительно проработать тему. Stop-point — только сам факт того, что вопрос задан и ответ получен.
+**This is not a stop-point based on the content of the answer** — a weak answer does not block the merge. The user decides themselves whether to proceed or explore the topic further. The stop-point is only the fact that the question was asked and an answer was received.
 
 ---
 
-## Шаг 3 — Code review
+## Step 3 — Code review
 
-Проверь PR:
+Check the PR:
 
 ```bash
 gh pr view <PR> --json reviews,comments --jq '{reviews: .reviews, comments: .comments}'
 ```
 
-Убедись, что все review-комментарии разобраны (resolved или отвечено с обоснованием). Сам вызов `/close-issue` — это апрув пользователя на мерж; отдельного APPROVED-review или фразы «lgtm» искать не нужно.
+Make sure all review comments are resolved (resolved or replied to with a justification). The `/close-issue` invocation itself is the user's approval for the merge; a separate APPROVED review or a "lgtm" phrase is not required.
 
 ---
 
-## Шаг 4 — Обновить документацию
+## Step 4 — Update documentation
 
-### 4.1 Статус в features/README.md
+### 4.1 Status in features/README.md
 
-Если задача реализовывала фичу из `docs/product/features/README.md` — обнови статус на `done`.
-Если это промежуточная задача (часть фичи) — обнови статус только если фича полностью готова.
+If the task implemented a feature from `docs/product/features/README.md` — update its status to `done`.
+If this is an intermediate task (part of a feature) — update the status only if the feature is fully complete.
 
-### 4.2 Затронутая документация
+### 4.2 Affected documentation
 
-Просмотри diff PR и определи: принимались ли в ходе задачи архитектурные или продуктовые решения, которые расходятся с текущей документацией?
+Review the PR diff and determine: were any architectural or product decisions made during this task that diverge from the current documentation?
 
-Затронутые файлы для проверки:
-- `docs/product/` — если изменилось поведение фичи, ЦА, стек
-- `docs/engineering/` — если изменились архитектурные принципы, схема модулей, правила DI
-- `CLAUDE.md` — если изменились процессы сборки, тестирования, структура проекта
+Files to check:
+- `docs/product/` — if feature behavior, target audience, or stack changed
+- `docs/engineering/` — if architectural principles, module layout, or DI rules changed
+- `CLAUDE.md` — if build, testing processes, or project structure changed
 
-Если документация устарела — обнови. Небольшие правки делай сразу, большие — создай отдельный issue.
+If the documentation is out of date — update it. Small edits do immediately, large ones — create a separate issue.
 
-**Doc-as-spec при первой имплементации архитектурного скетча.** Если PR — первая реальная имплементация паттерна, который в `docs/engineering/` был скетчем (маркер: «skeleton lands in #N» или примеры кода без рабочей реализации) — doc обязан быть обновлён в том же PR. Иначе следующий имплементатор пойдёт по устаревшему примеру.
+**Doc-as-spec on first implementation of an architectural sketch.** If the PR is the first real implementation of a pattern that was a sketch in `docs/engineering/` (marker: "skeleton lands in #N" or code examples without a working implementation) — the doc must be updated in the same PR. Otherwise, the next implementor will follow an outdated example.
 
-**Новый runtime-флаг — entry-point doc обязан его упомянуть.** Если в PR появился новый рантайм-флаг (env var, JVM system property, CLI option, build flag), который влияет на наблюдаемое поведение приложения — README или соответствующая entry-point секция должна его упоминать хотя бы одной строкой со ссылкой на engineering doc. Engineering doc как единственное место документации не считается покрытием: контрибьютор / пользователь ищет в README, не в `docs/engineering/`.
+**New runtime flag — the entry-point doc must mention it.** If the PR introduces a new runtime flag (env var, JVM system property, CLI option, build flag) that affects observable application behavior — the README or the corresponding entry-point section must mention it with at least one line and a link to the engineering doc. Engineering doc as the only documentation location does not count as coverage: a contributor / user looks in the README, not in `docs/engineering/`.
 
-**Новое правило в живом документе — audit фактического кода.** Если в PR добавлена / расширена политика или правило в `docs/engineering/` (sensitive-data policy, naming convention, layering rule, и т.п.) — прогони его по фактически затронутому коду свежего PR и убедись, что diff не нарушает только что введённое правило. Иначе doc сразу разойдётся с реальностью или правило молча создаст невидимые нарушения.
-
----
-
-## Шаг 5 — Зафиксировать инженерные решения, принятые по ходу
-
-Просмотри issue, переписку с пользователем и комментарии в PR: были ли приняты архитектурные / технические / процессные решения, которые **не зафиксированы** в `docs/engineering/` или `CLAUDE.md`?
-
-Примеры таких решений:
-- Выбор библиотеки, технологии или конкретного паттерна
-- Технические компромиссы — что приняли и что отложили
-- Принципы организации (модули, слои, нейминг)
-- Процессные конвенции (ветвление, формат артефактов, что выносится в отдельный issue)
-
-Если такое решение есть и оно нигде не записано — **до мержа** зафиксируй. Маленькое решение — короткой записью в существующий doc. Крупное — отдельным ADR или новым issue типа DOCS, если объём не помещается в текущий PR.
-
-Не оставляй решение жить только в чате: сессии теряются, следующий контрибьютор (или ты сам через месяц) не увидит истории и переоткроет тот же вопрос.
+**New rule in a live document — audit actual code.** If the PR adds or extends a policy or rule in `docs/engineering/` (sensitive-data policy, naming convention, layering rule, etc.) — run it against the code actually touched in the fresh PR and make sure the diff does not violate the just-introduced rule. Otherwise the doc will immediately diverge from reality, or the rule will silently create invisible violations.
 
 ---
 
-## Шаг 6 — Merge
+## Step 5 — Record engineering decisions made along the way
 
-**Перед merge: сверить `size:*` label с реальным объёмом работы.** Если задача исходно была `size:S`, а по факту получился `size:M` (или наоборот) — обнови label через `gh issue edit <N> --remove-label size:S --add-label size:M`. Метка должна отражать как реально вышло, не как изначально оценили — иначе будущая аналитика по объёмам будет врать.
+Review the issue, the conversation with the user, and comments in the PR: were any architectural / technical / process decisions made that are **not recorded** in `docs/engineering/` or `CLAUDE.md`?
 
-Не считай это «недоработкой оценки» — скоуп часто растёт по дороге из-за добавок пользователя или внешних условий. Просто фиксируй факт.
+Examples of such decisions:
+- Choice of library, technology, or specific pattern
+- Technical trade-offs — what was accepted and what was deferred
+- Organizational principles (modules, layers, naming)
+- Process conventions (branching, artifact format, what gets its own issue)
+
+If such a decision exists and is not recorded anywhere — **before merging**, record it. A small decision — as a short entry in an existing doc. A large one — as a separate ADR or a new DOCS issue if the volume doesn't fit in the current PR.
+
+Do not let a decision live only in the chat: sessions are lost, and the next contributor (or yourself a month later) won't see the history and will reopen the same question.
+
+---
+
+## Step 6 — Merge
+
+**Before merging: compare the `size:*` label with the actual volume of work.** If the task was originally `size:S` but turned out to be `size:M` (or vice versa) — update the label via `gh issue edit <N> --remove-label size:S --add-label size:M`. The label should reflect how it actually turned out, not the initial estimate — otherwise future analytics on volumes will be inaccurate.
+
+Don't treat this as "a poor estimate" — scope often grows along the way due to additions by the user or external conditions. Just record the fact.
 
 ```bash
 gh pr merge <PR> --squash --delete-branch
 ```
 
-Используй squash, если иное не указано. После мержа проверь, что PR закрыт и ветка удалена.
+Use squash unless otherwise specified. After merging, verify that the PR is closed and the branch is deleted.
 
 ---
 
-## Шаг 7 — Следующие задачи
+## Step 7 — Next tasks
 
-Посмотри в issue раздел «Следствия» и в PR — есть ли TODO, незакрытые вопросы, вещи вынесенные за скоуп.
+Look in the issue for a "Consequences" section and in the PR — are there TODOs, unresolved questions, things moved out of scope.
 
-Если есть явные следующие шаги — предложи создать issues (используй скилл `github-issue-author`).
-Если ничего нет — явно скажи об этом.
+If there are explicit next steps — offer to create issues (use the `github-issue-author` skill).
+If there is nothing — say so explicitly.
 
 ---
 
-## Шаг 8 — Ретро
+## Step 8 — Retro
 
-Были ли в ходе задачи системные сигналы? Триггеры на `/retro`:
+Were there any systemic signals during the task? Triggers for `/retro`:
 
-- багфикс (всегда — баг = система пропустила);
-- пользователь указал на трение с компонентом системы (гайд, скилл, команда, шаблон);
-- документация разошлась с реальностью (устаревший пример, неверный 3rd-party claim);
-- класс review-комментариев, который можно было поймать tooling'ом / правилом / hook'ом;
-- что-то прошло неожиданно хорошо — стоит зафиксировать механизм для воспроизведения;
-- issue/спека не хватило для старта — пробел в `github-issue-author` или `_template.md`.
+- bugfix (always — a bug = the system let it through);
+- user pointed to friction with a system component (guide, skill, command, template);
+- documentation diverged from reality (outdated example, incorrect 3rd-party claim);
+- a class of review comments that could have been caught by tooling / a rule / a hook;
+- something went unexpectedly well — worth recording the mechanism for reproduction;
+- the issue/spec wasn't sufficient to start without clarifications — a gap in `github-issue-author` or `_template.md`.
 
-**Не триггер:** агент ошибся → ревью поймало → агент починил в том же PR (это система работает). Много итераций сами по себе. Уточнения по скоупу в чате.
+**Not a trigger:** agent made a mistake → review caught it → agent fixed it in the same PR (this is the system working as intended). Many iterations by themselves. Scope clarifications in chat.
 
-Если триггер сработал — предложи `/retro` с указанием конкретного сигнала. Иначе закрой фразой «системных сигналов не вижу».
+If a trigger fired — propose `/retro` with the specific signal. Otherwise close with "I see no systemic signals".

--- a/.claude/commands/progress-boring.md
+++ b/.claude/commands/progress-boring.md
@@ -1,90 +1,90 @@
-Снимок прогресса проекта: инфра/фичи по PR + готовность MVP по roadmap.
+Project progress snapshot: infra/features by PR + MVP readiness by roadmap.
 
-## Что собрать
+## What to collect
 
-1. **PR-статистика через GraphQL.** Один запрос `gh api graphql` с пагинацией по `repository.pullRequests` — за раз `number, title, state, createdAt, mergedAt, additions, deletions, changedFiles, commits.totalCount, comments.totalCount, reviews.totalCount, reviewThreads.totalCount`. REST list endpoint `/pulls` не возвращает `commits`/`comments`/`review_comments` per PR — нужен GraphQL или per-PR detail call.
+1. **PR statistics via GraphQL.** One `gh api graphql` request with pagination over `repository.pullRequests` — fetching `number, title, state, createdAt, mergedAt, additions, deletions, changedFiles, commits.totalCount, comments.totalCount, reviews.totalCount, reviewThreads.totalCount` at once. The REST list endpoint `/pulls` does not return `commits`/`comments`/`review_comments` per PR — GraphQL or per-PR detail calls are needed.
 
-2. **MVP-скоуп.** Прочитай `docs/product/roadmap.md` (секция `## MVP`) — список MVP-пунктов. Прочитай `docs/product/features/README.md` — статусы фичей и связанные issues. Прочитай последний `docs/sprints/sprint-*.md` (по большему номеру) — что в работе сейчас.
+2. **MVP scope.** Read `docs/product/roadmap.md` (section `## MVP`) — list of MVP items. Read `docs/product/features/README.md` — feature statuses and linked issues. Read the latest `docs/sprints/sprint-*.md` (with the highest number) — what is in progress now.
 
-## Категоризация PR
+## PR categorization
 
-**Feature** — PR трогает продуктовый код или заполняет/правит продуктовую спеку:
-- `composeApp/src/**` (кроме `build.gradle.kts`-only), реализация discovery / FileServer / pairing / UI;
-- `docs/product/features/**` — заполнение спек фичей;
-- `docs/product/vision.md`, `roadmap.md`, `security.md`, `monetization.md` — продуктовое содержание.
+**Feature** — PR touches product code or fills in / edits a product spec:
+- `composeApp/src/**` (except `build.gradle.kts`-only), implementation of discovery / FileServer / pairing / UI;
+- `docs/product/features/**` — filling in feature specs;
+- `docs/product/vision.md`, `roadmap.md`, `security.md`, `monetization.md` — product content.
 
-**Infra** — всё остальное:
-- `.claude/**` (скиллы, агенты, hooks, commands);
-- `docs/engineering/**`, ADR'ы;
-- ретро-PR (заголовок начинается с `retro`);
+**Infra** — everything else:
+- `.claude/**` (skills, agents, hooks, commands);
+- `docs/engineering/**`, ADRs;
+- retro PRs (title starts with `retro`);
 - sprint planning, `docs/sprints/**`;
-- Gradle build, CI, конфиги;
-- чистые рефакторы без user-visible изменений.
+- Gradle build, CI, configs;
+- pure refactors with no user-visible changes.
 
-Если PR смешанный — отнеси по доминанте (>50% diff). Сомневаешься — спроси у пользователя один раз для всего батча.
+If a PR is mixed — categorize by the dominant part (>50% of the diff). If in doubt — ask the user once for the whole batch.
 
-## MVP-готовность
+## MVP readiness
 
-Для каждого пункта из `roadmap.md ## MVP` оцени готовность (0–100%) по доказательствам:
+For each item from `roadmap.md ## MVP` assess readiness (0–100%) based on evidence:
 
-- 100% — feature имеет статус `done` в `features/README.md` И есть смерженные PR, покрывающие все платформы.
-- 50–80% — частично: либо protocol-слой без UI, либо платформ-парность неполная (например, Android+iOS done, Desktop tbd).
-- 10–30% — только спека `scoped`, кода нет; или только один из нескольких компонентов.
-- 0% — ни кода, ни спеки в статусе ≥`scoped`.
+- 100% — feature has status `done` in `features/README.md` AND there are merged PRs covering all platforms.
+- 50–80% — partial: either protocol layer without UI, or platform parity incomplete (e.g., Android+iOS done, Desktop tbd).
+- 10–30% — only spec `scoped`, no code; or only one of several components.
+- 0% — neither code nor spec with status ≥`scoped`.
 
-Не угадывай — каждую оценку обоснуй ссылкой на PR номера и/или строки в `features/README.md`. Если по доказательствам не ясно — отметь `?` и спроси.
+Don't guess — justify each assessment with PR numbers and/or lines in `features/README.md`. If the evidence is unclear — mark `?` and ask.
 
-## Скорость (velocity) per day
+## Velocity per day
 
-Дневная скорость = сумма стоимости задач, закрытых за день. Стоимость одной задачи:
+Daily velocity = sum of the cost of tasks closed that day. Cost of one task:
 
 ```
 cost(task) = base(size) + 0.3·comments + LOC/200 + cycleHours/24
 ```
 
-- `base(size)` — по issue-лейблу закрытого PR: `size:S=1`, `size:M=3`, `size:L=8`, без лейбла=2. Ретро / PR без issue: `base=1`.
-- `comments` = `comments.totalCount + reviewThreads.totalCount` PR.
-- `LOC` = `additions + deletions` PR.
-- `cycleHours` = часы между первым коммитом PR (`commits.nodes[0].commit.committedDate`) и `mergedAt`.
+- `base(size)` — by the issue label of the closed PR: `size:S=1`, `size:M=3`, `size:L=8`, no label=2. Retro / PR without issue: `base=1`.
+- `comments` = `comments.totalCount + reviewThreads.totalCount` of the PR.
+- `LOC` = `additions + deletions` of the PR.
+- `cycleHours` = hours between the first commit of the PR (`commits.nodes[0].commit.committedDate`) and `mergedAt`.
 
-Все слагаемые подобраны так, чтобы для типичного `size:M` PR (~5 комментов, ~400 LOC, ~6h цикла) дать соизмеримый вклад: `3 + 1.5 + 2 + 0.25 ≈ 7`. Базовый размер задаёт пол, активность добавляет сверху.
+All components are calibrated so that for a typical `size:M` PR (~5 comments, ~400 LOC, ~6h cycle) they give a comparable contribution: `3 + 1.5 + 2 + 0.25 ≈ 7`. Base size sets the floor, activity adds on top.
 
-`velocity(D) = Σ cost(task)` по PR, смерженным в день `D` (по `mergedAt::date`, UTC). День без merge — `0`.
+`velocity(D) = Σ cost(task)` for PRs merged on day `D` (by `mergedAt::date`, UTC). A day without a merge — `0`.
 
-Связь PR ↔ issue по префиксу `#N:` в title PR или в первом коммите (CLAUDE.md commit convention). Лейбл size — с issue.
+PR ↔ issue linkage by the `#N:` prefix in the PR title or first commit (CLAUDE.md commit convention). Size label — from the issue.
 
-**Окно** — день. Неделя на проекте возрастом ~месяц неинформативна.
+**Window** — one day. A week for a project ~one month old is uninformative.
 
-## Вывод
+## Output
 
-Один HTML-файл `/tmp/tether-progress.html` (видим в Launch preview panel), содержащий:
+One HTML file `/tmp/tether-progress.html` (visible in the Launch preview panel), containing:
 
-1. **KPI-плитка сверху**: всего смержено PR · % feature / % infra · % MVP (средневзвешенно, равные веса по пунктам) · активные дни · текущий спринт + его номер · средняя дневная скорость.
-2. **Stacked bar по неделям** (feature vs infra) — динамика соотношения.
-3. **Velocity per day** — line chart дневной стоимости. Точки красятся по доминанте дня (feature золото, infra тёмный янтарь); серая линия — сам валор. Под ним три цифры: суммарный / средний / пиковый день. Цель графика — визуальная проверка гипотезы «инфра-дни тянут за собой feature-всплески».
-4. **Bubble scatter** PR: x=commits, y=comments, размер=LOC, цвет=категория. Подпись «правый верх — тяжёлые PR».
-5. **Таблица MVP** (7 строк): пункт roadmap | статус фичи | % готовности | доказательства (PR-номера, ссылка на спеку).
-6. **Топ-5 тяжёлых PR** (по `commits + comments`).
-7. **Блок «что дальше»**: что в работе в текущем спринте (issues), что блокирует MVP.
+1. **KPI tile at the top**: total merged PRs · % feature / % infra · % MVP (weighted average, equal weights per item) · active days · current sprint + its number · average daily velocity.
+2. **Stacked bar by week** (feature vs infra) — dynamics of the ratio.
+3. **Velocity per day** — line chart of daily cost. Points colored by the day's dominant category (feature gold, infra dark amber); gray line — the value itself. Below it three numbers: total / average / peak day. The goal of the chart is a visual check of the hypothesis "infra-days drive feature spikes".
+4. **Bubble scatter** of PRs: x=commits, y=comments, size=LOC, color=category. Label "top right — heavy PRs".
+5. **MVP table** (7 rows): roadmap item | feature status | % readiness | evidence (PR numbers, link to spec).
+6. **Top 5 heaviest PRs** (by `commits + comments`).
+7. **"What's next" block**: what is in progress in the current sprint (issues), what is blocking MVP.
 
-**Стиль — нейтральный, без RPG-обёртки.** `progress-boring` существует именно как трезвый dashboard, поэтому визуально он не должен наследовать палитру/шрифты из `/progress` (Cinzel, золото, пергамент, орнаменты `❧`). Не подключай `.claude/skills/progress/assets/palette.json` и не используй его токены даже если они уже загружены в контексте — это инерция, а не правило.
+**Style — neutral, no RPG wrapper.** `progress-boring` exists precisely as a sober dashboard, so visually it must not inherit the palette/fonts from `/progress` (Cinzel, gold, parchment, ornaments `❧`). Do not load `.claude/skills/progress/assets/palette.json` and do not use its tokens even if they are already in context — that would be inertia, not a rule.
 
-Конкретно:
-- **Шрифты** — системный sans-serif стек (`-apple-system, Segoe UI, Roboto, Inter, sans-serif`), для цифр — моноширинный (`ui-monospace, SF Mono, Menlo, monospace`). Никаких декоративных засечных и заголовочных антик.
-- **Палитра** — нейтральная тёмная: фон `#0f1115` / `#161922`, текст `#e6e8eb` / muted `#8b9098`, акцент `#6ea8fe` (холодный синий) для feature, `#9aa0a6` (серый) для infra. Кровавый/золотой не использовать.
-- **Декор** — без рамок-орнаментов, без псевдо-элементов, без эмодзи в заголовках. Простые `1px solid` границы карточек, плоские углы, минимум.
-- **Заголовки** — обычным весом (600), без `text-transform: uppercase` и `letter-spacing`, кроме мелких labels у KPI.
+Specifically:
+- **Fonts** — system sans-serif stack (`-apple-system, Segoe UI, Roboto, Inter, sans-serif`), for numbers — monospace (`ui-monospace, SF Mono, Menlo, monospace`). No decorative serif or display fonts.
+- **Palette** — neutral dark: background `#0f1115` / `#161922`, text `#e6e8eb` / muted `#8b9098`, accent `#6ea8fe` (cold blue) for feature, `#9aa0a6` (gray) for infra. No crimson/gold.
+- **Decoration** — no ornamental borders, no pseudo-elements, no emojis in headings. Simple `1px solid` card borders, flat corners, minimal.
+- **Headings** — normal weight (600), no `text-transform: uppercase` and no `letter-spacing`, except for small KPI labels.
 
-Chart.js через CDN. Графики тоже в нейтральных тонах (тот же синий+серый, не gold/amber).
+Chart.js via CDN. Charts also in neutral tones (same blue+gray, not gold/amber).
 
-После сборки HTML — короткий текстовый дайджест в чат (5–7 строк), без повторения цифр из таблицы:
-- одна фраза про соотношение и тренд по неделям;
-- общий процент MVP + какие 2-3 пункта тянут вниз;
-- одно наблюдение про скорость: есть ли видимая корреляция «infra-день → feature-всплеск через 1–2 дня», или дни перемешаны без паттерна;
-- 1-2 наблюдения, которых не видно по цифрам (например, «весь UI-слой ещё впереди», «спринт 4 снимает архитектурные блокеры»).
+After building the HTML — a short text digest in chat (5–7 lines), without repeating figures from the table:
+- one phrase on the ratio and weekly trend;
+- overall MVP percentage + which 2-3 items are pulling it down;
+- one observation on velocity: is there a visible correlation "infra-day → feature spike 1–2 days later", or are days mixed without a pattern;
+- 1-2 observations not visible from the numbers (e.g., "the entire UI layer is still ahead", "sprint 4 removes architectural blockers").
 
-## Чего не делать
+## What not to do
 
-- Не запускай Gradle, тесты, smoke — это чистая аналитика.
-- Не пиши markdown-отчёт в `docs/` — это эфемерный снимок, живёт в `/tmp/`.
-- Не категоризируй вручную больше 10 PR без оптимизации — если их много, напиши короткий Python-скрипт.
+- Do not run Gradle, tests, smoke — this is pure analytics.
+- Do not write a markdown report in `docs/` — this is an ephemeral snapshot, it lives in `/tmp/`.
+- Do not categorize more than 10 PRs manually without optimization — if there are many, write a short Python script.

--- a/.claude/commands/quick-issue.md
+++ b/.claude/commands/quick-issue.md
@@ -1,8 +1,8 @@
-Создай issue для задачи: $ARGUMENTS
+Create an issue for the task: $ARGUMENTS
 
-1. Напиши краткий черновик: заголовок + поле `**Тип:**` (`FEATURE | BUGFIX | REFACTOR | INFRA | DOCS | DEPENDENCY`) + 2-4 предложения контекста + DoD-чеклист + предполагаемый `size:` (S — до 4 часов, M — до одного дня, L — до трёх дней). Покажи пользователю, жди апрува.
-2. Создай issue через `gh issue create --body-file /tmp/issue-body.md --label size:<S|M|L>`.
-3. Если указан parent — привяжи через GraphQL `addSubIssue`.
-4. Верни номер и URL созданного issue.
+1. Write a brief draft: title + field `**Type:**` (`FEATURE | BUGFIX | REFACTOR | INFRA | DOCS | DEPENDENCY`) + 2-4 sentences of context + DoD checklist + estimated `size:` (S — up to 4 hours, M — up to one day, L — up to three days). Show it to the user and wait for approval.
+2. Create the issue via `gh issue create --body-file /tmp/issue-body.md --label size:<S|M|L>`.
+3. If a parent is specified — link via GraphQL `addSubIssue`.
+4. Return the number and URL of the created issue.
 
-Не задавай уточняющих вопросов, если из описания всё понятно. Черновик — в свободной форме, без elaborate шаблонов.
+Do not ask clarifying questions if everything is clear from the description. The draft — in free form, without elaborate templates.

--- a/.claude/commands/retro.md
+++ b/.claude/commands/retro.md
@@ -1,107 +1,107 @@
-Проведи ретроспективу по задаче <issue number> (и связанному PR, если есть).
+Run a retrospective on task <issue number> (and the associated PR, if any).
 
-Цель — не отчёт ради отчёта и не каталог точечных ошибок, а **системные улучшения**: что в промптах, командах, скиллах, документации или структуре проекта надо изменить, чтобы будущим исполнителям было легче делать качественную работу. Каждый вывод должен заканчиваться действием.
+The goal is not a report for its own sake and not a catalog of pointwise mistakes, but **systemic improvements**: what in the prompts, commands, skills, documentation, or project structure needs to change so that future assignees can do quality work more easily. Every conclusion must end with an action.
 
-**Что НЕ интересует ретро.** Точечные ошибки агента, которые поймал ревьюер и которые были исправлены в том же PR — это система работает как задумано, не сбой. Ретро не про «агент мог быть внимательнее». Ретро про «как сделать класс таких ошибок маловероятным независимо от внимательности».
+**What the retro is NOT interested in.** Pointwise agent mistakes that the reviewer caught and that were fixed in the same PR — this is the system working as intended, not a failure. The retro is not about "the agent could have been more careful". The retro is about "how to make this class of mistakes unlikely regardless of attentiveness".
 
-**Что интересует ретро.** Системные пробелы (gap в доках/скиллах/командах/промптах) и системные удачи (что прошло неожиданно хорошо благодаря архитектуре/инструменту/паттерну — и как воспроизводить это в будущих задачах).
+**What the retro IS interested in.** Systemic gaps (gaps in docs / skills / commands / prompts) and systemic successes (what went unexpectedly smoothly due to architecture / tool / pattern — and how to reproduce it in future tasks).
 
 ---
 
-## Шаг 1 — Сбор фактов
+## Step 1 — Gather facts
 
-Собери контекст:
+Collect context:
 
 ```bash
 gh issue view <N> --json title,body,comments
-gh pr view <PR> --json title,body,commits,comments,reviews  # если известен
-git log --oneline <merge-commit> -1  # если уже смержен
+gh pr view <PR> --json title,body,commits,comments,reviews  # if known
+git log --oneline <merge-commit> -1  # if already merged
 ```
 
-Прочитай всю историю: issue, комментарии, review, переписку в PR.
+Read the full history: issue, comments, review, conversation in the PR.
 
 ---
 
-## Шаг 2 — Системный анализ
+## Step 2 — Systemic analysis
 
-Фокус: **система → действие**, не «агент → внимательность».
+Focus: **system → action**, not "agent → attentiveness".
 
-**Системные пробелы:**
-- Пробел в `CLAUDE.md` / `docs/engineering/` / скилле / шаблоне, из-за которого ошибка была *запрограммированной*?
-- Полагался ли исполнитель/ревьюер на что-то, что оказалось неверным или устаревшим (doc, пример, 3rd-party claim)?
-- Класс ревью-комментариев, который можно поймать tooling/hook/правилом — не вниманием?
-- Чего не хватило в issue/спеке для старта без уточнений?
+**Systemic gaps:**
+- A gap in `CLAUDE.md` / `docs/engineering/` / a skill / a template that made the mistake *programmatic*?
+- Did the assignee / reviewer rely on something that turned out to be incorrect or outdated (doc, example, 3rd-party claim)?
+- A class of review comments that can be caught by tooling / a hook / a rule — not by attention?
+- What was missing in the issue/spec to start without clarifications?
 
-**Системные удачи:**
-- Что прошло неожиданно гладко, почему?
-- Есть ли воспроизводимая логика — закодифицировать как принцип в `docs/engineering/`, чек в скилле, пункт в шаблоне команды?
-- Бесплатный multiplier (одно действие → несколько платформ/задач)? Каким механизмом, как развернуть на похожие случаи?
+**Systemic successes:**
+- What went unexpectedly smoothly, and why?
+- Is there a reproducible logic — to codify as a principle in `docs/engineering/`, a check in a skill, an item in a command template?
+- A free multiplier (one action → multiple platforms/tasks)? By what mechanism, how to extend it to similar cases?
 
-Если нет ни пробелов, ни удач достойных фиксации — закрой фразой «системных изменений не вижу», не выдумывай action items ради формы.
-
----
-
-## Шаг 3 — Анализ бага (только если задача — багфикс)
-
-Багфикс = система пропустила баг в main. Ретро обязательно. Системно:
-
-1. **Как баг попал в main?** Отсутствие класса тестов; гайд описывал pattern, который и привёл к багу; ревью не ловит — какой именно чек не сработал; edge case известен но не зафиксирован.
-2. **Где нужна системная защита?** Тест на класс багов, валидация, чек в `/code-review`, hook на pattern, пример/ограничение в `CLAUDE.md` или спеке.
-
-Простая защита — в ретро-PR; крупная — отдельным issue.
+If there are neither gaps nor successes worth recording — close with "I see no systemic changes", don't invent action items for the sake of form.
 
 ---
 
-## Шаг 4 — Что оптимизировать
+## Step 3 — Bug analysis (only if the task is a bugfix)
 
-На основе шагов 2–3 определи конкретные системные правки. Категории:
+Bugfix = the system let a bug through to main. Retro is mandatory. Systemically:
 
-| Категория | Когда трогать |
-|-----------|--------------|
-| `.claude/commands/*.md` | Команда давала нечёткие инструкции, не покрывала сценарий, или не имела нужного шага |
-| `.claude/skills/` | Скилл не покрывал нужный сценарий или не предотвращал класс ошибок |
-| `CLAUDE.md` | Конвенция/процесс/структура проекта не зафиксированы — агент должен был догадаться |
-| `docs/engineering/` | Архитектурный принцип / паттерн зафиксирован неверно, неполно, или его примеры расходятся с реальностью |
-| `docs/product/features/` | Feature-спек неполный или отсутствует там, где был бы полезен |
-| `.claude/skills/github-issue-author` | Issue получался с недостаточным контекстом для прямой реализации |
-| Hook в `scripts/install-hooks.sh` | Класс ошибок ловится автоматически на уровне git операции, а не только инструкцией |
+1. **How did the bug get into main?** Absence of a class of tests; a guide described a pattern that led to the bug; review didn't catch it — which specific check didn't work; an edge case was known but not recorded.
+2. **Where is systemic protection needed?** A test for the class of bugs, validation, a check in `/code-review`, a hook on a pattern, an example/restriction in `CLAUDE.md` or the spec.
 
-Для каждой потенциальной правки явно укажи, **на какой системный gap она отвечает** — без этой связи правка превращается в добавку «на всякий случай».
+Simple protection — in the retro PR; larger — as a separate issue.
 
 ---
 
-## Шаг 5 — Формулировка действий (без применения)
+## Step 4 — What to optimize
 
-На основе анализа составь список предлагаемых изменений. **Не применяй их сразу** — сначала нужен явный апрув.
+Based on steps 2–3, identify specific systemic changes. Categories:
 
-Для каждого улучшения укажи:
-- Что именно изменить (файл, раздел)
-- На какой системный gap или системную удачу отвечает (явная связь с конкретным инцидентом / эффектом из истории задачи)
-- Размер: «маленькое» (правка на месте) или «задача» (отдельный issue)
+| Category | When to touch |
+|----------|--------------|
+| `.claude/commands/*.md` | The command gave unclear instructions, didn't cover a scenario, or lacked a needed step |
+| `.claude/skills/` | The skill didn't cover the needed scenario or didn't prevent a class of errors |
+| `CLAUDE.md` | A convention / process / project structure is not recorded — the agent had to guess |
+| `docs/engineering/` | An architectural principle / pattern is recorded incorrectly, incompletely, or its examples diverge from reality |
+| `docs/product/features/` | A feature spec is incomplete or missing where it would have been useful |
+| `.claude/skills/github-issue-author` | Issues came out with insufficient context for direct implementation |
+| Hook in `scripts/install-hooks.sh` | A class of errors is catchable automatically at the git operation level, not only by instruction |
 
-Выведи список и явно спроси:
-
-> Подтверждаешь эти изменения? Если нет — скажи, что скорректировать.
-
-**Не переходи к шагу 6 без явного «да» или «ок» от пользователя.**
+For each potential change explicitly state **which systemic gap it addresses** — without this link the change becomes an addition "just in case".
 
 ---
 
-## Шаг 6 — Применение (только после апрува)
+## Step 5 — Formulate actions (without applying)
 
-**Все изменения делай на отдельной ветке от `main`, не на `main` напрямую.** Ретро-правки — такой же процесс, как обычные задачи: ветка → коммит → PR → ревью. Даже если правки маленькие и в `.claude/` — они идут через PR, чтобы остался след и возможность откатить.
+Based on the analysis, compile a list of proposed changes. **Do not apply them immediately** — explicit approval is needed first.
 
-Для каждого подтверждённого улучшения:
+For each improvement specify:
+- What exactly to change (file, section)
+- Which systemic gap or systemic success it addresses (explicit link to a specific incident / effect from the task history)
+- Size: "small" (fix in place) or "task" (separate issue)
 
-**Если изменение маленькое** (правка в документе, уточнение в команде) — сделай прямо сейчас и покажи diff.
+Output the list and explicitly ask:
 
-**Если изменение требует отдельной задачи** — создай issue через скилл `github-issue-author`. Название должно читаться как полезный инкремент к рабочему процессу, например:
-- «Добавить проверку X в code-review.md»
-- «Уточнить scope скилла implement для случая Y»
+> Do you confirm these changes? If not — tell me what to adjust.
 
-**Title PR для ретро-правок** должен начинаться с `retro from #<PR>: ...`, где `<PR>` — номер исходного PR, по которому проводилось ретро. Это даёт сразу видимую связь и упрощает поиск. Пример: `retro from #70: clarify smoke step in close-issue command`.
+**Do not proceed to step 6 without an explicit "yes" or "ok" from the user.**
 
-**Итог ретро** — выведи списком:
-- ✅ Сделано сразу: [что именно, на какой gap/удачу отвечает]
-- 📋 Запланировано: [issue #N — что, на какой gap отвечает]
-- 💡 Наблюдение без действия: [если есть — почему без действия]
+---
+
+## Step 6 — Apply (only after approval)
+
+**Make all changes on a separate branch from `main`, not directly on `main`.** Retro fixes are the same process as regular tasks: branch → commit → PR → review. Even if the changes are small and in `.claude/` — they go through a PR, so that a trace remains and rollback is possible.
+
+For each confirmed improvement:
+
+**If the change is small** (edit in a document, clarification in a command) — do it right now and show the diff.
+
+**If the change requires a separate task** — create an issue via the `github-issue-author` skill. The name should read as a useful increment to the workflow, for example:
+- "Add check X to code-review.md"
+- "Clarify scope of implement skill for case Y"
+
+**PR title for retro fixes** must start with `retro from #<PR>: ...`, where `<PR>` is the number of the original PR the retro was run on. This gives an immediately visible link and simplifies search. Example: `retro from #70: clarify smoke step in close-issue command`.
+
+**Retro outcome** — output as a list:
+- ✅ Done immediately: [what exactly, which gap/success it addresses]
+- 📋 Planned: [issue #N — what, which gap it addresses]
+- 💡 Observation without action: [if any — why without action]

--- a/.claude/commands/sprint-pick.md
+++ b/.claude/commands/sprint-pick.md
@@ -1,61 +1,61 @@
-Экспресс: что брать из текущего спринта прямо сейчас. Только чтение и `gh`, без Gradle.
+Quick look: what to pick from the current sprint right now. Read-only and `gh` only, no Gradle.
 
-## 1. Спринт
+## 1. Sprint
 
-Возьми `docs/sprints/sprint-NN.md` с максимальным NN. Прочитай **только** секции «Цель спринта», «Состав», «Цепочки блокировок». Извлеки номера issue.
+Take `docs/sprints/sprint-NN.md` with the maximum NN. Read **only** the sections "Sprint goal", "Composition", "Blocking chains". Extract issue numbers.
 
-Если файла нет — скажи и предложи `/grooming`. Стоп.
+If the file doesn't exist — say so and propose `/grooming`. Stop.
 
-## 2. Статусы одним батчем
+## 2. Statuses in one batch
 
 ```bash
-gh issue view <N1> <N2> ... --json number,state,title    # последовательно, без --jq, можно в одном bash блоке через ;
+gh issue view <N1> <N2> ... --json number,state,title    # sequentially, without --jq, can be in one bash block via ;
 ```
 
-Или короче — для каждого `<N>` параллельно:
+Or shorter — for each `<N>` in parallel:
 ```bash
 gh issue view <N> --json number,state,title
 gh pr list --search "<N> in:title" --state open --json number,isDraft,mergeable
 ```
 
-Группируй в один tool-call с `;` между командами. Не вызывай `dependencies/blocked_by` сразу для всех — только для тех, что `OPEN` без активного PR (кандидаты на старт).
+Group into one tool-call with `;` between commands. Do not call `dependencies/blocked_by` for all at once — only for those that are `OPEN` without an active PR (candidates for starting).
 
-Маркировка:
+Marking:
 - ✅ closed
 - 🟡 open + open PR
-- 🟢 open, без PR
-- 🔴 blocked (если шаг 3 нашёл open-блокер)
+- 🟢 open, no PR
+- 🔴 blocked (if step 3 found an open blocker)
 
-## 3. Блокеры — только для 🟢
+## 3. Blockers — only for 🟢
 
-Для каждой 🟢:
+For each 🟢:
 ```bash
 gh api repos/khmelevartem/tether/issues/<N>/dependencies/blocked_by --jq '.[] | "\(.number) \(.state)"'
 ```
 
-Если есть open-блокер → 🔴. Учти также внутренний порядок мерджа из «Цепочки блокировок» спринт-дока.
+If there is an open blocker → 🔴. Also account for the internal merge order from the "Blocking chains" section of the sprint doc.
 
-## 4. Вывод (компактный)
+## 4. Output (compact)
 
 ```
-Спринт N — «<цель>»
+Sprint N — "<goal>"
 ✅ #a #b   🟡 #c   🟢 #d #e   🔴 #f (blocked by #g)
 
-Брать сейчас:
-1. #N — <название>. Почему: <одна фраза>.
+Pick now:
+1. #N — <title>. Why: <one sentence>.
 2. ...
 ```
 
-1–3 пункта максимум, только из 🟢. Критерии выбора (по убыванию):
-1. Разблокирует наибольший хвост (упомянута в «Цепочки блокировок наружу» или blocking-связях).
-2. Не конфликтует с тем, что уже 🟡 (по слоям из спринт-дока).
-3. Меньший размер → быстрее.
+1–3 items maximum, only from 🟢. Selection criteria (in descending order):
+1. Unblocks the longest tail (mentioned in "Blocking chains outward" or blocking-links).
+2. Does not conflict with what is already 🟡 (by layers from the sprint doc).
+3. Smaller size → faster.
 
-Если 🟢 пусто — скажи, и предложи: добить 🟡, разблокировать 🔴, или `/grooming` для нового спринта.
+If 🟢 is empty — say so, and propose: finish 🟡, unblock 🔴, or `/grooming` for a new sprint.
 
-## Не делать
+## Do not
 
-- Не править спринт-док (это `/grooming` шаг 0).
-- Не запускать Gradle/тесты/smoke.
-- Не делать gap-анализ, не создавать issues.
-- Не вызывать `/implement` — только предложить команду.
+- Do not edit the sprint doc (that's `/grooming` step 0).
+- Do not run Gradle / tests / smoke.
+- Do not do gap analysis, do not create issues.
+- Do not invoke `/implement` — only propose the command.

--- a/.claude/skills/document/SKILL.md
+++ b/.claude/skills/document/SKILL.md
@@ -19,14 +19,14 @@ Issue number `<N>`.
 
 ## Re-entry contract
 
-Skill идемпотентен по issue. На каждом вызове первым делом проверь `gh pr list --search "issue:#<N>" --state open`:
+The skill is idempotent per issue. At each invocation, first check `gh pr list --search "issue:#<N>" --state open`:
 
-- **PR нет** → стартуй Step 1.
-- **PR есть и открыт** → ты в pull-request feedback итерации. Прочитай **все** human-комменты на PR (`gh api repos/<owner>/<repo>/pulls/<PR>/comments` + `gh pr view <PR> --comments`) и для каждого определи статус: адресован в коммитах после него — или нет. **Дата создания не определяет актуальность** — фильтровать комменты по `created_at > <дата-прошлого-прогона>` запрещено, потому что неадресованный коммент остаётся актуальным независимо от того, насколько он старый. **Counted is not read** — выдача `length`/счётчика без выгрузки `body` каждого коммента не считается прочтением; пока неадресованные комменты не отработаны, consistency wave (Step 4) и review wave (Step 5) не запускаются, иначе обе пройдут впустую на diff'е, который надо переделать. Прогон **обязан** включать на свежем diff'е (`docs/` + `.claude/`): Step 4 (consistency pass) → Step 5 (review wave).
+- **No PR** → start Step 1.
+- **PR exists and is open** → you are in a pull-request feedback iteration. Read **all** human comments on the PR (`gh api repos/<owner>/<repo>/pulls/<PR>/comments` + `gh pr view <PR> --comments`) and for each determine its status: addressed in commits after it — or not. **Creation date does not determine relevance** — filtering comments by `created_at > <date-of-previous-run>` is forbidden, because an unaddressed comment remains relevant regardless of how old it is. **Counted is not read** — returning a `length`/count without fetching the `body` of each comment does not count as reading; while unaddressed comments remain outstanding, the consistency wave (Step 4) and review wave (Step 5) must not run, otherwise both will process a diff that needs to be redone. The run **must** include on a fresh diff (`docs/` + `.claude/`): Step 4 (consistency pass) → Step 5 (review wave).
 
-Шаг 6 (commit + present + push) в re-entry упрощается: коммит идёт в существующую ветку, force-push не нужен, новый PR не создавать.
+Step 6 (commit + present + push) is simplified on re-entry: the commit goes into the existing branch, force-push is not needed, do not create a new PR.
 
-**После push в re-entry — обязательно ответь на каждый адресованный inline-коммент** через `gh api -X POST repos/<owner>/<repo>/pulls/<PR>/comments/<comment_id>/replies -f body="<reply>"`. Для каждого коммента: что сделано + SHA коммита (или явное обоснование, если коммент сознательно отклонён). Без ответа ревьюер не видит закрытия loop'а и тред остаётся «висящим»; следующий re-entry опять прочитает его как unaddressed и зря погонит consistency + review. Ответ — это сигнал «адресовано», не вежливость.
+**After push on re-entry — reply to every addressed inline comment** via `gh api -X POST repos/<owner>/<repo>/pulls/<PR>/comments/<comment_id>/replies -f body="<reply>"`. For each comment: what was done + the commit SHA (or explicit reasoning if the comment was deliberately declined). Without a reply the reviewer cannot see the loop closed and the thread stays "hanging"; the next re-entry will read it again as unaddressed and uselessly re-run consistency + review. A reply is the "addressed" signal, not a courtesy.
 
 ## Gate semantics — when to stop and ask the user
 
@@ -54,12 +54,12 @@ gh issue view <N> --json title,body,labels,comments
 gh pr list --search "issue:#<N>" --state open --json number,isDraft,headRefName
 ```
 
-**Comments — это не дискуссия, это потенциально canon-update body.** При противоречии comment'а с body — приоритет comment'у, эскалируй пользователю одной строкой.
+**Comments are not a discussion — they are potentially a canon-update body.** When a comment conflicts with the body — the comment takes priority; escalate to the user in one line.
 
-**Critical reading.** Воспринимай описание issue как **стартовую точку, не как факт**. Подсвечивай и эскалируй пользователю до начала работы, если:
-- из issue непонятно, какие именно артефакты ожидаются на выходе;
-- противоречие comment vs body, не разрешимое prioritization-правилом;
-- фразы-затычки: «опиши как считаешь нужным», «зафиксируй где надо», «и так далее».
+**Critical reading.** Treat the issue description as a **starting point, not a fact**. Flag and escalate to the user before starting work if:
+- it is unclear from the issue which specific artifacts are expected as output;
+- a conflict between a comment and the body that cannot be resolved by the prioritisation rule;
+- filler phrases: "describe as you see fit", "record wherever appropriate", "and so on".
 
 ### Doc discovery
 
@@ -87,7 +87,7 @@ All subsequent agent dispatches happen with this as cwd.
 
 ### Briefing back to the user
 
-После прочтения issue и разведки, **перед** любым вопросом пользователю (D1, Open questions от sub-agent'ов, classification-неоднозначности) выдай в чат короткий бриф 3–6 строк: что делаем, зачем (мотивация / контекст из issue), предварительный набор слоёв (spec / ux-brief / tech-doc / ADR / knowledge / .claude prompt). Если в этом же сообщении задаёшь вопросы — к каждому приложи 1–2 строки контекста (что говорит issue, какие варианты на столе), чтобы пользователь отвечал, не уходя на GitHub перечитывать тело. Бриф один на прогон; в re-entry не повторяй.
+After reading the issue and doing recon, **before** any question to the user (D1, open questions from sub-agents, classification ambiguities) — post a short 3–6 line briefing in chat: what we are doing, why (motivation / context from the issue), the preliminary set of layers (spec / ux-brief / tech-doc / ADR / knowledge / .claude prompt). If you are asking questions in the same message — attach 1–2 lines of context to each (what the issue says, what options are on the table), so the user can answer without going to GitHub to re-read the body. One briefing per run; do not repeat on re-entry.
 
 ## Step 2 — Layer classification
 
@@ -95,12 +95,12 @@ Decide which artifact layers this issue needs. Read the issue body, comments, li
 
 | Layer | Needed when | Artifact | Writer |
 |---|---|---|---|
-| **spec** | Тип FEATURE AND `docs/product/features/<slug>/spec.md` отсутствует, `(stub)`, или blocking open questions | `docs/product/features/<slug>/spec.md` | `spec-writer` |
-| **ux-brief** | FEATURE с user-facing UI (screen / component / navigation) AND `ux-brief.md` отсутствует или stale relative to spec changes | `docs/product/features/<slug>/ux-brief.md` | `ux-expert` |
-| **tech-doc** | Subsystem с нетривиальным механизмом (protocol / library choice / cross-platform invariant) не покрыт `docs/engineering/<name>.md`, либо существующий устарел | `docs/engineering/<name>.md` | `architect` |
-| **ADR** | Architectural choice с ≥3 considered options, история выбора имеет ценность (нельзя восстановить из кода + living docs) | `docs/engineering/adr/adr-<name>.md` | `architect` |
-| **knowledge** | Solved problem / platform quirk / workaround worth capturing for the next person (the kind currently in `docs/knowledge/`: Android FGS gotchas, Apple platform quirks, Ktor CIO traps, mDNS-Bonjour interactions, …). Trigger usually from a retro or a closed BUGFIX — issue says «зафиксируй вот это поведение» | `docs/knowledge/<name>.md` | `architect` |
-| **.claude prompt** | Deliverable — правка skill prompt (`.claude/skills/<name>/SKILL.md`), agent definition (`.claude/agents/<name>.md`), slash command (`.claude/commands/<name>.md`), hook (`.claude/scripts/*`, `.claude/settings.json`). Сюда же — задачи типа INFRA / без Тип, меняющие поведение агентов или slash-commands | `.claude/skills/<...>` / `.claude/agents/<...>` / `.claude/commands/<...>` | orchestrator (inline) |
+| **spec** | Type FEATURE AND `docs/product/features/<slug>/spec.md` is missing, `(stub)`, or has blocking open questions | `docs/product/features/<slug>/spec.md` | `spec-writer` |
+| **ux-brief** | FEATURE with user-facing UI (screen / component / navigation) AND `ux-brief.md` is missing or stale relative to spec changes | `docs/product/features/<slug>/ux-brief.md` | `ux-expert` |
+| **tech-doc** | Subsystem with a non-trivial mechanism (protocol / library choice / cross-platform invariant) not covered by `docs/engineering/<name>.md`, or the existing one is outdated | `docs/engineering/<name>.md` | `architect` |
+| **ADR** | Architectural choice with ≥3 considered options, the decision history has value (cannot be reconstructed from code + living docs) | `docs/engineering/adr/adr-<name>.md` | `architect` |
+| **knowledge** | Solved problem / platform quirk / workaround worth capturing for the next person (the kind currently in `docs/knowledge/`: Android FGS gotchas, Apple platform quirks, Ktor CIO traps, mDNS-Bonjour interactions, …). Trigger usually from a retro or a closed BUGFIX — issue says "record this behaviour" | `docs/knowledge/<name>.md` | `architect` |
+| **.claude prompt** | Deliverable — editing a skill prompt (`.claude/skills/<name>/SKILL.md`), agent definition (`.claude/agents/<name>.md`), slash command (`.claude/commands/<name>.md`), hook (`.claude/scripts/*`, `.claude/settings.json`). Also includes INFRA / typeless tasks that change agent or slash-command behaviour | `.claude/skills/<...>` / `.claude/agents/<...>` / `.claude/commands/<...>` | orchestrator (inline) |
 
 Multiple layers per issue are normal (e.g. FEATURE with UI and a new mechanism → spec + ux-brief + tech-doc; mechanism choice on existing FEATURE → tech-doc + ADR; new skill + its README example → .claude prompt + tech-doc; closed BUGFIX revealing a platform quirk → knowledge).
 
@@ -169,7 +169,7 @@ git push -u origin docs/<N>-<short-slug>
 gh pr create --title "<title>" --body "<...>"
 ```
 
-Read [`.github/pull_request_template.md`](../../../.github/pull_request_template.md) before composing the body. `Closes #<N>` is required. `👀 Sanity-check` lists every defer-decision (open question parked, follow-up artifact planned, layer skipped). List layers touched + artifact paths in `Что / зачем` or as a trailing line; omit `Dependency check: n/a` boilerplate.
+Read [`.github/pull_request_template.md`](../../../.github/pull_request_template.md) before composing the body. `Closes #<N>` is required. `👀 Sanity-check` lists every defer-decision (open question parked, follow-up artifact planned, layer skipped). List layers touched + artifact paths in the "What / why" section or as a trailing line; omit `Dependency check: n/a` boilerplate.
 
 Report to the user:
 - PR URL.

--- a/.claude/skills/github-issue-author/EXAMPLES.md
+++ b/.claude/skills/github-issue-author/EXAMPLES.md
@@ -1,46 +1,46 @@
-# Примеры создания issue
+# Issue creation examples
 
-## Пример 1: одиночный issue, фича
+## Example 1: single issue, feature
 
-**Запрос пользователя:** «Заведи issue в myorg/shop про то, что нам нужно кешировать результаты поиска на фронте, чтобы при возврате назад не было запроса к API».
+**User request:** "Create an issue in myorg/shop about the fact that we need to cache search results on the frontend so that navigating back does not trigger an API request."
 
-**После разведки:** в репо есть `AGENTS.md` с командами `pnpm test`, `pnpm lint`, `pnpm test:e2e`. Найден похожий закрытый issue #128 — LRU-кеш для recently viewed.
+**After scouting:** the repo has `AGENTS.md` with commands `pnpm test`, `pnpm lint`, `pnpm test:e2e`. Found a similar closed issue #128 — LRU cache for recently viewed.
 
-**После интервью:** пользователь подтвердил TTL 5 минут, отсутствие parent epic, labels `frontend,performance`.
+**After interview:** the user confirmed TTL of 5 minutes, no parent epic, labels `frontend,performance`.
 
-**Черновик:**
+**Draft:**
 
-> **Название:** Кеширование результатов поиска на стороне клиента
+> **Title:** Client-side search results caching
 >
-> **Тип:** FEATURE
+> **Type:** FEATURE
 >
-> ## Контекст
+> ## Context
 >
-> Фронтенд интернет-магазина (myorg/shop), страница поисковой выдачи и навигация между ней и карточками товаров.
+> The front end of an online store (myorg/shop), the search results page, and navigation between it and product cards.
 >
-> ## Зачем
+> ## Why
 >
-> Сейчас при возврате со страницы товара на страницу выдачи происходит повторный запрос к `/api/search`, что даёт ощущение лагов и грузит API. Пользователь видит лоадер вместо мгновенного отображения уже знакомого списка. Цель — отображать предыдущую выдачу мгновенно, актуализируя её в фоне (stale-while-revalidate).
+> Currently, returning from a product page to the results page triggers a repeat request to `/api/search`, which feels laggy and loads the API. The user sees a loader instead of an instant display of an already-familiar list. The goal is to display the previous results instantly, refreshing them in the background (stale-while-revalidate).
 >
-> ## Как должно работать
+> ## How it should work
 >
-> ### Основной сценарий
+> ### Main scenario
 >
-> 1. Пользователь делает поиск, видит выдачу. Результат сохраняется в кеш по ключу `query + filters + page`.
-> 2. Пользователь кликает на товар, переходит на карточку.
-> 3. Пользователь жмёт «назад» — выдача отображается мгновенно из кеша, в фоне идёт revalidate-запрос.
-> 4. Если ответ revalidate отличается — список плавно обновляется.
+> 1. The user performs a search and sees results. The result is saved to the cache under the key `query + filters + page`.
+> 2. The user clicks on a product and navigates to its card.
+> 3. The user presses "back" — the results are displayed instantly from the cache; a revalidate request runs in the background.
+> 4. If the revalidate response differs — the list updates smoothly.
 >
-> ### Краевые случаи
+> ### Edge cases
 >
-> - Кеш протух (старше 5 минут) — показываем skeleton, ждём ответа API.
-> - Изменились фильтры — кеш по новому ключу, старый не показываем.
-> - Ошибка revalidate — оставляем кешированный результат, показываем тост.
+> - Cache is stale (older than 5 minutes) — show skeleton, wait for API response.
+> - Filters changed — cache under a new key; do not show the old one.
+> - Revalidate error — keep the cached result, show a toast.
 >
-> ## Контракт
+> ## Contract
 >
 > ```ts
-> // src/features/search/cache.ts (новый файл)
+> // src/features/search/cache.ts (new file)
 > export interface SearchCache {
 >   get(key: SearchKey): CachedResult | null
 >   set(key: SearchKey, value: SearchResult): void
@@ -49,71 +49,71 @@
 > export type CachedResult = { value: SearchResult; storedAt: number }
 > ```
 >
-> Изменённые внешние контракты: нет.
-> Новые/изменённые таблицы БД: нет.
+> Changed external contracts: none.
+> New/changed DB tables: none.
 >
-> ## Технические подробности
+> ## Technical details
 >
-> ### Затрагиваемые модули
+> ### Affected modules
 >
-> - `src/features/search/api.ts` — обёртка над fetch, точка интеграции с кешем
-> - `src/features/search/cache.ts` (новый) — in-memory + sessionStorage LRU
-> - `src/features/search/SearchResultsPage.tsx` — использование revalidate-флоу
+> - `src/features/search/api.ts` — fetch wrapper, integration point with the cache
+> - `src/features/search/cache.ts` (new) — in-memory + sessionStorage LRU
+> - `src/features/search/SearchResultsPage.tsx` — consuming the revalidate flow
 >
-> ### Ориентиры в коде
+> ### Code landmarks
 >
-> - `src/features/recentlyViewed/cache.ts` — похожий LRU + sessionStorage, можно взять за образец
-> - `src/lib/cache-key.ts` — есть `buildCacheKey`, использовать его, не писать свой
+> - `src/features/recentlyViewed/cache.ts` — similar LRU + sessionStorage, can be used as a reference
+> - `src/lib/cache-key.ts` — has `buildCacheKey`, use it instead of writing your own
 >
 > ```bash
-> rg "sessionStorage" src/features/    # места, где уже используется
-> rg "stale-while-revalidate"          # есть ли паттерн в проекте
+> rg "sessionStorage" src/features/    # places where it is already used
+> rg "stale-while-revalidate"          # whether the pattern exists in the project
 > ```
 >
-> ### Нефункциональные требования
+> ### Non-functional requirements
 >
-> Размер кеша — не больше 50 последних запросов, вытеснение по LRU. Не складывать в кеш ответы с `Cache-Control: no-store`.
+> Cache size — no more than 50 recent queries, eviction by LRU. Do not cache responses with `Cache-Control: no-store`.
 >
-> ### Обработка ошибок
+> ### Error handling
 >
-> При ошибке revalidate — `logger.warn`, кеш не инвалидируем. При ошибке записи в sessionStorage (квота) — fallback на in-memory only, `logger.debug`.
+> On revalidate error — `logger.warn`, do not invalidate cache. On sessionStorage write error (quota) — fall back to in-memory only, `logger.debug`.
 >
 > ## Out of scope
 >
-> - Серверный edge-кеш для `/api/search` — отдельный issue (см. «Следствия»).
-> - Кеширование автокомплита `/api/search/suggest` — другая поверхность.
-> - Рефакторинг `SearchResultsPage.tsx` сверх минимально необходимой интеграции.
+> - Server-side edge cache for `/api/search` — separate issue (see "Consequences").
+> - Caching autocomplete `/api/search/suggest` — different surface.
+> - Refactoring `SearchResultsPage.tsx` beyond the minimum necessary integration.
 >
 > ## Definition of Done
 >
-> - [ ] `pnpm test src/features/search/cache.test.ts` проходит, покрывает: add, evict-on-overflow (>50), ttl-expiry
-> - [ ] `pnpm lint` без новых ошибок
-> - [ ] `pnpm test:e2e -- search-cache` — сценарий «поиск → карточка → назад» проходит без запроса к `/api/search` в первые 100мс
-> - [ ] Ручная проверка: открыть DevTools → Network, выполнить поиск, перейти на товар, вернуться — запрос к `/api/search` не повторяется
-> - [ ] Lighthouse Performance ≥ 85 на `/search` (`pnpm lighthouse --url /search`)
+> - [ ] `pnpm test src/features/search/cache.test.ts` passes, covers: add, evict-on-overflow (>50), ttl-expiry
+> - [ ] `pnpm lint` with no new errors
+> - [ ] `pnpm test:e2e -- search-cache` — the "search → product card → back" scenario passes without a request to `/api/search` in the first 100ms
+> - [ ] Manual check: open DevTools → Network, perform a search, navigate to a product, go back — no repeat request to `/api/search`
+> - [ ] Lighthouse Performance ≥ 85 on `/search` (`pnpm lighthouse --url /search`)
 >
-> ## Референсы
+> ## References
 >
-> - #128 — LRU для recently viewed (закрыт, паттерн оттуда)
+> - #128 — LRU for recently viewed (closed, pattern taken from there)
 >
-> ## Следствия
+> ## Consequences
 >
-> - Завести issue на серверный edge-кеш для `/api/search`
-> - Решить, нужно ли кешировать выдачу автокомплита — отдельное обсуждение
+> - Create an issue for the server-side edge cache for `/api/search`
+> - Decide whether autocomplete results need caching — separate discussion
 
-После апрува:
+After approval:
 
 ```bash
 gh issue create --repo myorg/shop \
-  --title "Кеширование результатов поиска на стороне клиента" \
+  --title "Client-side search results caching" \
   --body-file /tmp/issue-body.md \
   --label "frontend,performance"
 ```
 
-## Пример 2: epic + sub-issues
+## Example 2: epic + sub-issues
 
-Если пользователь говорит «разбей на подзадачи», создаёшь N+1 issue: один родительский (краткий, обзорный) и N дочерних (по полному шаблону), затем связываешь через `addSubIssue`.
+If the user says "break it into subtasks", create N+1 issues: one parent (brief, overview) and N children (using the full template), then link them via `addSubIssue`.
 
-Родительский issue в этом случае имеет **сокращённое** тело — Контекст, Зачем, общий DoD. Контракт и технические подробности живут в дочерних. Label `size:L` на parent-issue уместен.
+The parent issue in this case has a **shortened** body — Context, Why, overall DoD. Contract and technical details live in the children. The label `size:L` on the parent issue is appropriate.
 
-Если задача явно тянет на `size:L` — это сигнал предложить пользователю дробление в эпик ещё на этапе интервью.
+If a task clearly warrants `size:L` — that is a signal to suggest breaking it into an epic during the interview stage.

--- a/.claude/skills/github-issue-author/SKILL.md
+++ b/.claude/skills/github-issue-author/SKILL.md
@@ -1,153 +1,153 @@
 ---
 name: github-issue-author
-description: Создание issue на GitHub через `gh` CLI по строгому шаблону - название как полезный инкремент, развёрнутое описание (контекст, сценарии, технические детали, DoD, следствия) и связи parent/blocking/blocked. Используй этот скилл всегда, когда пользователь просит создать issue, задачу, тикет на GitHub, оформить фичу/баг, завести задачу в репозиторий, или упоминает `gh issue create` - даже если он не называет шаблон явно. Подходит как для одиночных issue, так и для серии связанных задач (epic + sub-issues).
+description: Create a GitHub issue via `gh` CLI using a strict template — title as a useful increment, detailed description (context, scenarios, technical details, DoD, dependencies) and parent/blocking/blocked relationships. Use this skill whenever the user asks to create an issue, task, or ticket on GitHub, to formalise a feature/bug, to file a task in the repository, or mentions `gh issue create` — even if they don't name the template explicitly. Suitable for both single issues and a series of related tasks (epic + sub-issues).
 ---
 
 # GitHub Issue Author
 
-Скилл для создания issue на GitHub через `gh` CLI по шаблону, в котором название читается как полезный инкремент к проекту, а описание содержит достаточно контекста и критериев приёмки, чтобы исполнитель мог взять задачу без дополнительных уточнений.
+Skill for creating GitHub issues via the `gh` CLI using a template where the title reads as a useful increment to the project and the description contains enough context and acceptance criteria for the assignee to pick up the task without further clarification.
 
-## Язык issue
+## Issue language
 
-По умолчанию — **русский**. Название и тело issue пишутся на русском. Технические термины (имена классов, файлов, флагов, API) остаются на английском как есть.
+Default — **English**. Issue titles and bodies are written in English. Technical terms (class names, file names, flags, APIs) stay in English as-is.
 
-Переключайся на другой язык только если пользователь явно об этом попросил («оформи на английском», «делай issue по-английски»), либо если репозиторий явно англоязычный (README/issues/CONTRIBUTING на английском, команда работает на английском) — в этом случае подтверди выбор у пользователя одной фразой перед созданием черновика.
+Switch to a different language only if the user explicitly requests it ("write it in Russian", "make the issue in Russian"), or if the repository is explicitly non-English (README/issues/CONTRIBUTING in another language, team works in another language) — in that case, confirm the choice with the user in one sentence before drafting.
 
-## Когда применять
+## When to apply
 
-- Пользователь просит «создай issue / задачу / тикет», «оформи задачу на github», «заведи issue про X».
-- Пользователь описывает фичу или багу и подразумевает, что её надо положить в трекер.
-- Пользователь просит разбить большую задачу на серию связанных issue (epic + дочерние).
-- Пользователь упоминает `gh issue create` или редактирует уже черновик issue.
+- The user says "create an issue / task / ticket", "file a task on github", "open an issue about X".
+- The user describes a feature or bug and implies it should go into the tracker.
+- The user asks to split a large task into a series of related issues (epic + children).
+- The user mentions `gh issue create` or is editing an existing issue draft.
 
-Не применяй, если пользователь просит **обсудить** идею, написать ТЗ в документ, или сделать PR (это другое).
+Do not apply if the user wants to **discuss** an idea, write a spec into a document, or create a PR (those are different).
 
-## Высокоуровневый процесс
+## High-level process
 
-1. **Разведка проекта** — найти `AGENTS.md` / `CLAUDE.md` / `CONTRIBUTING.md`, найти 1-2 похожих закрытых issue.
-2. **Интервью** — перечислить, что уже понятно из запроса и разведки, и спросить про пробелы.
-3. **Черновик** — сформировать название и описание по шаблону (см. [TEMPLATE.md](TEMPLATE.md)).
-4. **Glossary review.** Дёрни `review-glossary` сабагент на draft body. Drift flags поверни в правку черновика; если term отсутствует в глоссарии — спроси пользователя, добавлять ли entry сейчас или это task-local.
-5. **Ревью** — показать черновик пользователю **до создания issue**, дождаться апрува или правок.
-6. **Создание** — `gh issue create --body-file`.
-7. **Связи** — привязать к родительскому через `gh api` (sub-issues) или упоминания в теле.
+1. **Project reconnaissance** — find `AGENTS.md` / `CLAUDE.md` / `CONTRIBUTING.md`, find 1–2 similar closed issues.
+2. **Interview** — list what is already clear from the request and recon, and ask about gaps.
+3. **Draft** — form a title and description according to the template (see [TEMPLATE.md](TEMPLATE.md)).
+4. **Glossary review.** Dispatch the `review-glossary` sub-agent on the draft body. Turn drift flags into draft edits; if a term is absent from the glossary — ask the user whether to add an entry now or treat it as task-local.
+5. **Review** — show the draft to the user **before creating the issue**, wait for approval or edits.
+6. **Create** — `gh issue create --body-file`.
+7. **Relationships** — link to the parent via `gh api` (sub-issues) or mentions in the body.
 
-Никогда не создавай issue без явного апрува черновика — `gh issue create` это сторонний эффект, который пользователь должен подтвердить.
+Never create an issue without explicit draft approval — `gh issue create` is a side effect the user must confirm.
 
-Никогда не пиши черновик до того, как получены ответы на ключевые вопросы интервью. Исключение — запрос пользователя уже содержит фактически готовый черновик со всеми разделами.
+Never write a draft before receiving answers to key interview questions. Exception: the user's request already contains a practically complete draft with all sections.
 
-## Разведка проекта
+## Project reconnaissance
 
-Перед интервью сделай два быстрых действия — они дают контекст, без которого интервью получится поверхностным, а issue — расходящимся со стилем проекта.
+Before the interview, take two quick actions — they provide context without which the interview will be superficial and the issue will diverge from the project's style.
 
-### Файл правил для агентов
+### Agent rules file
 
-Проверь наличие в репозитории одного из:
-- `AGENTS.md` (формирующийся стандарт)
+Check the repository for one of:
+- `AGENTS.md` (emerging standard)
 - `CLAUDE.md`
-- `.cursor/rules/` (директория)
+- `.cursor/rules/` (directory)
 - `CONTRIBUTING.md`
 
-Если файл есть — **прочитай его**. Из него ты узнаешь команды тестов/линтера/билда, конвенции коммитов, какие папки трогать нельзя — это всё пригодится для разделов «DoD» и «Out of scope».
+If the file exists — **read it**. It tells you test/linter/build commands, commit conventions, and which folders to avoid — all useful for the "DoD" and "Out of scope" sections.
 
-Если файла нет — **отметь это для пользователя одной строкой** в начале интервью: «В репозитории нет AGENTS.md / CLAUDE.md / CONTRIBUTING.md. Отдельным issue стоит завести его создание — это сильно помогает агентам в дальнейшей работе. Сделать сейчас или позже?» Не настаивай, но проговори.
+If no file exists — **note this to the user in one line** at the start of the interview: "The repository has no AGENTS.md / CLAUDE.md / CONTRIBUTING.md. A separate issue should be filed to create one — it greatly helps agents in future work. Do it now or later?" Don't insist, but mention it.
 
-### Похожие закрытые issue
+### Similar closed issues
 
-Сделай 1-2 поиска по закрытым issue, чтобы найти референсы:
+Run 1–2 searches over closed issues to find references:
 
 ```bash
-gh issue list --repo OWNER/REPO --state closed --search "ключевые слова задачи" --limit 5 --json number,title,url
+gh issue list --repo OWNER/REPO --state closed --search "relevant keywords" --limit 5 --json number,title,url
 ```
 
-Если нашёл явно похожие (тот же модуль, та же область) — запомни их номера. На этапе черновика добавишь в раздел «Референсы». Это даёт исполнителю **готовые примеры решений в этом конкретном проекте** — намного ценнее общих принципов.
+If you find clearly similar ones (same module, same area) — note their numbers. At the draft stage you'll add them to the "References" section. This gives the assignee **ready-made solution examples in this specific project** — far more valuable than general principles.
 
-Если ничего не нашлось — это нормально, раздел «Референсы» можно опустить.
+If nothing was found — that's fine, the "References" section can be omitted.
 
-### Продуктовая документация
+### Product documentation
 
-Если в репозитории есть `docs/product/`, проверь наличие feature-спека для создаваемой задачи:
+If the repository has `docs/product/`, check for a feature spec for the task being created:
 
 ```bash
 ls docs/product/features/
 ```
 
-Если файл для этой фичи существует — **прочитай его**. Он содержит:
-- Acceptance Criteria — переноси в DoD issue напрямую
-- Out of scope — переноси в одноимённый раздел issue
-- Technical Notes — используй для раздела «Технические подробности»
+If a file for this feature exists — **read it**. It contains:
+- Acceptance Criteria — copy directly into the issue DoD
+- Out of scope — copy into the same-named section of the issue
+- Technical Notes — use for the "Technical details" section
 
-Feature-спек имеет приоритет над тем, что пользователь описал в запросе — если есть противоречие, уточни у пользователя перед черновиком.
+The feature spec takes priority over what the user described in the request — if there is a conflict, clarify with the user before drafting.
 
-Если `docs/product/features/` есть, но файла для этой фичи нет — работай как обычно, без упоминания этого пользователю.
+If `docs/product/features/` exists but there is no file for this feature — proceed as normal without mentioning this to the user.
 
-### Когда разведку можно пропустить
+### When to skip reconnaissance
 
-- Пользователь явно сказал «не лезь в репо, я знаю что делаю»
-- Репозиторий приватный и `gh` не имеет доступа (в этом случае честно скажи об этом и переходи к интервью)
-- Запрос — про создание самого первого issue в новом репозитории
+- The user explicitly said "don't dig into the repo, I know what I'm doing"
+- The repository is private and `gh` has no access (in this case, tell the user honestly and proceed to the interview)
+- The request is about creating the very first issue in a new repository
 
-## Сбор контекста
+## Gathering context
 
-**Сначала уточни пробелы, потом пиши черновик.** Скилл работает в режиме «интервью → черновик», а не «черновик с допущениями → правки». Это экономит итерации: дешевле задать 2-3 вопроса, чем переписывать готовый issue.
+**Clarify gaps first, then write the draft.** The skill operates in "interview → draft" mode, not "draft with assumptions → revisions". This saves iterations: asking 2–3 questions is cheaper than rewriting a finished issue.
 
-Перед написанием черновика убедись, что у тебя есть ответы на все эти вопросы:
+Before writing the draft, make sure you have answers to all these questions:
 
-- **Репозиторий** — `owner/repo`. Если не указан, попробуй определить через `gh repo view --json nameWithOwner` в текущей рабочей директории. Если не вышло — спроси.
-- **Тип задачи** — `FEATURE | BUGFIX | REFACTOR | INFRA | DOCS | DEPENDENCY`. Определи сам по описанию и подтверди в интервью, если неочевидно. Нужно для поля `**Тип**` в шаблоне — агент-ревьюер читает его при проверке PR.
-- **Что за приложение/проект** — на одной фразе. Нужно для раздела «Контекст».
-- **Зачем нужна задача** — какую проблему решает, что станет лучше после её выполнения. Без этого раздел «Зачем» получится пустым.
-- **Как должно работать** — основной сценарий хотя бы в общих чертах. Краевые случаи можешь предложить сам, но основной поток должен подтвердить пользователь.
-- **Технический контур** — какие файлы/модули затронуты. Если пользователь не знает или это не определено заранее — допустимо оставить `(уточнить при разборе)`, но **спроси сначала**, не предполагай молча.
-- **Связи** — есть ли parent epic, что блокирует, что блокируется этой задачей. Спрашивай явно, потому что пользователь часто забывает упомянуть.
-- **Labels / assignee / milestone** — есть ли стандартные для этого репозитория. Опционально, но если пользователь хочет — узнай.
+- **Repository** — `owner/repo`. If not specified, try to determine it via `gh repo view --json nameWithOwner` in the current working directory. If that fails — ask.
+- **Task type** — `FEATURE | BUGFIX | REFACTOR | INFRA | DOCS | DEPENDENCY`. Determine from the description and confirm in the interview if unclear. Needed for the `**Type**` field in the template — the reviewer agent reads it when checking the PR.
+- **What the app/project is** — in one sentence. Needed for the "Context" section.
+- **Why this task is needed** — what problem it solves, what will improve after it's done. Without this the "Why" section will be empty.
+- **How it should work** — the main scenario at least in broad strokes. You can propose edge cases yourself, but the main flow must be confirmed by the user.
+- **Technical scope** — which files/modules are affected. If the user doesn't know or it isn't defined upfront — it's acceptable to leave `(clarify during breakdown)`, but **ask first**, don't assume silently.
+- **Relationships** — is there a parent epic, what does this block, what blocks it. Ask explicitly, because the user often forgets to mention.
+- **Labels / assignee / milestone** — are there standard ones for this repository. Optional, but find out if the user wants them.
 
-### Как задавать вопросы
+### How to ask questions
 
-Группируй в один заход. Не больше 4-5 вопросов за раз — иначе пользователь устанет отвечать. Если вопросов больше — раздели на две волны: сначала самое нужное (что за проект, зачем, основной сценарий), потом детали (модули, связи, labels).
+Group into one pass. No more than 4–5 questions at a time — otherwise the user gets tired of answering. If there are more — split into two waves: first the most important (what is the project, why, main scenario), then details (modules, relationships, labels).
 
-Если пользователь в исходном запросе уже ответил на часть вопросов — не переспрашивай их, спрашивай только про пробелы. Явно перечисли в начале, что **уже** понятно из запроса, чтобы пользователь видел: ты прочитал и понял.
+If the user's original request already answered some questions — don't ask them again, ask only about gaps. Explicitly list at the start what is **already** clear from the request, so the user sees you read and understood.
 
-**Пример хорошего вопроса:**
+**Example of a good question:**
 
-> Из запроса я понял:
-> - репозиторий `myorg/shop`
-> - задача про кеширование поисковой выдачи на фронте
-> - проблема — повторный запрос при возврате со страницы товара
+> From the request I understood:
+> - repository `myorg/shop`
+> - task is about caching search results on the frontend
+> - problem — repeated request when returning from a product page
 >
-> Уточни, пожалуйста:
-> 1. Какой TTL у кеша? (или это «до закрытия вкладки»)
-> 2. Есть ли parent issue / epic, к которому привязать?
-> 3. Какие labels поставить? (или ничего)
+> Please clarify:
+> 1. What is the cache TTL? (or is it "until the tab is closed")
+> 2. Is there a parent issue / epic to link to?
+> 3. Which labels to apply? (or none)
 
-После получения ответов — переходи к черновику. Не задавай повторно вопросы, ответ на которые уже есть, не растягивай интервью.
+After receiving answers — move to the draft. Don't ask again questions that already have answers, don't stretch the interview.
 
-### Когда пропустить интервью
+### When to skip the interview
 
-Если запрос пользователя уже содержит развёрнутое описание со всеми разделами (фактически готовый черновик), и нет очевидных пробелов — пропусти этап вопросов, сразу переходи к оформлению по шаблону. В этом случае в черновике пометь `[?допущение: ...]` те места, которые ты дополнил сам, и пользователь подтвердит/поправит на этапе ревью.
+If the user's request already contains a detailed description with all sections (effectively a ready draft), and there are no obvious gaps — skip the questions step, go directly to formatting with the template. In this case, mark `[?assumption: ...]` in the draft where you filled in something yourself, and the user will confirm/correct at the review stage.
 
-## Шаблон issue
+## Issue template
 
-Полный шаблон и объяснение каждого раздела — см. [TEMPLATE.md](TEMPLATE.md).
+Full template and explanation of each section — see [TEMPLATE.md](TEMPLATE.md).
 
-## Связи между issue
+## Relationships between issues
 
-**Принцип: связи проставляем через нативные GitHub-поля, а не текстом в теле issue.** Тело issue остаётся про задачу; связи живут в API/UI и видны как структурированные данные (sub-issues sidebar, blocked-by/blocking sidebar, project fields). Это даёт боту-ревьюеру и автоматизациям машинно-читаемый граф зависимостей.
+**Principle: relationships are set through native GitHub fields, not text in the issue body.** The issue body stays about the task; relationships live in the API/UI and are visible as structured data (sub-issues sidebar, blocked-by/blocking sidebar, project fields). This gives the reviewer bot and automations a machine-readable dependency graph.
 
-GitHub поддерживает:
+GitHub supports:
 
-1. **Sub-issues / parent** — нативный механизм через GraphQL (`addSubIssue` / `removeSubIssue`), виден в UI как иерархия.
-2. **Blocked by / blocks (Relationships в UI)** — нативные issue dependencies. Экспонируются через **REST**, а не GraphQL: `POST /repos/{owner}/{repo}/issues/{issue_number}/dependencies/blocked_by` с телом `{"issue_id": <database_id>}`. В UI показываются в сайдбаре issue как "Relationships". GraphQL-мутации `addIssueDependency` **не существует** — не пытайся её вызывать.
-3. **Related** — нативного поля нет; используем упоминание `#123` в теле, либо общий parent/epic, либо тег labels.
+1. **Sub-issues / parent** — native mechanism via GraphQL (`addSubIssue` / `removeSubIssue`), visible in the UI as a hierarchy.
+2. **Blocked by / blocks (Relationships in UI)** — native issue dependencies. Exposed via **REST**, not GraphQL: `POST /repos/{owner}/{repo}/issues/{issue_number}/dependencies/blocked_by` with body `{"issue_id": <database_id>}`. Shown in the UI in the issue sidebar as "Relationships". GraphQL mutation `addIssueDependency` **does not exist** — do not attempt to call it.
+3. **Related** — no native field; use a `#123` mention in the body, a shared parent/epic, or label tags.
 
-**Текстовый блок `**Связи:**` в теле issue не используем** — он дублирует то, что уже есть в нативных полях, и расходится с ним при правках. Исключение — fallback, если конкретная мутация недоступна в репозитории (см. ниже).
+**Do not use a text block `**Relationships:**` in the issue body** — it duplicates what's already in native fields and drifts from them when edited. Exception: fallback if a specific mutation is unavailable in the repository (see below).
 
 ### Sub-issue (parent → child)
 
-Sub-issues создаются через `gh api` (фича выкатилась в 2024 и доступна через GraphQL):
+Sub-issues are created via `gh api` (the feature rolled out in 2024 and is available via GraphQL):
 
 ```bash
-# Получить node_id родительского и дочернего issue
+# Get node_id of parent and child issues
 PARENT_ID=$(gh api graphql -f query='
   query($owner: String!, $repo: String!, $number: Int!) {
     repository(owner: $owner, name: $repo) {
@@ -162,7 +162,7 @@ CHILD_ID=$(gh api graphql -f query='
     }
   }' -F owner=OWNER -F repo=REPO -F number=CHILD_NUMBER --jq '.data.repository.issue.id')
 
-# Привязать дочернее к родительскому
+# Link child to parent
 gh api graphql -f query='
   mutation($parentId: ID!, $childId: ID!) {
     addSubIssue(input: { issueId: $parentId, subIssueId: $childId }) {
@@ -171,115 +171,115 @@ gh api graphql -f query='
   }' -F parentId="$PARENT_ID" -F childId="$CHILD_ID"
 ```
 
-Если `addSubIssue` возвращает ошибку про неизвестное поле — у репозитория не включена фича sub-issues. Сообщи об этом пользователю и предложи fallback через упоминания в теле parent.
+If `addSubIssue` returns an error about an unknown field — the repository does not have sub-issues enabled. Notify the user and offer a fallback via mentions in the parent body.
 
 ### Blocked by / blocks (Relationships)
 
-В UI GitHub это поле называется **Relationships**, в REST API — **issue dependencies**. Используется **REST**, не GraphQL.
+In the GitHub UI this field is called **Relationships**, in the REST API — **issue dependencies**. Use **REST**, not GraphQL.
 
 ```bash
-# Получи database id (целое число, поле `id` в REST-ответе, НЕ node_id) блокирующего issue
+# Get the database id (integer, the `id` field in the REST response, NOT node_id) of the blocking issue
 BLOCKER_DB_ID=$(gh api repos/OWNER/REPO/issues/BLOCKER_NUMBER --jq .id)
 
-# A блокирует B  ⇄  B blocked by A
-# Вызываем на blocked issue (B), передаём database id блокирующего (A)
+# A blocks B  ⇄  B blocked by A
+# Call on the blocked issue (B), pass the database id of the blocker (A)
 gh api repos/OWNER/REPO/issues/BLOCKED_NUMBER/dependencies/blocked_by \
   -X POST -F issue_id=$BLOCKER_DB_ID
 ```
 
-Проверить текущие связи: `gh api repos/OWNER/REPO/issues/N/dependencies/blocked_by` (возвращает массив issue, блокирующих N).
+Check current relationships: `gh api repos/OWNER/REPO/issues/N/dependencies/blocked_by` (returns an array of issues blocking N).
 
-Если endpoint возвращает 404 на `POST` — фича Relationships в репозитории не включена. Fallback: добавить в тело blocked issue одну строку `Blocked by #N` и попросить пользователя включить Relationships в settings репозитория.
+If the endpoint returns 404 on `POST` — the Relationships feature is not enabled in the repository. Fallback: add one line `Blocked by #N` to the blocked issue body and ask the user to enable Relationships in repository settings.
 
 ### Related
 
-Нативного поля нет. Используем:
-- Упоминание `#N` в разделе **Контекст** или **Зачем** issue (там, где это естественно по смыслу).
-- Общий parent/epic, если задачи действительно связаны иерархически.
-- Labels (например, `area:discovery`), если это тематическая, а не задаче-задачная связь.
+No native field. Use:
+- A `#N` mention in the **Context** or **Why** section of the issue (where it makes natural sense).
+- A shared parent/epic, if the tasks are genuinely related hierarchically.
+- Labels (e.g. `area:discovery`), if it's a thematic relationship rather than a task-to-task one.
 
-Отдельный текстовый блок `**Связи:**` в конце issue не делаем — упоминание `#N` уже создаёт двустороннюю ссылку в GitHub UI.
+Don't create a separate text block `**Relationships:**` at the end of the issue — the `#N` mention already creates a bidirectional link in the GitHub UI.
 
-## Создание issue через `gh` CLI
+## Creating issues via `gh` CLI
 
-### Подготовка
+### Preparation
 
-1. Проверь, что `gh` авторизован: `gh auth status`. Если нет — попроси пользователя выполнить `gh auth login`.
-2. Определи репозиторий. Если работаешь в локальном клоне — `gh issue create` сам подхватит. Иначе нужен `--repo owner/repo`.
-3. Сохрани тело issue во временный файл (через флаг `--body-file`), а не в `--body` — так не сломается на спецсимволах, кавычках и переносах строк.
+1. Verify `gh` is authorised: `gh auth status`. If not — ask the user to run `gh auth login`.
+2. Determine the repository. If working in a local clone — `gh issue create` will detect it automatically. Otherwise `--repo owner/repo` is needed.
+3. Save the issue body to a temporary file (via the `--body-file` flag), not in `--body` — this won't break on special characters, quotes, and line breaks.
 
-### Команда создания
+### Create command
 
 ```bash
-# Сохрани тело в файл (используй create_file tool, не heredoc, чтобы избежать проблем с экранированием)
-# Путь: /tmp/issue-body.md
+# Save body to file (use the create_file tool, not heredoc, to avoid escaping issues)
+# Path: /tmp/issue-body.md
 
 gh issue create \
   --repo OWNER/REPO \
-  --title "Кеширование результатов поиска на стороне клиента" \
+  --title "Cache search results on the client side" \
   --body-file /tmp/issue-body.md \
   --label "feature,frontend"
 ```
 
-Опциональные флаги:
-- `--assignee @me` или `--assignee username`
+Optional flags:
+- `--assignee @me` or `--assignee username`
 - `--milestone "v1.2"`
 - `--project "Roadmap"`
 
-После создания `gh` выводит URL — сохрани его, он понадобится для привязки sub-issues.
+After creation `gh` outputs a URL — save it, it will be needed for linking sub-issues.
 
-### Получение номера созданного issue
+### Getting the number of the created issue
 
 ```bash
 URL=$(gh issue create --repo OWNER/REPO --title "..." --body-file /tmp/issue-body.md)
 NUMBER=$(echo "$URL" | grep -oE '[0-9]+$')
 ```
 
-### Создание серии связанных issue
+### Creating a series of related issues
 
-Если нужно создать parent + N дочерних:
+If you need to create a parent + N children:
 
-1. Создай parent первым, запиши его номер.
-2. Создай каждый child, запиши номера.
-3. Для каждого child вызови `addSubIssue` mutation с parent_id и child_id.
-4. В тело parent **не добавляй** список дочерних руками — UI GitHub отрисует их сам через sub-issues API.
+1. Create the parent first, record its number.
+2. Create each child, record their numbers.
+3. For each child call the `addSubIssue` mutation with parent_id and child_id.
+4. Do **not** add a list of children manually to the parent body — the GitHub UI will render them automatically via the sub-issues API.
 
-Если sub-issues API недоступен — добавь в тело parent список:
+If the sub-issues API is unavailable — add a list to the parent body:
 
 ```markdown
-**Дочерние задачи:**
-- [ ] #11 — Авторизация по email
-- [ ] #12 — Восстановление пароля
-- [ ] #13 — Двухфакторка через TOTP
+**Child tasks:**
+- [ ] #11 — Email authentication
+- [ ] #12 — Password recovery
+- [ ] #13 — Two-factor via TOTP
 ```
 
-## Workflow при работе с пользователем
+## Workflow when working with the user
 
-1. **Разведка** — проверь `AGENTS.md` / `CONTRIBUTING.md`, поищи 1-2 похожих закрытых issue. Это занимает 2-3 команды и сильно улучшает качество черновика.
-2. **Интервью** — перечисли, что уже понятно из запроса и разведки, и задай вопросы по пробелам. Не более 4-5 вопросов за раз. Не переходи к черновику, пока не получишь ответы.
-3. **Черновик** — название и полное тело issue **на русском** (если не оговорено иное), как markdown в чате. Не создавай файл и не вызывай `gh` на этом шаге. Помечай `[?допущение: ...]` оставшиеся неуверенности. За шаблоном — см. [TEMPLATE.md](TEMPLATE.md).
-4. **Glossary review** — дёрни `review-glossary` сабагент на draft body. Drift flags поверни в правку, undocumented terms — спроси у пользователя, добавлять ли entry сейчас.
-5. **Ревью** — дождись апрува или правок. Если правок много или они касаются скоупа — может стоит переспросить пару пунктов из интервью.
-6. **Создание** — `gh issue create --body-file`. Покажи URL результата.
-7. **Связи** — sub-issues через API, упоминания через редактирование тела (`gh issue edit NUMBER --body-file ...`).
-8. **Итог** — список созданных issue с номерами и URL.
+1. **Reconnaissance** — check `AGENTS.md` / `CONTRIBUTING.md`, search for 1–2 similar closed issues. This takes 2–3 commands and greatly improves draft quality.
+2. **Interview** — list what is already clear from the request and recon, and ask questions about gaps. No more than 4–5 questions at a time. Don't proceed to the draft until you receive answers.
+3. **Draft** — title and full issue body **in English** (unless otherwise agreed), as markdown in the chat. Don't create a file or call `gh` at this step. Mark `[?assumption: ...]` for remaining uncertainties. For the template — see [TEMPLATE.md](TEMPLATE.md).
+4. **Glossary review** — dispatch the `review-glossary` sub-agent on the draft body. Turn drift flags into edits; undocumented terms — ask the user whether to add an entry now.
+5. **Review** — wait for approval or edits. If there are many edits or they affect scope — it may be worth re-asking a couple of interview questions.
+6. **Create** — `gh issue create --body-file`. Show the result URL.
+7. **Relationships** — sub-issues via API, mentions via body editing (`gh issue edit NUMBER --body-file ...`).
+8. **Summary** — list of created issues with numbers and URLs.
 
-## Примеры
+## Examples
 
-Полные примеры создания issue — см. [EXAMPLES.md](EXAMPLES.md).
+Full issue creation examples — see [EXAMPLES.md](EXAMPLES.md).
 
-- Пример 1: одиночный issue, фича
-- Пример 2: epic + sub-issues
+- Example 1: single issue, feature
+- Example 2: epic + sub-issues
 
-## Что избегать
+## What to avoid
 
-- **Не создавай issue без апрува** черновика, даже если запрос кажется однозначным.
-- **Не пропускай разведку** — `AGENTS.md` и похожие закрытые issue обычно дают 80% контекста, который пользователь иначе бы дал руками.
-- **Не растягивай тело** ради заполнения всех разделов — пропускай опциональные если нечего сказать. Лучше пустой раздел отсутствует, чем заполнен «нет» или «н/д».
-- **Не оставляй DoD абстрактным** — если в репозитории нашёлся `AGENTS.md` или `package.json` / `pyproject.toml`, бери команды оттуда. «Юнит-тесты есть» — это не DoD.
-- **Не выдумывай `Out of scope` ради раздела** — но и не оставляй его пустым на сложных задачах. Один-два пункта почти всегда есть.
-- **Не используй приставки** в названиях (`[FEATURE]`, `feat:`). Категоризация — через labels.
-- **Не клади тело в `--body`** через CLI напрямую с большим текстом — используй `--body-file`.
-- **Не проставляй labels, которых нет в репозитории** — сначала проверь `gh label list --repo OWNER/REPO`, если не уверен.
-- **Не выдумывай файлы и модули**, если их не упоминал пользователь и они не очевидны из репозитория. Лучше написать `(уточнить при разборе)`.
-- **Не игнорируй `size:L`** — это сигнал «дроби на эпик», а не «пиши большой issue».
+- **Don't create an issue without draft approval**, even if the request seems unambiguous.
+- **Don't skip reconnaissance** — `AGENTS.md` and similar closed issues usually provide 80% of the context the user would otherwise supply manually.
+- **Don't pad the body** just to fill all sections — skip optional ones if there's nothing to say. A missing section is better than one filled with "none" or "n/a".
+- **Don't leave DoD abstract** — if the repository has `AGENTS.md` or `package.json` / `pyproject.toml`, take commands from there. "Unit tests exist" is not a DoD.
+- **Don't invent Out of scope just to fill the section** — but don't leave it empty on complex tasks. One or two points are almost always there.
+- **Don't use prefixes** in titles (`[FEATURE]`, `feat:`). Categorisation — via labels.
+- **Don't put the body in `--body`** via CLI directly with large text — use `--body-file`.
+- **Don't apply labels that don't exist in the repository** — first check `gh label list --repo OWNER/REPO` if unsure.
+- **Don't invent files and modules** if the user didn't mention them and they're not obvious from the repository. Better to write `(clarify during breakdown)`.
+- **Don't ignore `size:L`** — it's a signal to "split into an epic", not "write a big issue".

--- a/.claude/skills/github-issue-author/TEMPLATE.md
+++ b/.claude/skills/github-issue-author/TEMPLATE.md
@@ -1,205 +1,205 @@
-# Шаблон GitHub Issue
+# GitHub Issue Template
 
-Полный шаблон и объяснение каждого раздела.
+Full template and explanation of each section.
 
-## Название
+## Title
 
-Краткое (обычно 4-10 слов), описывает **полезный инкремент** к проекту — то, что появится после выполнения задачи. Читается как пункт changelog или коммит в стиле «что добавили / что починили».
+Brief (usually 4-10 words), describes a **useful increment** to the project — what will exist after the task is done. Reads like a changelog entry or a commit in the style of "what was added / what was fixed."
 
-**Никаких приставок** типа `[FEATURE]`, `[BUG]`, `feat:`, `task:`. Категоризация — через labels, не через название.
+**No prefixes** like `[FEATURE]`, `[BUG]`, `feat:`, `task:`. Categorization — via labels, not the title.
 
-Тест: если выписать названия всех закрытых issue подряд — они должны читаться как история развития проекта.
+Test: if you list the titles of all closed issues in sequence — they should read as the history of the project's development.
 
-**Хорошо:**
-- `Авторизация по магической ссылке на email`
-- `Кеширование результатов поиска на стороне клиента`
-- `Экспорт отчёта в PDF из карточки заказа`
-- `Откат миграции БД при падении init-контейнера`
+**Good:**
+- `Magic-link email authentication`
+- `Client-side search results caching`
+- `PDF export from order card`
+- `DB migration rollback on init-container failure`
 
-**Плохо:**
-- `[FEATURE] Добавить авторизацию` — приставка, глагол «добавить»
-- `Fix bug` — не описывает инкремент
-- `Авторизация` — слишком общо, непонятно что именно появится
-- `Реализовать класс AuthService` — про реализацию, а не про инкремент
+**Bad:**
+- `[FEATURE] Add authentication` — prefix, verb "add"
+- `Fix bug` — does not describe the increment
+- `Authentication` — too broad, unclear what exactly will appear
+- `Implement AuthService class` — about the implementation, not the increment
 
-## Размер задачи
+## Task size
 
-GitHub не имеет нативного поля «размер» на уровне issue — де-факто стандарт это **label** вида `size:S`, `size:M`, `size:L`. Его и используй при создании через `--label`.
+GitHub has no native "size" field at the issue level — the de facto standard is a **label** of the form `size:S`, `size:M`, `size:L`. Use that when creating via `--label`.
 
-Шкала: `S` — до 4 часов, `M` — до одного дня, `L` — до трёх дней. Всё крупнее `L` — сигнал дробить на эпик с sub-issues.
+Scale: `S` — up to 4 hours, `M` — up to one day, `L` — up to three days. Anything larger than `L` is a signal to break it into an epic with sub-issues.
 
-Если в репозитории есть GitHub Projects с кастомным полем «Size» или «Story Points» — его можно выставить после создания issue через `gh project item-edit` (требует `gh auth refresh -s project`). Спроси пользователя нужно ли это, не делай по умолчанию.
+If the repository has a GitHub Projects with a custom "Size" or "Story Points" field — it can be set after issue creation via `gh project item-edit` (requires `gh auth refresh -s project`). Ask the user whether this is needed; do not do it by default.
 
-## Полный шаблон описания
+## Full description template
 
 ```markdown
-**Тип:** FEATURE | BUGFIX | REFACTOR | INFRA | DOCS | DEPENDENCY
+**Type:** FEATURE | BUGFIX | REFACTOR | INFRA | DOCS | DEPENDENCY
 
-## Контекст
+## Context
 
-Одно-два предложения: какая часть какого приложения. Где в системе живёт эта задача.
+One or two sentences: which part of which application. Where in the system this task lives.
 
-## Что сделать
+## What to do
 
-Одно-два предложения: что конкретно сделать. Что добавить, починить, изменить или удалить.
+One or two sentences: what exactly to do. What to add, fix, change, or remove.
 
-## Зачем
+## Why
 
-Развёрнуто (~5 предложений, без жёсткого лимита): какую проблему решает, зачем сейчас, опционально — откуда возник запрос. Термины с расшифровкой и полезные ссылки (RFC, дизайн-документ, обсуждение в чате) — здесь же.
+In detail (~5 sentences, no strict limit): what problem it solves, why now, optionally — where the request came from. Terms with definitions and useful links (RFC, design document, chat discussion) — here too.
 
-## Блокеры и внешние условия
+## Blockers and external conditions
 
-Что должно быть готово/доступно к моменту выполнения: внешние сервисы, креды, решения от смежных команд, мерж другого PR, прогон миграции.
+What must be ready/available at the time of execution: external services, credentials, decisions from adjacent teams, another PR merged, a migration run.
 
-## Как должно работать
+## How it should work
 
-### Основной сценарий
+### Main scenario
 
-Пошагово или прозой — что происходит в типичном случае. Что видит/делает пользователь (или вызывающий код), что отвечает система.
+Step-by-step or in prose — what happens in the typical case. What the user (or calling code) sees/does, what the system responds.
 
-### Краевые случаи
+### Edge cases
 
-Что делать, если: пустой ввод, отвалилась сеть, конкурентные запросы, истёкший токен, отсутствие прав, лимиты. Перечислить только релевантное — лучше 3 реальных, чем 10 надуманных.
+What to do if: empty input, network failure, concurrent requests, expired token, missing permissions, limits. List only the relevant ones — 3 real ones are better than 10 invented ones.
 
-### Продолжение работы
+### Continuation of work
 
-Если задача — часть большего флоу: что происходит после, кто подхватывает, какие следующие шаги пользователя/системы.
+If the task is part of a larger flow: what happens next, who picks it up, what are the next steps for the user/system.
 
-## Контракт
+## Contract
 
-Точная форма того, что должно появиться после задачи. Это снимает с исполнителя необходимость додумывать сигнатуры.
+The exact shape of what should exist after the task. This removes the need for the implementer to guess signatures.
 
-**Публичный API после задачи** — TypeScript-интерфейсы, Python-сигнатуры функций, схемы эндпоинтов, схемы событий, форматы CLI-команд. То, что увидит и будет использовать вызывающий код.
+**Public API after the task** — TypeScript interfaces, Python function signatures, endpoint schemas, event schemas, CLI command formats. What calling code will see and use.
 
 \`\`\`ts
-// пример: src/features/search/cache.ts (новый файл)
+// example: src/features/search/cache.ts (new file)
 export interface SearchCache {
   get(key: SearchKey): CachedResult | null
   set(key: SearchKey, value: SearchResult): void
 }
 \`\`\`
 
-**Изменённые внешние контракты** — что меняется в существующих публичных API, схемах БД, форматах конфигов, переменных окружения. Если ничего не меняется — написать «нет».
+**Changed external contracts** — what changes in existing public APIs, DB schemas, config formats, environment variables. If nothing changes — write "none."
 
-**Новые/изменённые таблицы или коллекции** — schema-diff, если затрагивается БД.
+**New/changed tables or collections** — schema diff, if the DB is affected.
 
-Если задача чисто визуальная или конфигурационная и контракта нет — раздел можно опустить.
+If the task is purely visual or configurational and has no contract — the section can be omitted.
 
-## Перед началом
+## Before starting
 
-**Обязательно сделать план реализации до того, как трогать код.** План показать пользователю, дождаться апрува. Без апрува плана задачу не начинать.
+**Mandatory: produce an implementation plan before touching code.** Show the plan to the user and wait for approval. Do not start the task without plan approval.
 
-В плане отразить: какие файлы/модули затрагиваются, какая стратегия валидации, какие открытые вопросы из задачи решаются по дороге. Если что-то в техдеталях задачи кажется сомнительным или конфликтует с гайдами — не переделывать молча, показать альтернативу в плане.
+The plan should reflect: which files/modules are affected, what the validation strategy is, what open questions from the task are resolved along the way. If something in the technical details looks questionable or conflicts with the guides — do not silently rework it; show the alternative in the plan.
 
-Этот пункт — default для проекта, оставлять во всех задачах сложнее тривиальных. Убирать только при `size:S` И когда задача — точечная правка без архитектурных решений (опечатка, переименование, обновление зависимости).
+This item is the default for the project; keep it in all tasks more complex than trivial. Remove only for `size:S` AND when the task is a pinpoint fix with no architectural decisions (typo, rename, dependency update).
 
-Дополнительные шаги, специфичные для конкретной задачи:
+Additional steps specific to the task:
 
-1. Воспроизвести проблему по шагам (для багов).
-2. Замерить текущий показатель (для оптимизаций).
-3. Подтвердить, что ожидаемое поведение действительно отсутствует.
+1. Reproduce the problem step by step (for bugs).
+2. Measure the current metric (for optimizations).
+3. Confirm that the expected behavior is genuinely absent.
 
-Если воспроизвести/замерить не удалось — закрыть как `outdated` и не делать.
+If reproduction/measurement fails — close as `outdated` and do not proceed.
 
-### Гипотезы о причинах (для BUGFIX)
+### Hypotheses about the cause (for BUGFIX)
 
-Если в issue включён раздел с возможными причинами / гипотезами / candidate-объяснениями — оформляй его именно как **непроверенные гипотезы**, а не как факт. Используй формулировки «возможно», «гипотеза», «candidate cause», нумеруй пункты и явно укажи в начале раздела:
+If the issue includes a section on possible causes / hypotheses / candidate explanations — format it explicitly as **unverified hypotheses**, not as fact. Use formulations like "possibly," "hypothesis," "candidate cause," number the items, and explicitly state at the top of the section:
 
-> Это **непроверенные гипотезы** автора issue. До написания PR исполнитель обязан верифицировать реальный root cause (через `/implement` → агент `bug-reproducer`, или вручную воспроизведя баг и проверив каждую гипотезу минимальным экспериментом) и зафиксировать его комментарием в issue.
+> These are **unverified hypotheses** by the issue author. Before writing a PR the implementer must verify the actual root cause (via `/implement` → `bug-reproducer` agent, or by manually reproducing the bug and checking each hypothesis with a minimal experiment) and record it in a comment on the issue.
 
-Без этой пометки исполнитель может взять первую гипотезу как факт и написать корректный с виду фикс, который не решает реальную проблему. Это уже происходило (см. retro по #71 / #47).
+Without this note the implementer may treat the first hypothesis as fact and write a fix that looks correct but does not solve the real problem. This has already happened (see retro on #71 / #47).
 
-## Технические подробности
+## Technical details
 
-### Затрагиваемые модули
+### Affected modules
 
-Список классов / модулей / файлов / эндпоинтов / таблиц БД, которые предполагается тронуть. Если неизвестно точно — указать предполагаемое место и пометить `(уточнить)`.
+List of classes / modules / files / endpoints / DB tables expected to be touched. If not known precisely — state the presumed location and mark `(to confirm)`.
 
-### Ориентиры в коде
+### Code landmarks
 
-(опционально, но сильно помогает агенту-исполнителю)
+(optional, but greatly helps the implementing agent)
 
-**Похожие реализации в проекте** — указать файлы/модули, где уже есть похожий паттерн. Это помогает не писать с нуля и держать стиль проекта консистентным:
+**Similar implementations in the project** — point to files/modules where a similar pattern already exists. This helps avoid writing from scratch and keeps the project style consistent:
 
-- `src/features/recentlyViewed/cache.ts` — похожая идея LRU + sessionStorage, можно взять за образец
+- `src/features/recentlyViewed/cache.ts` — similar LRU + sessionStorage idea, can be used as a reference
 
-**Команды для разведки** — `rg` / `grep` / `gh` команды, которые помогают исполнителю быстро найти нужные места:
+**Scouting commands** — `rg` / `grep` / `gh` commands that help the implementer quickly find the relevant places:
 
 \`\`\`bash
-rg "sessionStorage" src/features/    # все места, где уже используется
-rg "swr|stale-while-revalidate"      # есть ли уже паттерн в проекте
+rg "sessionStorage" src/features/    # all places where it is already used
+rg "swr|stale-while-revalidate"      # whether the pattern already exists in the project
 \`\`\`
 
-### Нефункциональные требования
+### Non-functional requirements
 
-Производительность, безопасность, совместимость, ограничения по ресурсам, требования к логированию/метрикам.
+Performance, security, compatibility, resource limits, logging/metrics requirements.
 
-### Обработка ошибок
+### Error handling
 
-Какие ошибки могут возникнуть, как обрабатываются, что логировать, что показывать пользователю.
+What errors can occur, how they are handled, what to log, what to show the user.
 
 ## Out of scope
 
-Явные границы — что в эту задачу **не входит**, даже если кажется, что входит. Это снимает раздувание PR и упреждает «по дороге починю».
+Explicit boundaries — what is **not** part of this task, even if it might seem like it is. This prevents PR scope creep and pre-empts "I'll fix this along the way."
 
-- Что не делаем (с пояснением, если неочевидно).
-- Сопутствующие задачи, которые вынесены в отдельный issue (с номерами, если уже заведены).
-- Технический долг, который видно по дороге, но трогать сейчас нельзя.
+- What we are not doing (with explanation if non-obvious).
+- Related tasks that have been moved to a separate issue (with numbers, if already created).
+- Technical debt that is visible along the way but must not be touched now.
 
-Если границы тривиальны — раздел можно опустить, но для задач сложнее «поправить опечатку» обычно стоит заполнить.
+If the boundaries are trivial — the section can be omitted, but for tasks more complex than "fix a typo" it is usually worth filling in.
 
 ## Definition of Done
 
-Формулировки в стиле «можно проверить да/нет», в терминах наблюдаемого поведения или измеримой характеристики, не структурного артефакта. Класс / интерфейс / метод существуют как способ доставить поведение, но их наличие само по себе ничего не доказывает (пустая реализация, не подключённая в DI). Описывай то, что увидит пользователь или автотест.
+Formulations in the style of "can be verified yes/no," in terms of observable behavior or a measurable characteristic, not a structural artifact. A class / interface / method exists as a means of delivering behavior, but its mere existence proves nothing (empty implementation, not wired into DI). Describe what the user or an automated test will see.
 
-✗ `DeviceNameStore с реализациями на 4 платформах поднят` — структурно, не наблюдаемо.
-✓ `Сохранённое имя устройства переживает перезапуск приложения на всех 4 платформах`.
+✗ `DeviceNameStore with implementations on 4 platforms is in place` — structural, not observable.
+✓ `The saved device name survives an app restart on all 4 platforms`.
 
-Где можно — указывай **конкретные команды** для прогона, не описания. Исполнитель должен иметь возможность скопировать и запустить.
+Where possible — specify **concrete commands** to run, not descriptions. The implementer should be able to copy and execute.
 
-- [ ] План реализации согласован с пользователем до начала кодинга (см. «Перед началом»)
-- [ ] `<команда тестов на затронутые файлы>` проходит, покрывает: <перечислить сценарии>
-- [ ] `<команда линтера>` без новых ошибок
-- [ ] `<команда e2e/интеграционных тестов, если применимо>` проходит
-- [ ] Ручная проверка: `<пошаговый сценарий или ссылка на демо-стенд>`
-- [ ] Документация / changelog / обновлённые ENV — если применимо
+- [ ] Implementation plan approved by the user before coding starts (see "Before starting")
+- [ ] `<test command for affected files>` passes, covers: <list scenarios>
+- [ ] `<linter command>` with no new errors
+- [ ] `<e2e/integration test command, if applicable>` passes
+- [ ] Manual check: `<step-by-step scenario or link to demo environment>`
+- [ ] Documentation / changelog / updated ENV — if applicable
 
-Команды берутся из `AGENTS.md` / `CONTRIBUTING.md` / `package.json` проекта (см. раздел «Разведка»). Если правил нет — пиши общеупотребительные (`pytest path/to/test.py`, `pnpm test`, `cargo test`) и помечай `(уточнить раннер)`.
+Commands are taken from `AGENTS.md` / `CONTRIBUTING.md` / `package.json` of the project (see "Scouting"). If no rules exist — write common ones (`pytest path/to/test.py`, `pnpm test`, `cargo test`) and mark `(confirm runner)`.
 
-## Референсы
+## References
 
-Похожие задачи в истории проекта — закрытые issue, PR, обсуждения, которые служат хорошим образцом. Найдены на этапе разведки.
+Similar tasks in the project history — closed issues, PRs, discussions that serve as a good example. Found during the scouting phase.
 
-- #42 — кеширование автокомплита (закрыт, паттерн оттуда)
-- #128 — LRU для recently viewed (закрыт)
+- #42 — autocomplete caching (closed, pattern taken from there)
+- #128 — LRU for recently viewed (closed)
 
-## Следствия
+## Consequences
 
-Задачи, которые непосредственно вытекают из этой, но не помещаются в её скоуп. Будущие issue, которые надо завести после мержа.
+Tasks that directly follow from this one but do not fit within its scope. Future issues to be created after the merge.
 ```
 
-**Связи (parent / blocked-by / blocks) в теле не пишем** — они проставляются через нативные GitHub-поля: sub-issues (GraphQL) + Relationships, известные в REST как issue dependencies (REST `POST /repos/{o}/{r}/issues/{n}/dependencies/blocked_by`). См. раздел «Связи между issue» в [SKILL.md](SKILL.md). В теле issue остаётся только сама задача.
+**Relationships (parent / blocked-by / blocks) are not written in the body** — they are set via native GitHub fields: sub-issues (GraphQL) + Relationships, known in REST as issue dependencies (REST `POST /repos/{o}/{r}/issues/{n}/dependencies/blocked_by`). See the "Issue relationships" section in [SKILL.md](SKILL.md). Only the task itself remains in the issue body.
 
-«Related» — упоминание `#N` встраивается в раздел «Контекст» или «Зачем» там, где это естественно по смыслу, либо выражается через общий parent/labels.
+"Related" — a mention of `#N` is embedded in the "Context" or "Why" section where it fits naturally by meaning, or expressed through a shared parent/labels.
 
-## Что важно при заполнении
+## What matters when filling in
 
-- **Контекст** — широкий мазок, не пересказ README. Координата «где мы сейчас».
-- **Зачем** — здесь главная ценность для исполнителя. Не «нужно сделать X», а «без X происходит Y, что мешает Z».
-- **Контракт** — даже если пользователь не дал точные сигнатуры, **предложи их в черновике** на основе раздела «Зачем». Пользователь подправит. Это всё равно лучше, чем оставлять додумывание исполнителю.
-- **Технические подробности** — гипотеза, а не приказ. Исполнитель может выбрать другой путь, но имеет от чего оттолкнуться.
-- **Out of scope** — даже 1-2 пункта лучше, чем пустой раздел. «Не трогаем серверный кеш», «Не рефакторим X сверх необходимого» — это уже сильно сужает поле для агента.
-- **DoD** — конкретика побеждает. «`pnpm test path/to/cache.test.ts` проходит» лучше, чем «юнит-тесты есть». Команды берутся из `AGENTS.md` если он есть.
-- **Парные стороны контракта — в одной задаче.** Если фикс/фича логически двусторонняя (client↔server, sender↔receiver, producer↔consumer, write-path↔read-path), обе стороны должны жить в одном issue и быть в DoD одной задачи. Не выноси «вторую половину» в doc-ремарку, отдельный issue или TODO в коде — серверная защита, у которой клиент не выставляет precondition, физически не срабатывает в продакшне, и об этом узнают только когда уже произошёл инцидент. Признак, что задача двусторонняя: «server X validates Y» / «receiver checks Z, sent by sender» / «consumer expects field N, produced by producer». Если в `Что сделать` фигурируют только одна сторона — проверь, что вторая либо уже в main, либо включена в эту же задачу.
+- **Context** — a broad stroke, not a retelling of the README. A coordinate of "where we are now."
+- **Why** — this is the main value for the implementer. Not "we need to do X," but "without X, Y happens, which prevents Z."
+- **Contract** — even if the user did not provide exact signatures, **propose them in a draft** based on the "Why" section. The user will correct them. That is still better than leaving the guesswork to the implementer.
+- **Technical details** — a hypothesis, not an order. The implementer may choose a different path but has something to start from.
+- **Out of scope** — even 1-2 points is better than an empty section. "We are not touching the server cache," "We are not refactoring X beyond what is necessary" — that already significantly narrows the scope for the agent.
+- **DoD** — specifics win. "`pnpm test path/to/cache.test.ts` passes" is better than "unit tests exist." Commands are taken from `AGENTS.md` if it is present.
+- **Paired sides of the contract — in one task.** If a fix/feature is logically two-sided (client↔server, sender↔receiver, producer↔consumer, write-path↔read-path), both sides must live in the same issue and be in the DoD of the same task. Do not move "the other half" into a doc remark, a separate issue, or a TODO in code — a server-side guard for which the client does not set a precondition physically does not trigger in production, and this is only discovered when an incident has already occurred. The sign that a task is two-sided: "server X validates Y" / "receiver checks Z, sent by sender" / "consumer expects field N, produced by producer." If "What to do" mentions only one side — verify that the other is either already in main or included in this same task.
 
-## Что пропускать на маленьких задачах (size:S)
+## What to skip for small tasks (size:S)
 
-Для задач размером до 4 часов часть разделов — лишний вес. Правило: если раздел потребует больше времени на написание, чем выполнение задачи — пропускай.
+For tasks up to 4 hours, some sections are unnecessary weight. Rule: if a section takes more time to write than the task takes to execute — skip it.
 
-**Можно пропустить целиком:** Блокеры, Контракт (если изменений API нет), Ориентиры в коде, Нефункциональные требования, Продолжение работы, Референсы, Следствия.
+**Can be skipped entirely:** Blockers, Contract (if no API changes), Code landmarks, Non-functional requirements, Continuation of work, References, Consequences.
 
-**Перед началом** — для тривиальных правок (опечатка, переименование, обновление зависимости) можно пропустить. Иначе оставить хотя бы default-пункт про план + апрув.
+**Before starting** — for trivial fixes (typo, rename, dependency update) can be skipped. Otherwise keep at least the default item about the plan + approval.
 
-**Нельзя пропускать никогда:** Контекст, Зачем, Основной сценарий, Краевые случаи (хотя бы 2-3), Out of scope (хотя бы 1-2 пункта если задача неочевидна), DoD (включая пункт про апрув плана).
+**Can never be skipped:** Context, Why, Main scenario, Edge cases (at least 2-3), Out of scope (at least 1-2 points if the task is non-obvious), DoD (including the plan approval item).
 
-Для `size:S` разумный минимум — Контекст + Зачем + Как должно работать + Out of scope (1-2) + DoD (3-4 конкретных пункта).
+For `size:S` the reasonable minimum is Context + Why + How it should work + Out of scope (1-2) + DoD (3-4 concrete points).

--- a/.claude/skills/grooming/SKILL.md
+++ b/.claude/skills/grooming/SKILL.md
@@ -1,206 +1,206 @@
 ---
 name: grooming
-description: Проведи груминг бэклога — закрой текущий sprint-NN.md по факту (статусы задач, доп. результаты в окне), пройдись по открытым issue, найди незаведённые задачи через gap-analysis (платформенная симметрия, TODO в коде, MVP-блокеры по роадмапу) и составь компактный кандидат на следующий спринт в фиксированном формате (Цель / Состав / Следствия / опциональный merge order). Используй когда пользователь просит «прогруми», «груминг», «спланируй спринт», «закрой спринт».
+description: Run a backlog grooming session — close the current sprint-NN.md by actuals (task statuses, extra results within the window), go through open issues, find unfiled tasks via gap-analysis (platform symmetry, TODOs in code, MVP blockers from the roadmap) and compose a compact candidate for the next sprint in a fixed format (Goal / Composition / Consequences / optional merge order). Use when the user says "groom", "grooming", "plan the sprint", "close the sprint".
 ---
 
-Проведи груминг бэклога и составь кандидат на план следующего спринта.
+Run a backlog grooming session and compose a candidate plan for the next sprint.
 
 ---
 
-## Шаг 0 — Закрыть прошлый спринт по факту
+## Step 0 — Close the previous sprint by actuals
 
-Прежде чем планировать следующий спринт, доведи текущий до состояния «факт зафиксирован». Без этого следующее планирование работает по устаревшему контексту.
+Before planning the next sprint, bring the current one to "actuals recorded" state. Without this, the next planning works from stale context.
 
-**0.1 Найди текущий спринт-док.** `ls docs/sprints/` — последний по номеру файл. Если папки нет или последний спринт уже отмечен как «closed/итог» во всех строках — пропусти шаг 0.
+**0.1 Find the current sprint doc.** `ls docs/sprints/` — the last file by number. If the folder doesn't exist or the last sprint is already marked as "closed/done" in all rows — skip Step 0.
 
-**0.2 Прочитай его** и определи список issue из секции «Состав».
+**0.2 Read it** and identify the list of issues from the "Composition" section.
 
-**0.3 Проверь фактическое состояние каждой задачи:**
+**0.3 Check the actual state of each task:**
 
 ```bash
 gh issue view <N> --json state,title
 ```
 
-Для тех, где `state` ≠ `CLOSED` — также проверь PR через `gh pr list --state all --search "<N>"`, потому что PR может быть merged без авто-закрытия issue.
+For those where `state` ≠ `CLOSED` — also check the PR via `gh pr list --state all --search "<N>"`, because a PR can be merged without auto-closing the issue.
 
-**0.4 Найди задачи, которые закрылись в окне спринта, но **не** были в исходном составе.** Это «доп. результаты» — что было захвачено сверх плана.
+**0.4 Find tasks that closed within the sprint window but were **not** in the original composition.** These are "extra results" — work done beyond the plan.
 
 ```bash
-# Дата старта/мерджа задач из состава — ориентир для окна
+# Date of start/merge of tasks from the composition — a reference for the window
 git log --oneline --since="<date-of-first-sprint-commit>" --until="<date-of-last-sprint-commit>" | grep -E "^[a-f0-9]+ #[0-9]+:"
 ```
 
-Сопоставь с составом спринта. Всё, что закрыто в этом окне и не было в составе — кандидат в секцию «Дополнительно».
+Compare with the sprint composition. Everything closed in this window that was not in the composition is a candidate for the "Additional" section.
 
-**0.5 Обнови спринт-док:**
+**0.5 Update the sprint doc:**
 
-- В таблице «Состав» добавь колонку `Итог` со статусом по каждой задаче: `✅ closed ([commit](url), PR #N)` / `🟡 partial (что осталось)` / `❌ не сделано (причина)`.
-- В начале/конце таблицы добавь одну строку **Итог:** `X/Y задач закрыты` плюс короткое «все цели достигнуты» / «частично, остался Z».
-- Добавь секцию **«Доп. результаты»** или **«Вне исходного состава»** — issues, закрытые в окне спринта, но не запланированные. Каждый — одна строка: `#N (commit, PR) — что и почему важно для feature-прогресса`.
-- В секции «Полезный инкремент» (или эквивалентной) — преврати future tense в past: «После спринта X станет...» → «X сделано: ...». Добавь подсекцию «Дополнительно» с доп. результатами.
-- В секции «Связанные продуктовые спеки» — добавь любые спеки, которые правились в окне спринта вне состава.
+- In the "Composition" table add an `Outcome` column with the status for each task: `✅ closed ([commit](url), PR #N)` / `🟡 partial (what remained)` / `❌ not done (reason)`.
+- At the beginning/end of the table add one line **Total:** `X/Y tasks closed` plus a short "all goals achieved" / "partially, Z remains".
+- Add a section **"Additional results"** or **"Outside original composition"** — issues closed in the sprint window but not planned. Each one — one line: `#N (commit, PR) — what it was and why it matters for feature progress`.
+- In the "Useful increment" section (or equivalent) — change future tense to past: "After sprint X will become..." → "X done: ...". Add an "Additional" subsection with the extra results.
+- In the "Related product specs" section — add any specs that were edited within the sprint window outside of the composition.
 
-**Стиль:** не переписывай цель спринта, не редактируй «Не вошло намеренно» — это исторический срез решения на момент планирования. Добавляй факт поверх плана, не заменяя его.
+**Style:** do not rewrite the sprint goal, do not edit "Intentionally not included" — that is a historical snapshot of the decision at planning time. Add actuals on top of the plan, don't replace it.
 
-**0.6 Сообщи пользователю результат закрытия:** «Спринт N: X/Y задач закрыты, Z доп. результатов в окне. Спринт-док обновлён. Перехожу к планированию следующего».
-
----
-
-## Шаг 1 — Продуктовый контекст
-
-Прочитай последовательно:
-
-1. `docs/product/vision.md` — зачем продукт существует
-2. `docs/product/README.md` — обзор
-3. `docs/product/roadmap.md` — этапы и приоритеты
-4. `docs/product/features/README.md` — список фич и их статус
-
-Цель: понять, на каком этапе роадмапа мы находимся, что уже реализовано, что следующее.
+**0.6 Report the closing result to the user:** "Sprint N: X/Y tasks closed, Z additional results in the window. Sprint doc updated. Moving on to planning the next one."
 
 ---
 
-## Шаг 2 — Изучение открытых issues
+## Step 1 — Product context
 
-Работай от общего к частному — не читай подробности без необходимости.
+Read in sequence:
 
-**2.1 Получи список:**
+1. `docs/product/vision.md` — why the product exists
+2. `docs/product/README.md` — overview
+3. `docs/product/roadmap.md` — stages and priorities
+4. `docs/product/features/README.md` — list of features and their status
+
+Goal: understand which roadmap stage we are at, what has already been implemented, what comes next.
+
+---
+
+## Step 2 — Review open issues
+
+Work from general to specific — don't read details unless necessary.
+
+**2.1 Get the list:**
 ```bash
 gh issue list --state open --json number,title,labels
 ```
 
-**2.2 Для каждого issue прочитай только ключевые разделы** (контекст, цель, DoD, связи):
+**2.2 For each issue read only the key sections** (context, goal, DoD, relationships):
 ```bash
 gh issue view <N> --json title,body,labels
 ```
-Ищи в body разделы: «Контекст», «Зачем», «Сделать», «DoD», «Связи», «Блокеры».
-Подробности (комментарии, история) — только если непонятны блокеры или зависимости.
+Look in body for sections: "Context", "Why", "To do", "DoD", "Relationships", "Blockers".
+Details (comments, history) — only if blockers or dependencies are unclear.
 
-**2.3 Построй мысленную карту:**
-- Какие issues блокированы другими?
-- Какие касаются одной и той же части кодовой базы (UI, network, discovery, protocol)?
-- Какие можно делать параллельно без конфликтов?
+**2.3 Build a mental map:**
+- Which issues are blocked by others?
+- Which ones touch the same part of the codebase (UI, network, discovery, protocol)?
+- Which ones can be done in parallel without conflicts?
 
 ---
 
-## Шаг 3 — Анализ готовности к спринту
+## Step 3 — Sprint readiness analysis
 
-Для каждого открытого issue оцени:
+For each open issue assess:
 
-| Критерий | Да / Нет |
+| Criterion | Yes / No |
 |----------|----------|
-| Нет известных блокеров | — |
-| Есть понятный DoD | — |
-| Если фича — есть спека в `docs/product/features/` | — |
-| Спека указана в тексте issue | — |
-| Не конфликтует по кодовой базе с другими кандидатами | — |
+| No known blockers | — |
+| Clear DoD exists | — |
+| If a feature — spec exists in `docs/product/features/` | — |
+| Spec referenced in the issue body | — |
+| Does not conflict with other candidates in the codebase | — |
 
-Если для новой функциональности нет спеки в `docs/product/features/` — отметь это явно как риск.
+If there is no spec in `docs/product/features/` for new functionality — flag this explicitly as a risk.
 
 ---
 
-## Шаг 4 — Поиск незаведённых задач (gap-analysis)
+## Step 4 — Finding unfiled tasks (gap-analysis)
 
-Прежде чем составлять план, проверь: **всё ли осмысленное к этому моменту уже заведено как issue?** Бэклог отстаёт от реального состояния кода — задача может быть очевидно нужной по смыслу, но просто никем не зафиксированной.
+Before composing the plan, check: **is everything meaningful at this point already filed as an issue?** The backlog lags behind the real state of the code — a task can be obviously needed but simply never recorded.
 
-Систематически пройдись по двум осям:
+Systematically go through two axes:
 
-### 4.1 Платформенная симметрия
+### 4.1 Platform symmetry
 
-Принцип `vision.md` обычно требует cross-platform паритет. Сравни состояние таргетов между собой:
+The `vision.md` principle usually requires cross-platform parity. Compare the state of targets against each other:
 
 ```bash
-# Что есть на каждом таргете?
+# What exists on each target?
 ls composeApp/src/{commonMain,androidMain,iosMain,appleMain,desktopMain,jvmMain}/kotlin/...
 ```
 
-Для каждого крупного компонента (`FileServer`, `FileClient`, `MdnsDiscovery`, `TrustedDeviceStore`, UI screens) сделай таблицу: **где реализовано, где stub, где не существует**. Stub'ы (классы, бросающие `error("not implemented")`) — это формально «есть», а фактически gap.
+For each major component (`FileServer`, `FileClient`, `MdnsDiscovery`, `TrustedDeviceStore`, UI screens) make a table: **where implemented, where stub, where missing**. Stubs (classes throwing `error("not implemented")`) are formally "present" but factually a gap.
 
-Если видишь асимметрию (фича закрыта на 2 из 3 платформ) — проверь:
-- Есть ли уже открытое или закрытое issue на отстающую платформу?
-- Если нет — это кандидат на новый issue.
+If you see asymmetry (a feature covered on 2 of 3 platforms) — check:
+- Is there an open or closed issue for the lagging platform?
+- If not — it's a candidate for a new issue.
 
-### 4.2 Stub'ы и TODO в коде
+### 4.2 Stubs and TODOs in code
 
 ```bash
 rg "TODO|FIXME|not (yet )?implemented|stub" composeApp/src/ --type kotlin
-rg "error\(\"" composeApp/src/ --type kotlin   # заглушки, бросающие ошибки
+rg "error\(\"" composeApp/src/ --type kotlin   # stubs throwing errors
 ```
 
-Каждое такое место — потенциальная незаведённая задача. Не фиксируй мелкие TODO внутри методов, но структурные «здесь будет реализация позже» — кандидаты.
+Each such location is a potentially unfiled task. Don't file minor TODOs inside methods, but structural "implementation comes later" markers are candidates.
 
-### 4.3 Блокеры из роадмапа
+### 4.3 Roadmap blockers
 
-Перечитай `docs/product/roadmap.md`. Для каждого пункта MVP проверь: есть ли issue, который его двигает? Если пункт MVP не имеет ни одного issue — это gap.
+Re-read `docs/product/roadmap.md`. For each MVP item check: is there an issue moving it forward? If an MVP item has no issue at all — that's a gap.
 
-### 4.4 Что делать с найденными gap'ами
+### 4.4 What to do with found gaps
 
-Перечисли пользователю **до** составления плана спринта:
+List them for the user **before** composing the sprint plan:
 
-> Перед сборкой плана я нашёл задачи, которые по смыслу нужны сейчас, но не заведены как issue:
+> Before building the plan I found tasks that are conceptually needed now but not filed as issues:
 >
-> 1. **<Название>** — <одна фраза: что и почему>. Слой/платформа: <...>. Размер: <S/M/L>.
+> 1. **<Title>** — <one sentence: what and why>. Layer/platform: <...>. Size: <S/M/L>.
 > 2. ...
 >
-> Заводить их сейчас через /github-issue-author, чтобы они стали кандидатами в спринт?
+> File them now via /github-issue-author so they become sprint candidates?
 
-Не заводи issue молча. Пользователь решает: завести сейчас, отложить, или добавить как заметку в план без формального issue.
+Don't file issues silently. The user decides: file now, defer, or add as a note to the plan without a formal issue.
 
-Если пользователь согласен — пройди интервью /github-issue-author по каждой задаче. Только после создания issue они становятся кандидатами в Шаг 5.
-
----
-
-## Шаг 5 — Отбор кандидатов
-
-Выбери 3–5 задач, которые:
-- Соответствуют текущему этапу роадмапа
-- Не блокированы — ни внешними issues, ни друг другом внутри спринта.
-  **Если #A блокирует #B — нельзя брать обе в один спринт, даже если #A почти готова.** Цепочки разводятся по спринтам: #A в этот спринт, #B в следующий. Это правило строгое: «сделаем #A быстро, потом возьмёмся за #B» приводит к простою исполнителя #B и срыву DoD спринта.
-- Можно делать параллельно (разные платформы, разные слои кодовой базы, разные фичи)
-
-Хорошие комбинации для параллельной работы:
-- Одна фича на iOS + одна на Android/Desktop
-- UI-изменение + network/discovery изменение
-- Новая фича + несвязанный багфикс
-- Несколько фич, затрагивающих разные модули
+If the user agrees — run the /github-issue-author interview for each task. Only after the issues are created do they become candidates for Step 5.
 
 ---
 
-## Шаг 6 — Формат спринт-дока
+## Step 5 — Candidate selection
 
-Сохрани в `docs/sprints/sprint-NN.md`. Только три обязательные секции + одна опциональная. Ничего сверх.
+Pick 3–5 tasks that:
+- Match the current roadmap stage
+- Are not blocked — neither by external issues nor by each other within the sprint.
+  **If #A blocks #B — both cannot be in the same sprint, even if #A is nearly done.** Chains are split across sprints: #A in this sprint, #B in the next. This rule is strict: "we'll finish #A quickly then take on #B" leads to assignee-B downtime and DoD failure.
+- Can be done in parallel (different platforms, different codebase layers, different features)
+
+Good combinations for parallel work:
+- One iOS feature + one Android/Desktop feature
+- A UI change + a network/discovery change
+- A new feature + an unrelated bugfix
+- Several features touching different modules
+
+---
+
+## Step 6 — Sprint doc format
+
+Save to `docs/sprints/sprint-NN.md`. Only three mandatory sections + one optional. Nothing beyond that.
 
 ```markdown
-## Цель спринта
+## Sprint goal
 
-<1–2 предложения. Пользовательский инкремент после спринта — не перечисление задач, а что меняется в продукте / для разработки.>
+<1–2 sentences. User-facing increment after the sprint — not a task list, but what changes in the product / for development.>
 
-## Состав
+## Composition
 
-| # | Issue | Название | Тип | Размер |
-| - | ----- | -------- | --- | ------ |
+| # | Issue | Title | Type | Size |
+| - | ----- | ----- | ---- | ---- |
 
-## Следствия
+## Consequences
 
-<1–3 пункта. Разблокированные направления — что становится возможным после этого спринта. Не «задача N сделана, теперь есть результат N» — инкремент уже описан в Цели. Мелкие infra/bug-фиксы можно не упоминать.>
+<1–3 items. Unblocked directions — what becomes possible after this sprint. Not "task N is done, now we have result N" — the increment is already described in the Goal. Minor infra/bug fixes don't need a mention.>
 
-## Порядок мерджа (опционально)
+## Merge order (optional)
 
-<Если для минимизации ребейзов имеет значение: #A → #B → #C. Иначе секцию опустить.>
+<If it matters for minimising rebases: #A → #B → #C. Otherwise omit the section.>
 ```
 
-**Размер (для колонки):**
-- **S** — изолированное изменение без платформенной специфики
-- **M** — несколько файлов / одна платформа с нюансами
-- **L** — новый компонент / несколько платформ / много неизвестного
+**Size (for the column):**
+- **S** — isolated change with no platform specifics
+- **M** — several files / one platform with nuances
+- **L** — new component / multiple platforms / lots of unknowns
 
-**Чего в спринт-доке быть не должно:**
-- Обоснований почему выбрана задача («приоритет», «потому что блокирует #N»).
-- Таблиц параллелизма по слоям, конфликт-матриц.
-- Цепочек блокировок наружу — это в Следствиях, одной фразой.
-- Списка «не вошло намеренно» — он живёт в бэклоге issue, не в спринт-доке.
-- Списка связанных продуктовых спек — спеки линкуются из issue, не дублируются здесь.
-- Per-task разворота DoD / acceptance criteria.
+**What must NOT be in the sprint doc:**
+- Justifications for why a task was chosen ("priority", "because it blocks #N").
+- Parallelism tables by layer, conflict matrices.
+- External blocking chains — that goes in Consequences, in one sentence.
+- A "not included intentionally" list — it lives in the issue backlog, not the sprint doc.
+- A list of related product specs — specs are linked from issues, not duplicated here.
+- Per-task DoD / acceptance criteria expansion.
 
-При закрытии спринта (Шаг 0) к таблице «Состав» дописывается колонка `Итог`, и добавляется секция `## Доп. результаты` — это единственное, что дорастает поверх плана.
+When closing the sprint (Step 0), an `Outcome` column is appended to the "Composition" table, and a `## Additional results` section is added — this is the only thing that grows on top of the plan.
 
-Если среди кандидатов есть задачи без спеки — явно спроси перед сохранением, нужно ли создать спеку.
+If there are tasks among the candidates without a spec — explicitly ask before saving whether a spec needs to be created.

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -15,30 +15,30 @@ Issue number `<N>`.
 
 ## Re-entry contract
 
-Skill идемпотентен по issue. На каждом вызове первым делом проверь `gh pr list --search "issue:#<N>" --state open`:
+The skill is idempotent per issue. At each invocation, first check `gh pr list --search "issue:#<N>" --state open`:
 
-- **PR нет** → стартуй Step 1.
-- **PR есть и открыт** → ты в pull-request feedback итерации. **Сначала** перепроверь docs-only детекцию (Step 1 классификация) на текущем состоянии issue + diff'а PR: если задача docs-only, делегируй re-entry в `/document <N>` и завершайся (`/document` сам идемпотентен и подхватит этот PR). Иначе остаёшься в code-track re-entry.
-- **Code-track re-entry.** На текущей feature-branch могут быть новые комменты ревьюера или коммиты после прошлого прогона. Прочитай **все** human-комменты на PR (`gh api repos/<owner>/<repo>/pulls/<PR>/comments` + `gh pr view <PR> --comments`) и для каждого определи статус: адресован в коммитах после него — или нет. **Дата создания не определяет актуальность** — фильтровать комменты по `created_at > <дата-прошлого-прогона>` запрещено, потому что неадресованный коммент остаётся актуальным независимо от того, насколько он старый. Прогон **обязан** включать на свежем diff'е: Step 4 (inner loop reviewers) → Step 5 (simplify) → Step 6 (full review wave A + adversarial) → Step 7 (smoke, скоуп по diff'у). Из дисциплины на re-entry ничего пропускать нельзя — иначе review-итерации проходят с меньшим качеством, чем первичная имплементация.
+- **No PR** → start Step 1.
+- **PR exists and is open** → you are in a pull-request feedback iteration. **First** re-check the docs-only detection (Step 1 classification) on the current state of the issue + PR diff: if the task is docs-only, delegate re-entry to `/document <N>` and exit (`/document` is itself idempotent and will pick up this PR). Otherwise stay in the code-track re-entry.
+- **Code-track re-entry.** The current feature branch may have new reviewer comments or commits since the last run. Read **all** human comments on the PR (`gh api repos/<owner>/<repo>/pulls/<PR>/comments` + `gh pr view <PR> --comments`) and for each determine its status: addressed in commits after it — or not. **Creation date does not determine relevance** — filtering comments by `created_at > <date-of-previous-run>` is forbidden, because an unaddressed comment remains relevant regardless of how old it is. The run **must** include on a fresh diff: Step 4 (inner loop reviewers) → Step 5 (simplify) → Step 6 (full review wave A + adversarial) → Step 7 (smoke, scoped to diff). Nothing from the re-entry discipline may be skipped — otherwise review iterations run at lower quality than the initial implementation.
 
-Шаг 8 (commit + push + final summary) — в re-entry упрощается: коммит идёт в существующую ветку, force-push не нужен, новый PR не создавать.
+Step 8 (commit + push + final summary) is simplified on re-entry: the commit goes into the existing branch, force-push is not needed, do not create a new PR.
 
-**После push в re-entry — обязательно ответь на каждый адресованный inline-коммент** через `gh api -X POST repos/<owner>/<repo>/pulls/<PR>/comments/<comment_id>/replies -f body="<reply>"`. Для каждого коммента: что сделано + SHA коммита (или явное обоснование, если коммент сознательно отклонён). Без ответа ревьюер не видит закрытия loop'а и тред остаётся «висящим»; следующий re-entry опять прочитает его как unaddressed и зря погонит inner loop. Ответ — это сигнал «адресовано», не вежливость.
+**After push on re-entry — reply to every addressed inline comment** via `gh api -X POST repos/<owner>/<repo>/pulls/<PR>/comments/<comment_id>/replies -f body="<reply>"`. For each comment: what was done + the commit SHA (or explicit reasoning if the comment was deliberately declined). Without a reply the reviewer cannot see the loop closed and the thread stays "hanging"; the next re-entry will read it again as unaddressed and uselessly re-run the inner loop. A reply is the "addressed" signal, not a courtesy.
 
 ## No-deflection principle
 
-Когда кто-то — пользователь или ревьюер — задаёт вопрос об артефакте или требует изменения, ответ должен быть **по существу**: либо обоснование, почему артефакт остаётся как есть, либо реальная правка артефакта по сути. Промежуточные действия — деструкция «на всякий случай», полу-правка, оправдание через KDoc / комментарий / документацию вместо изменения кода — это deflection. Запрещено.
+When someone — the user or a reviewer — asks a question about an artifact or demands a change, the answer must be **substantive**: either a justification for why the artifact stays as-is, or a genuine edit to the artifact itself. Intermediate actions — precautionary destruction, a half-fix, justifying via KDoc / comment / documentation instead of changing the code — are deflection. Forbidden.
 
-Два проявления, оба в inner-loop:
+Two manifestations, both in the inner loop:
 
-**1. Пользовательский вопрос мид-loop.** Сообщение «точно нужно X?» / «зачем X?» / «не лучше ли A вместо B?» / «может вынести в Y?» / «здесь nullable обязательно?» — это запрос на твоё суждение, не директива. Дефолт:
+**1. User question mid-loop.** A message like "is X really needed?" / "why X?" / "wouldn't A be better than B?" / "maybe extract to Y?" / "is nullable mandatory here?" — this is a request for your judgement, not a directive. Default:
 
-- **Обоснуй** — что артефакт даёт, чего нет в альтернативе, или почему ограничение оправдано.
-- **Уточни встречно** — «снести X совсем или сомневаешься в Y внутри X?», «вынести наружу или переименовать?».
+- **Justify** — what the artifact provides that the alternative lacks, or why the constraint is warranted.
+- **Counter-clarify** — "remove X entirely or are you unsure about Y inside X?", "extract externally or rename?".
 
-Молчаливое выполнение предполагаемого действия (удалить, переместить, переписать, заменить тип, развернуть nullable) на одном вопросе запрещено. Если бы пользователь хотел действие, он написал бы директивно. Вопрос заслуживает ответа первым; директива придёт после.
+Silently performing the assumed action (delete, move, rewrite, change type, unwrap nullable) on a single question is forbidden. If the user wanted an action, they would have written it directively. A question deserves an answer first; the directive will follow.
 
-**2. Ответ coder'а на reviewer finding.** Если coder адресовал finding «снеси X» / «убери Y» правкой, защищающей X через KDoc / комментарий / параграф в docs (вместо реального удаления / замены / переделки) — deflection, отклоняй. Ревьюер хотел X убрать, не задокументировать. Re-dispatch coder'а с явной формулировкой «правка X сама, без оправдания через документацию».
+**2. Coder's response to a reviewer finding.** If the coder addressed a finding of "remove X" / "delete Y" by making an edit that defends X via KDoc / comment / a paragraph in docs (instead of actually deleting / replacing / reworking) — that is deflection; reject it. The reviewer wanted X removed, not documented. Re-dispatch the coder with the explicit wording "change X itself, without justifying it through documentation".
 
 ## Gate semantics — when to stop and ask the user
 
@@ -62,28 +62,28 @@ gh issue view <N> --json title,body,labels,comments
 gh pr list --search "issue:#<N>" --state open --json number,isDraft,headRefName
 ```
 
-**Comments — это не дискуссия, это потенциально canon-update body.** При противоречии comment'а с body — приоритет comment'у, эскалируй пользователю одной строкой.
+**Comments are not a discussion — they are potentially a canon-update body.** When a comment conflicts with the body — the comment takes priority; escalate to the user in one line.
 
-**Critical reading.** Воспринимай описание issue как **стартовую точку, не как факт**. Подсвечивай и эскалируй пользователю до начала работы, если видишь хотя бы один пробел:
-- упомянута только одна платформа, хотя задача общая;
-- не описаны ошибки и fail-paths;
-- непонятно, как тестировать (нет указаний на edge cases / runtime check);
-- BUGFIX без хотя бы предполагаемой причины бага;
-- фразы-затычки: «дополни если есть чем», «должно работать корректно», «и так далее».
+**Critical reading.** Treat the issue description as a **starting point, not a fact**. Flag and escalate to the user before starting work if you see at least one gap:
+- only one platform is mentioned, yet the task is cross-platform;
+- errors and fail-paths are not described;
+- it is unclear how to test (no edge cases / runtime check guidance);
+- BUGFIX without at least a hypothesised bug cause;
+- filler phrases: "fill in if you have something", "should work correctly", "and so on".
 
-Любой такой пробел — повод вернуться к гейту spec/AC ambiguity, не «допилить по дороге».
+Any such gap is a reason to return to the spec/AC ambiguity gate, not to "patch it along the way".
 
-**Classification.** На основе issue body — `**Тип:**` поля, описания deliverable, label'ов — отнеси задачу к одной из веток:
+**Classification.** Based on the issue body — the `**Type:**` field, deliverable description, labels — assign the task to one of these tracks:
 
-| Trigger | Track | Действие |
+| Trigger | Track | Action |
 |---|---|---|
-| `**Тип:** DOCS` | docs-only | делегируй в `/document <N>` и завершайся |
-| `**Тип:** FEATURE` + явный маркер docs-only (фраза «docs-only» / «only docs» / «scope: docs» в body/DoD, либо label `docs-only`) | docs-only | то же |
-| Issue без `**Тип:**` AND deliverable **ограничен исключительно** правкой `.claude/` или `docs/` (никакого кода в исходниках) | docs-only | то же |
-| `**Тип:** INFRA` AND deliverable **ограничен исключительно** правкой `.claude/` файлов (skill prompts, agent definitions, hooks) | docs-only | то же |
-| `**Тип:** FEATURE` / `BUGFIX` / `REFACTOR` / `INFRA` с deliverable в исходниках или build/CI/scripts (даже если попутно нужен ADR) | code-track | продолжай Step 2–8 |
+| `**Type:** DOCS` | docs-only | delegate to `/document <N>` and exit |
+| `**Type:** FEATURE` + explicit docs-only marker (phrase "docs-only" / "only docs" / "scope: docs" in body/DoD, or label `docs-only`) | docs-only | same |
+| Issue without `**Type:**` AND deliverable **limited exclusively** to editing `.claude/` or `docs/` (no code in source sets) | docs-only | same |
+| `**Type:** INFRA` AND deliverable **limited exclusively** to editing `.claude/` files (skill prompts, agent definitions, hooks) | docs-only | same |
+| `**Type:** FEATURE` / `BUGFIX` / `REFACTOR` / `INFRA` with deliverable in source sets or build/CI/scripts (even if an ADR is also needed) | code-track | continue Steps 2–8 |
 
-При делегации в /document: «Эта задача — docs-only. Запускаю `/document <N>` и завершаюсь.» `/document` сам обработает выбор слоёв, консистентность, ревью и PR. **НЕ делегируй** код-FEATURE с попутным ADR — для таких задач Step 4 диспатчит `architect` mid-flight, и ADR пишется в той же PR что и код.
+When delegating to /document: "This task is docs-only. Running `/document <N>` and exiting." `/document` will handle layer selection, consistency, review and the PR itself. **Do NOT delegate** a code-FEATURE with an incidental ADR — for such tasks Step 4 dispatches `architect` mid-flight and the ADR is written in the same PR as the code.
 
 ### Doc discovery
 
@@ -111,7 +111,7 @@ All subsequent agent dispatches happen with this as cwd. Skipping this step mean
 
 ### Briefing back to the user
 
-После прочтения issue и разведки, **перед** любым вопросом пользователю (gate-вопросы, Open questions от sub-agent'ов, classification-неоднозначности) выдай в чат короткий бриф 3–6 строк: что делаем, зачем (мотивация / контекст из issue), классификация (track + затрагиваемые слои/платформы). Если в этом же сообщении задаёшь вопросы — к каждому приложи 1–2 строки контекста (что говорит issue, какие варианты на столе), чтобы пользователь отвечал, не уходя на GitHub перечитывать тело. Бриф один на прогон; в re-entry не повторяй.
+After reading the issue and doing recon, **before** any question to the user (gate questions, open questions from sub-agents, classification ambiguities) — post a short 3–6 line briefing in chat: what we are doing, why (motivation / context from the issue), classification (track + affected layers/platforms). If you are asking questions in the same message — attach 1–2 lines of context to each (what the issue says, what options are on the table), so the user can answer without going to GitHub to re-read the body. One briefing per run; do not repeat on re-entry.
 
 ## Step 2 — Resolve early gates
 
@@ -129,7 +129,7 @@ If BUGFIX → dispatch `bug-reproducer`. It reproduces locally, verifies each hy
 
 ### Publication of confirmed cause
 
-After receiving a confirmed cause from `bug-reproducer`, show the paste-ready block to the user and ask: «Опубликовать как комментарий к issue #<N>?» Wait for explicit OK before `gh issue comment <N>`. Reason: a team-visible side effect must not happen without an explicit gate, even if the orchestrator is doing it instead of the agent — that just moves the problem one level up. If the user says no — keep the cause locally as a constraint for `coder`; do not publish.
+After receiving a confirmed cause from `bug-reproducer`, show the paste-ready block to the user and ask: "Publish as a comment on issue #<N>?" Wait for explicit OK before `gh issue comment <N>`. Reason: a team-visible side effect must not happen without an explicit gate, even if the orchestrator is doing it instead of the agent — that just moves the problem one level up. If the user says no — keep the cause locally as a constraint for `coder`; do not publish.
 
 The confirmed root cause becomes a hard constraint for the `coder` in Step 4 regardless of whether it was published.
 
@@ -137,9 +137,9 @@ The confirmed root cause becomes a hard constraint for the `coder` in Step 4 reg
 
 Use the built-in `Plan` agent (or `general-purpose` if plan unavailable) to produce a short implementation plan: phases, files to touch, validation strategy.
 
-**Выбор уровня фикса.** Issue указывает место бага, но не обязательно место фикса. Когда root cause описывает класс багов (а не один экземпляр) или когда параллельные реализации содержат тот же дефект — рассмотри фикс на уровень выше: изменение типа / контейнера / контракта, делающее класс багов невозможным. Сравни стоимость: N point-фиксов vs 1 структурный. Если выбираешь point — явно перечисли в плане параллельные места, остающиеся с дефектом, и заведи follow-up issue до начала кодинга.
+**Choosing the fix level.** The issue identifies where the bug manifests, not necessarily where to fix it. When the root cause describes a class of bugs (not a single instance) or when parallel implementations contain the same defect — consider a fix one level up: a type / container / contract change that makes the class of bugs impossible. Compare costs: N point-fixes vs 1 structural fix. If you choose point-fix — explicitly list in the plan the parallel locations that remain defective, and file a follow-up issue before starting coding.
 
-**Scope issue — стартовая точка, не клетка.** Список файлов в issue — отправная точка. Если для качественного решения нужно тронуть смежные классы или соседние платформы — расширяй scope в этом же PR. Follow-up issue только когда расширение реально ломает PR (новый таргет, широкая правка публичного контракта, кратный рост объёма, обнаружение отдельного бага). Notes / TODO, которые исполнитель сам добавил по ходу — доделываются здесь же.
+**Issue scope — starting point, not a cage.** The file list in the issue is a starting point. If touching adjacent classes or neighbouring platforms is needed for a quality solution — expand scope in this same PR. A follow-up issue only when expansion genuinely breaks the PR (new target, broad public contract edit, multiplicative volume growth, discovery of a separate bug). Notes / TODOs the implementer added along the way — finish them here.
 
 **Track splitting.** Default is **sequential single-track** execution. Split into parallel tracks ONLY if the plan can enumerate file-level disjoint sets: track A's files ∩ track B's files = ∅. The plan must list explicit file paths per track. If any file appears in two tracks → tracks are not independent → execute sequentially.
 
@@ -157,7 +157,7 @@ Per track (or sequentially if single track):
    - **Architectural design point** — plan from Step 3 surfaces a non-trivial mechanism / library / structural choice that `coder` should not make alone → `architect` first. It converges the choice (its own palette + user trade-off questions + ADR/living doc), returns a one-line decision summary; that summary then becomes a hard constraint for the subsequent `coder` dispatch in the same track.
    - **Everything else** (network, discovery, protocol, persistence, build, infra) → `coder`
    - **Mixed** — split into sub-tracks if disjoint files, else dispatch `coder` which can pull in `ui-expert` / `architect` via Agent tool.
-2. **Перед dispatch'ем reviewer wave — закоммить изменения coder'а** на feature-branch (новый коммит или `--amend`, на твоё усмотрение). Reviewer'ы читают `git diff main...HEAD` и **в working tree не должно быть uncommitted изменений** на момент их запуска. Иначе часть агентов читает только committed state и шлёт stale [REQUIRED] на проблемах, которые уже починены, но не видны им — оркестратор тратит контекст на разбор фантомных flag'ов, плюс риск false-block'a. Один источник истины = один коммит per inner-loop iteration.
+2. **Before dispatching the reviewer wave — commit the coder's changes** on the feature branch (a new commit or `--amend`, your call). Reviewers read `git diff main...HEAD` and **the working tree must have no uncommitted changes** at the time they run. Otherwise some agents read only the committed state and send stale [REQUIRED] flags for problems already fixed but not yet visible to them — the orchestrator wastes context parsing phantom flags, plus there is a risk of false-blocks. One source of truth = one commit per inner-loop iteration.
 3. Dispatch a **fast reviewer wave** in parallel:
    - `review-dod` (always)
    - `review-correctness` (always unless DOCS/REFACTOR)
@@ -177,9 +177,9 @@ Per track (or sequentially if single track):
 >
 > <list of [REQUIRED] findings with file:line>
 
-   **Red CI test = broken code, not broken test.** Дефолт — чинить код. Удаление failing теста, переписывание в narrower fast-check, ослабление assertion/таймаута/входов — без явного апрува пользователя запрещены. Гипотеза «тест проверял не то» — эскалация к пользователю, не самостоятельное решение.
+   **Red CI test = broken code, not broken test.** Default — fix the code. Deleting a failing test, rewriting it as a narrower fast-check, weakening assertions/timeouts/inputs — all forbidden without explicit user approval. Hypothesis "the test was checking the wrong thing" — escalate to the user, do not resolve independently.
 
-   **Точность передачи ревью.** Coder получает контекст cold и не верифицирует orchestrator'а — если ты перепаковал «снеси X» в «оправдай X через KDoc», coder сделает ровно последнее. Передавай findings максимально близко к исходным формулировкам ревьюера; не сужай и не смягчай. Если несколько findings сходятся на одном принципе — назови принцип явно в инструкции и перечисли ВСЕ сайты, где он применяется, даже если в комментариях упомянуты не все. Сомневаешься в интерпретации — эскалируй пользователю ДО dispatch'а, не после следующего раунда ревью. См. также `## No-deflection principle` — defensive-via-docs ответ coder'а на «снеси X» отклоняется по тому же правилу.
+   **Review transmission accuracy.** The coder receives context cold and does not verify the orchestrator — if you repackaged "remove X" as "justify X via KDoc", the coder will do exactly the latter. Pass findings as close as possible to the reviewer's original wording; do not narrow or soften. If several findings converge on one principle — name the principle explicitly in the instruction and list ALL sites where it applies, even if not all were mentioned in comments. If you are unsure about interpretation — escalate to the user BEFORE dispatching, not after the next review round. See also `## No-deflection principle` — a coder's defensive-via-docs response to "remove X" is rejected by the same rule.
 
    Go back to step 2.
 
@@ -196,13 +196,13 @@ Dispatch the implementing agent once more:
 > **Do not rephrase prose for brevity.** If a sentence is load-bearing and free of the issues above, leave its wording alone. Cut whole sentences when they fail the rule above; otherwise keep them as written. Word-count reduction on well-formed sentences is not a goal.
 > Do not change behavior; do not touch anything outside the diff. Run `./gradlew allTests -q` after.
 
-If anything was simplified — **закоммить simplification** (см. дисциплину Step 4 — reviewer'ы читают только committed diff), затем re-run **the same set of agents that ran in Step 4 for this PR type** (i.e. dod + guides + glossary + correctness + tests + platform-if-touched + ux-if-touched + design-system-if-touched + visual-if-touched) **plus `review-reuse`** on the simplified diff. `review-reuse` is critical here because duplication is what most likely accumulated across iterations and tracks. `review-platform`, `review-ux`, `review-design-system`, and `review-visual` follow the same skip rules as Step 4 (platform set touched / `composeApp/src/**` touched). If clean, proceed.
+If anything was simplified — **commit the simplification** (see Step 4 discipline — reviewers read only the committed diff), then re-run **the same set of agents that ran in Step 4 for this PR type** (i.e. dod + guides + glossary + correctness + tests + platform-if-touched + ux-if-touched + design-system-if-touched + visual-if-touched) **plus `review-reuse`** on the simplified diff. `review-reuse` is critical here because duplication is what most likely accumulated across iterations and tracks. `review-platform`, `review-ux`, `review-design-system`, and `review-visual` follow the same skip rules as Step 4 (platform set touched / `composeApp/src/**` touched). If clean, proceed.
 
 ## Step 6 — Full pre-PR review (inline, not via /code-review skill)
 
 `/code-review` skill requires an existing PR (it posts via `gh pr review`). At this step the PR does not exist yet — Step 8 creates it. So instead of calling the skill, **orchestrate the same agent fan-out inline, without GitHub publication**:
 
-1. Перед Wave A — working tree должно быть чистым (committed). Если после Step 5 остались uncommitted правки — закоммить. Reviewer'ы читают `git diff main...HEAD`; uncommitted состояние вызывает stale-view findings.
+1. Before Wave A — the working tree must be clean (committed). If there are uncommitted edits after Step 5 — commit them. Reviewers read `git diff main...HEAD`; uncommitted state causes stale-view findings.
 2. Wave A in parallel: `review-dod`, `review-guides`, `review-glossary`, `review-reuse`, plus (if applicable to PR type / diff) `review-architecture`, `review-correctness`, `review-tests`, `review-platform`, `review-ux`, `review-design-system`, `review-visual`. Each agent receives the issue number and is told to review the local working tree (`git diff main...HEAD`) instead of a PR. `review-ux`, `review-design-system`, and `review-visual` all run whenever the diff touches `composeApp/src/**`; each agent decides skip vs. block.
 3. Wave B: `review-adversarial` with the combined Wave A findings as input.
 4. Aggregate. Apply any `[REQUIRED]` via the implementing agent (with the symmetry-pass instruction). Re-run until approved or 2 iterations.
@@ -213,11 +213,11 @@ No `gh pr review` here — findings are consumed locally only. The post-PR `/cod
 
 ### Smoke verdict
 
-Две ветки. Выбирается по природе deliverable'а, не взаимоисключающие — для PR где меняется и фича и enforcer, делаются обе.
+Two branches. Chosen by the nature of the deliverable, not mutually exclusive — for a PR that changes both a feature and an enforcer, do both.
 
 ### 7a — Smoke (feature behavior)
 
-Когда deliverable PR — runtime-поведение фичи (пользовательский путь, сетевой обмен, lifecycle).
+When the PR deliverable is runtime feature behaviour (user path, network exchange, lifecycle).
 
 Run `/smoke-test` blocks relevant to the diff:
 
@@ -233,21 +233,21 @@ If the PR introduces a new critical happy-path not covered by smoke (start-time 
 
 ### 7b — Enforcement probe (static check is wired in)
 
-Когда deliverable PR — сам enforcement mechanism (custom lint rule, CI guard, git hook, custom Gradle check, ktlint/detekt правило, schema validator). Unit-тесты механизма не доказывают, что он подключён через ServiceLoader / Gradle / hook chain — нужна инъекция через ту же дверь, через которую пройдёт реальный нарушитель.
+When the PR deliverable is the enforcement mechanism itself (custom lint rule, CI guard, git hook, custom Gradle check, ktlint/detekt rule, schema validator). Unit tests of the mechanism do not prove it is wired in via ServiceLoader / Gradle / hook chain — an injection is needed through the same door a real violator would use.
 
-Шаги:
-1. Создай минимальный артефакт, нарушающий проверку, в реальном месте кодовой базы (там, где enforcer должен сработать — `src/.../Test.kt` для ktlint test rule, `.github/workflows/` для CI guard).
-2. Запусти соответствующий Gradle/CI task (`./gradlew ktlintCheck`, `./gradlew <task>`, `git commit` для pre-commit hook).
-3. Проверь: build FAILED **с ожидаемым сообщением** (rule id / hook name).
-4. Удали probe, убедись через `git status -s` что ничего не осталось.
+Steps:
+1. Create a minimal artifact violating the check in a real location in the codebase (where the enforcer should fire — `src/.../Test.kt` for a ktlint test rule, `.github/workflows/` for a CI guard).
+2. Run the corresponding Gradle/CI task (`./gradlew ktlintCheck`, `./gradlew <task>`, `git commit` for a pre-commit hook).
+3. Verify: build FAILED **with the expected message** (rule id / hook name).
+4. Delete the probe; confirm via `git status -s` that nothing remains.
 
-Если шаг 3 проходит зелёно — enforcer не подключён, несмотря на зелёные unit-тесты. Это red gate, эскалируй пользователю.
+If step 3 passes green — the enforcer is not wired in, despite green unit tests. This is a red gate; escalate to the user.
 
 ### Verdict
 
-Record the verdict (🟢/🟡/🔴) per branch run, плюс блоки/probe path.
+Record the verdict (🟢/🟡/🔴) per branch run, plus blocks/probe path.
 
-Если любая ветка 🟡/🔴 → present to user, stop.
+If any branch is 🟡/🔴 → present to user, stop.
 
 ## Step 8 — Commit, push, PR (final summary)
 
@@ -268,7 +268,7 @@ Report to the user:
 - AC: all `[DONE]` (from `review-dod`).
 - Smoke: 🟢 with blocks executed.
 - Any `[UNVERIFIABLE]` from reviewers.
-- Manual test plan — 1–2 предложения с упором на регрессионный smoke и shipping behaviour, явно говори «backend-only, нечего тестировать руками» если нет visible diff'а.
+- Manual test plan — 1–2 sentences focused on regression smoke and shipping behaviour; explicitly say "backend-only, nothing to test manually" if there is no visible diff.
 
 Next step is manual review on GitHub, then `/close-issue <N>`.
 

--- a/.claude/skills/progress/SKILL.md
+++ b/.claude/skills/progress/SKILL.md
@@ -1,182 +1,182 @@
 ---
 name: progress
-description: Снимок прогресса проекта в виде RPG-листа персонажа Skyrim — класс героя, уровень+XP по PR-статистике, главы MVP с прогресс-барами, легендарные артефакты (топ-PR), карта заданий (граф зависимостей кластеризованный по школам), Печать Долга (планируемое vs импровизация). Цифры обёрнуты в RPG-язык; голые проценты — только в чисто статистических таблицах. Используй когда пользователь просит «прогресс», «статус проекта», «снимок», «как идут дела» — или явно вызывает `/progress`. Для сухих цифр без RPG-обёртки — отдельная команда `/progress-boring`.
+description: Project progress snapshot as an RPG character sheet from Skyrim — hero class, level+XP from PR statistics, MVP chapters with progress bars, legendary artifacts (top PRs), quest map (dependency graph clustered by schools), Seal of Debt (planned vs improvised). Numbers wrapped in RPG language; bare percentages only in purely statistical tables. Use when the user asks for "progress", "project status", "snapshot", "how things are going" — or explicitly calls `/progress`. For dry numbers without RPG framing — separate command `/progress-boring`.
 ---
 
-Снимок прогресса проекта в виде RPG-листа персонажа. Tether — это не проект, это сага. Пользователь — Драконорождённый разработчик. Roadmap — главная сюжетная линия, инфра — побочки и крафт, MVP — финальный данж.
+Project progress snapshot as an RPG character sheet. Tether is not a project — it's a saga. The user is the Dragonborn developer. The roadmap is the main story line, infra is side quests and crafting, MVP is the final dungeon.
 
-Тон серьёзно-эпический с лёгкой самоиронией. Перевод цифр в RPG-язык обязателен в нарративных блоках; чистые статистические таблицы (Жаркие Сражения, Тяжёлые Походы) — голые цифры допустимы.
+Tone: seriously epic with light self-irony. Translating numbers into RPG language is mandatory in narrative blocks; pure statistical tables (Hot Battles, Heavy Marches) — bare numbers are acceptable.
 
 ## Assets
 
-Фиксированные словари и палитра рядом в `assets/`. Никаких имён, ключевых слов или цветов сверх того, что там лежит — это обеспечивает сравнимость снапшотов между запусками. Изменения в палитре, школах и локациях — через правку JSON-файлов, не инструкции.
+Fixed dictionaries and palette are nearby in `assets/`. No names, keywords, or colours beyond what is there — this ensures snapshot comparability between runs. Changes to palette, schools, and locations — via editing JSON files, not instructions.
 
-- [`assets/schools.json`](assets/schools.json) — 7 кластеров для графа зависимостей, имена и `keywords` для классификации.
-- [`assets/locations.json`](assets/locations.json) — 8 source set'ов с атмосферными именами и lore.
-- [`assets/keywords.json`](assets/keywords.json) — title-эвристики feature vs infra.
-- [`assets/classes.json`](assets/classes.json) — правила выбора класса героя по доминанте PR.
-- [`assets/palette.json`](assets/palette.json) — цвета, шрифты, стили рамок артефактов по rarity.
+- [`assets/schools.json`](assets/schools.json) — 7 clusters for the dependency graph, names and `keywords` for classification.
+- [`assets/locations.json`](assets/locations.json) — 8 source sets with atmospheric names and lore.
+- [`assets/keywords.json`](assets/keywords.json) — title heuristics for feature vs infra.
+- [`assets/classes.json`](assets/classes.json) — rules for choosing the hero class based on PR dominance.
+- [`assets/palette.json`](assets/palette.json) — colours, fonts, artifact frame styles by rarity.
 
-## Что собрать (сырые данные)
+## What to collect (raw data)
 
-1. **PR-статистика через GraphQL.** Один запрос `gh api graphql` с пагинацией по `repository.pullRequests` — за раз получи `number, title, state, createdAt, mergedAt, additions, deletions, changedFiles, commits.totalCount, comments.totalCount, reviews.totalCount, reviewThreads.totalCount`. REST list endpoint (`/pulls`) не возвращает commits/comments/review_threads — нужен GraphQL или per-PR detail call.
+1. **PR statistics via GraphQL.** One `gh api graphql` request with pagination over `repository.pullRequests` — fetch at once `number, title, state, createdAt, mergedAt, additions, deletions, changedFiles, commits.totalCount, comments.totalCount, reviews.totalCount, reviewThreads.totalCount`. The REST list endpoint (`/pulls`) does not return commits/comments/review_threads — GraphQL or per-PR detail calls are required.
 
-2. **Issues.** `gh issue list --state all --limit 500 --json number,title,state,labels,createdAt,closedAt` плюс `gh api 'repos/<owner>/<repo>/issues?state=all&per_page=100' --paginate` — нужно ради `parent_issue_url` и `issue_dependencies_summary`.
+2. **Issues.** `gh issue list --state all --limit 500 --json number,title,state,labels,createdAt,closedAt` plus `gh api 'repos/<owner>/<repo>/issues?state=all&per_page=100' --paginate` — needed for `parent_issue_url` and `issue_dependencies_summary`.
 
-3. **Зависимости issue.** Для тех, у кого `issue_dependencies_summary.total_blocked_by > 0` — `gh api 'repos/<owner>/<repo>/issues/<N>/dependencies/blocked_by'`. REST endpoint; `addIssueDependency` mutation в GraphQL у GitHub не существует (это в памяти проекта). Parent — из `parent_issue_url` основного endpoint'а.
+3. **Issue dependencies.** For those where `issue_dependencies_summary.total_blocked_by > 0` — `gh api 'repos/<owner>/<repo>/issues/<N>/dependencies/blocked_by'`. REST endpoint; the `addIssueDependency` GraphQL mutation does not exist in GitHub (this is in the project memory). Parent — from `parent_issue_url` of the main endpoint.
 
-4. **MVP-скоуп.** `docs/product/roadmap.md` секция `## MVP`. `docs/product/features/README.md` — статусы фичей. Последний `docs/sprints/sprint-*.md` — активный спринт.
+4. **MVP scope.** `docs/product/roadmap.md` section `## MVP`. `docs/product/features/README.md` — feature statuses. The latest `docs/sprints/sprint-*.md` — the active sprint.
 
-5. **LOC по локациям.** `git ls-files 'composeApp/src/<sourceSet>/'` + подсчёт по `.kt`/`.swift`. Source set'ы в `assets/locations.json`.
+5. **LOC by locations.** `git ls-files 'composeApp/src/<sourceSet>/'` + count over `.kt`/`.swift`. Source sets are in `assets/locations.json`.
 
-6. **Спринт-планы.** Парсинг секции `## Состав` каждого `docs/sprints/sprint-*.md` (regex `## Состав .. (?=^## |\Z)`), извлечь `#N` в эту секцию — множество запланированных задач.
+6. **Sprint plans.** Parse the `## Composition` section of each `docs/sprints/sprint-*.md` (regex `## Composition .. (?=^## |\Z)`), extract `#N` into that section — the set of planned tasks.
 
-7. **Cutoff для Печати Долга.** `git log --diff-filter=A --follow --format='%aI' -- docs/sprints/sprint-01.md | tail -1` — дата заведения первого спринт-плана. Issues, созданные раньше, в Печати Долга не учитываются.
+7. **Cutoff for the Seal of Debt.** `git log --diff-filter=A --follow --format='%aI' -- docs/sprints/sprint-01.md | tail -1` — the date the first sprint plan was filed. Issues created before this date are not counted in the Seal of Debt.
 
-## Правила расчёта
+## Calculation rules
 
-### Класс персонажа
-Один по правилам из `assets/classes.json` (порядковое сопоставление, первое сработавшее). Обоснуй одной строкой («каждый пятый PR — ретро»).
+### Hero class
+One class per the rules in `assets/classes.json` (ordinal matching, first match wins). Justify in one line ("every fifth PR is a retro").
 
-### Уровень и XP
-`Level = floor(sqrt(2·merged_PRs + closed_issues))`. XP-бар:
-- `xp_total = 2·merged_PRs + closed_issues` (та же формула что у уровня — иначе бар уходит в отрицательные значения)
+### Level and XP
+`Level = floor(sqrt(2·merged_PRs + closed_issues))`. XP bar:
+- `xp_total = 2·merged_PRs + closed_issues` (same formula as level — otherwise the bar goes negative)
 - `xp_in_level = xp_total − level²`
 - `xp_needed = (level+1)² − level²`
 
-### Категоризация PR / issue
-По `assets/keywords.json`. Используется в Хронике Подвигов, Печати Долга, классе персонажа.
+### PR / issue categorisation
+Per `assets/keywords.json`. Used in the Chronicle of Deeds, Seal of Debt, hero class.
 
-### MVP (Главный Сюжет)
-7 глав из roadmap с эпическими подзаголовками («Глава II: Печать Доверия — четыре руны связывают двоих»). Каждой — % готовности по доказательствам:
-- 100% — feature `done` + смерженные PR по всем платформам.
-- 50–80% — частично (один из слоёв / часть платформ).
-- 20–40% — только spec scoped.
-- 5% — ни кода, ни решения.
+### MVP (Main Quest)
+7 chapters from the roadmap with epic subtitles ("Chapter II: The Seal of Trust — four runes bind two souls"). Each gets a completion % based on evidence:
+- 100% — feature `done` + merged PRs across all platforms.
+- 50–80% — partial (one of the layers / some platforms).
+- 20–40% — only spec scoped.
+- 5% — no code, no decision.
 
-Прогресс-бары под статусом, палитра золото→золото-pale (закрытые) и серый (не начатые).
+Progress bars below the status, palette gold→gold-pale (completed) and grey (not started).
 
-### Артефакты (топ-5 PR)
-Вес: `commits·2 + comments + review_threads·3 + (additions+deletions)/200`. Топ-5 с rarity-цветами рамок по `assets/palette.json#artifact_rarity`. Внутри карточки три строки: коммиты, обсуждения (`comments + review_threads`), `+/−` строк.
+### Artifacts (top-5 PRs)
+Weight: `commits·2 + comments + review_threads·3 + (additions+deletions)/200`. Top-5 with rarity-colour frames per `assets/palette.json#artifact_rarity`. Inside each card three lines: commits, discussions (`comments + review_threads`), `+/−` lines.
 
-### Жаркие Сражения / Тяжёлые Походы
-- **Жаркие** — топ-5 PR по `comments + review_threads`.
-- **Тяжёлые** — топ-5 PR по `additions + deletions`.
+### Hot Battles / Heavy Marches
+- **Hot** — top-5 PRs by `comments + review_threads`.
+- **Heavy** — top-5 PRs by `additions + deletions`.
 
-Таблицы `#PR | название | значение`, моноширинные цифры справа. Без RPG-перевода в значениях — чистая статистика.
+Tables `#PR | title | value`, monospace numbers right-aligned. No RPG translation in values — pure statistics.
 
-### Печать Долга — план vs импровизация
-**Cutoff:** учитываем только issues, созданные **после** даты заведения `sprint-01.md` в git. Ретро-PR не учитываются (идут без отдельного issue).
+### Seal of Debt — planned vs improvised
+**Cutoff:** count only issues created **after** the date `sprint-01.md` was filed in git. Retro-PRs are not counted (they have no separate issue).
 
-- `planned ∩ closed` после cutoff — «По свитку спринтов»
-- `closed − planned` после cutoff — «Случайные встречи»
+- `planned ∩ closed` after cutoff — "By the Sprint Scroll"
+- `closed − planned` after cutoff — "Random Encounters"
 
-Три цифры + двуцветная stacked-полоска (золото ↔ пурпур) + последние 6 в каждой категории.
+Three numbers + a two-colour stacked bar (gold ↔ purple) + the last 6 in each category.
 
-### Карта Заданий — граф зависимостей
-Force-directed граф через D3 v7 с кластеризацией по школам из `assets/schools.json`.
+### Quest Map — dependency graph
+Force-directed graph via D3 v7 with clustering by schools from `assets/schools.json`.
 
 **Layout:**
-- Якоря школ на радиальной окружности `R = min(W,H)·0.30` равноудалены по углу.
-- Подписи школ на внешнем кольце `R_LBL = min(W·0.46, H·0.48)` с динамическим `text-anchor` по углу (cos<−0.3 → end, cos>0.3 → start, иначе middle).
-- Сила притяжения узла к якорю своего кластера: `0.14`.
+- School anchors on a radial circle `R = min(W,H)·0.30` equidistant by angle.
+- School labels on the outer ring `R_LBL = min(W·0.46, H·0.48)` with dynamic `text-anchor` by angle (cos<−0.3 → end, cos>0.3 → start, otherwise middle).
+- Node attraction force toward its cluster anchor: `0.14`.
 - Charge `-50`, link distance `38`, collide `13`, alphaDecay `.025`.
-- Координаты узлов клампятся в `[PAD, W-PAD]` × `[PAD, H-PAD]` каждый tick.
+- Node coordinates clamped to `[PAD, W-PAD]` × `[PAD, H-PAD]` on each tick.
 
-**Цвета** — `assets/palette.json#graph_nodes` и `#graph_edges`. Сирый узел = ни parent, ни blocked_by, ни blocks (полная изоляция). В цепях = open AND хотя бы один открытый `blocked_by` предок.
+**Colours** — `assets/palette.json#graph_nodes` and `#graph_edges`. Lone node = no parent, no blocked_by, no blocks (complete isolation). In chains = open AND at least one open `blocked_by` ancestor.
 
-**Интерактив:**
-- Drag узлов (D3 drag behavior, fx/fy фиксируются на время).
-- Scroll wheel / drag-by-empty-space → pan+zoom через `d3.zoom().scaleExtent([0.3, 4])`. Filter: не зумить когда курсор над узлом (иначе конфликтует с node drag).
-- Кнопки `+ / − / ⤺` для зума через `zoom.scaleBy` / `zoom.transform(zoomIdentity)`.
+**Interactivity:**
+- Node drag (D3 drag behaviour, fx/fy fixed during drag).
+- Scroll wheel / drag-on-empty-space → pan+zoom via `d3.zoom().scaleExtent([0.3, 4])`. Filter: do not zoom when the cursor is over a node (otherwise conflicts with node drag).
+- `+ / − / ⤺` buttons for zoom via `zoom.scaleBy` / `zoom.transform(zoomIdentity)`.
 
-**Тултип** — HTML div absolutely positioned внутри graph-box, появляется на `mouseenter` с opacity transition. Содержит: `#N`, полный title, кластер, статус (`открыт`/`закрыт`, `в цепях`/`сирый`).
+**Tooltip** — HTML div absolutely positioned inside the graph box, appears on `mouseenter` with opacity transition. Contains: `#N`, full title, cluster, status (`open`/`closed`, `in chains`/`lone`).
 
-**Подписи узлов** в `JetBrains Mono 9px` на отдельном top-слое с `paint-order:stroke; stroke:<card_bg>; stroke-width:3px` — halo сохраняет читаемость при наложении на соседние узлы и рёбра.
+**Node labels** in `JetBrains Mono 9px` on a separate top layer with `paint-order:stroke; stroke:<card_bg>; stroke-width:3px` — halo preserves readability when overlapping neighbouring nodes and edges.
 
-**Сводка над графом** — 3 карточки: свободные открытые, в цепях, сирые открытые. Числа в соответствующих цветах из палитры.
+**Summary above the graph** — 3 cards: free open nodes, in chains, lone open nodes. Numbers in the corresponding palette colours.
 
-**Под графом** — две легенды: цвета узлов/рёбер; описание школ (имя + `summary` из `schools.json`).
+**Below the graph** — two legends: node/edge colours; school descriptions (name + `summary` from `schools.json`).
 
-### Слава Дней — дневная скорость героя
+### Glory of Days — daily hero speed
 
-Сумма «доблести» закрытых за день квестов. Доблесть квеста =
+Sum of "valour" of quests closed on a given day. Quest valour =
 
 ```
 valor(task) = base(size) + 0.3·comments + LOC/200 + cycleHours/24
 ```
 
-- `base(size)` — `assets/palette.json#valor_size` (S=1, M=3, L=8, без лейбла=2). Привязка к лейблам `size:S` / `size:M` / `size:L` issue, закрытого PR.
-- `comments` = `comments.totalCount + reviewThreads.totalCount` PR (тяжесть обсуждения).
-- `LOC` = `additions + deletions` PR (тяжесть переписки с кодом).
-- `cycleHours` — часы между первым коммитом PR (`commits.nodes[0].commit.committedDate`, сортировка по дате asc) и `mergedAt`. Долгий цикл = задача упёрлась.
+- `base(size)` — `assets/palette.json#valor_size` (S=1, M=3, L=8, no label=2). Mapped to `size:S` / `size:M` / `size:L` labels on the issue closed by the PR.
+- `comments` = `comments.totalCount + reviewThreads.totalCount` of the PR (discussion weight).
+- `LOC` = `additions + deletions` of the PR (code churn weight).
+- `cycleHours` — hours between the first PR commit (`commits.nodes[0].commit.committedDate`, sorted by date asc) and `mergedAt`. Long cycle = the task hit a wall.
 
-Привязка PR ↔ issue по префиксу `#N:` в title PR (или в первом коммите). Если PR ретро / без issue — `base = 1`.
+Linking PR ↔ issue by the `#N:` prefix in the PR title (or in the first commit). If the PR is a retro / has no issue — `base = 1`.
 
-`valor(day D) = Σ valor(task)` по PR с `mergedAt::date == D`, разложенный на две полосы — `valor_feature` и `valor_infra` (категория по `assets/keywords.json`). День без merge — `0` в обеих полосах.
+`valor(day D) = Σ valor(task)` for PRs with `mergedAt::date == D`, broken into two bars — `valor_feature` and `valor_infra` (category from `assets/keywords.json`). A day with no merges — `0` in both bars.
 
-**Отрисовка.** Chart.js stacked area chart по дням (от даты заведения `sprint-01.md` до сегодня). Две области с накоплением: нижняя — feature (золото `gold.primary`), верхняя — infra (тёмный янтарь `gold.dim`). Верхняя граница стопки = суммарный дневной валор. Полупрозрачные заливки (alpha ≈ 0.7), точки на узлах не нужны.
+**Rendering.** Chart.js stacked area chart by day (from the date `sprint-01.md` was filed to today). Two stacked areas: bottom — feature (gold `gold.primary`), top — infra (dark amber `gold.dim`). Top boundary of the stack = total daily valour. Semi-transparent fills (alpha ≈ 0.7), no points on nodes.
 
-Под графиком — три карточки: суммарный валор за всё время / средний дневной валор / самый славный день (дата + значение).
+Below the chart — three cards: total valour over all time / average daily valour / most glorious day (date + value).
 
-Тон карточек — RPG: «Слава Драконорождённого», «Средняя поступь», «День Великой Битвы». Сама ось Y — голая (это статистика).
+Card tone — RPG: "Glory of the Dragonborn", "Average Stride", "Day of the Great Battle". The Y axis itself — bare (this is statistics).
 
-### Баланс Недели — доля feature за последние 7 дней
+### Balance of the Week — feature share over the last 7 days
 
-Одна цифра на карточке: `feature_share(last 7d), %`, в скобках — изменение к предыдущей 7-дневке. Формат `25% (−6%)`. Знак рендерим явно: `(+X%)` зелёным `#5a8a3a`, `(−X%)` кровавым `blood`, `(±0%)` приглушённым `text.muted`. Карточка стоит в «Листе Персонажа» рядом с «Хроникой пути» — это компактная замена прежней Хроники Подвигов (недельный stacked-bar снесён, дневной валор и так показывает доли).
+One number on a card: `feature_share(last 7d), %`, in parentheses — change from the previous 7-day period. Format `25% (−6%)`. Sign rendered explicitly: `(+X%)` in green `#5a8a3a`, `(−X%)` in blood `blood`, `(±0%)` in muted `text.muted`. The card sits in the "Character Sheet" next to the "Journey Chronicle" — it is a compact replacement for the former Chronicle of Deeds (weekly stacked bar removed; daily valour already shows proportions).
 
-### Книга Знаний
-Внизу страницы — раздел с формулами и расшифровками: уровень+XP, вес артефакта, как определяется класс, прогресс MVP-глав, Жаркие/Тяжёлые. Двухколоночный layout в Cinzel-золоте.
+### Book of Knowledge
+At the bottom of the page — a section with formulae and explanations: level+XP, artifact weight, how the class is determined, MVP chapter progress, Hot/Heavy. Two-column layout in Cinzel-gold.
 
-## Вывод
+## Output
 
-HTML `/tmp/tether-progress.html`. Палитра, шрифты, рамки — из `assets/palette.json`. Декоративные рамки секций — `border: 2px double <gold.dim>` с псевдо-элементами-орнаментами (`❧` в углах).
+HTML `/tmp/tether-progress.html`. Palette, fonts, frames — from `assets/palette.json`. Decorative section frames — `border: 2px double <gold.dim>` with ornament pseudo-elements (`❧` in corners).
 
-Подключи через CDN:
+Include via CDN:
 - `https://cdn.jsdelivr.net/npm/chart.js` — area/bar/doughnut.
-- `https://cdn.jsdelivr.net/npm/d3@7` — force-граф.
+- `https://cdn.jsdelivr.net/npm/d3@7` — force-directed graph.
 
-Шрифты через Google Fonts — берутся из `assets/palette.json#fonts`. По умолчанию: Cinzel (заголовки), Lora (body, читаемый засечный — IM Fell English SC слишком декоративен для body-сайзов), JetBrains Mono (цифры).
+Fonts via Google Fonts — taken from `assets/palette.json#fonts`. Defaults: Cinzel (headings), Lora (body, readable serif — IM Fell English SC is too decorative for body sizes), JetBrains Mono (numbers).
 
-Базовый размер body — `palette.json#fonts.base_size_px` (16 px), мелкие подписи в карточках — `small_size_px` (13 px). Не опускайся ниже 11 px нигде кроме осей графиков и лейблов узлов графа — снапшот должен читаться без масштабирования.
+Base body size — `palette.json#fonts.base_size_px` (16 px), small card labels — `small_size_px` (13 px). Do not go below 11 px anywhere except chart axes and graph node labels — the snapshot must be readable without zooming.
 
-### Структура страницы (сверху вниз)
+### Page structure (top to bottom)
 
-1. **Header banner** — «Tether Saga» / «Хроники Драконорождённого Разработчика» / дата.
-2. **Лист Персонажа** — Класс/Уровень/XP слева, Хроника пути справа (артефакты, свитки, дни, обсуждения, самое жаркое, текущая глава).
-3. **Главный Сюжет — Хроника MVP** — таблица 7 глав с прогресс-барами.
-4. **Открытые Локации** — карточки + LOC bar-chart, отсортированный по убыванию.
-5. **Легендарные Артефакты** — top-5 PR с rarity-рамками.
-6. **Жаркие Сражения / Тяжёлые Походы** — две таблицы статистики PR.
-7. **Текущая Глава — Спринт N** — название + список квестов.
-8. **Карта Заданий** — сводка + D3-граф + легенды (цвета и школы).
-9. **Печать Долга** — план vs импровизация с фильтром по дате.
-10. **Слава Дней** — stacked area chart дневного валора (feature + infra) + три карточки (суммарный/средний/пиковый).
-11. **Размах Артефактов** — doughnut размеров PR.
-12. **Книга Знаний** — формулы.
+1. **Header banner** — "Tether Saga" / "Chronicles of the Dragonborn Developer" / date.
+2. **Character Sheet** — Class/Level/XP on the left, Journey Chronicle on the right (artifacts, scrolls, days, discussions, hottest, current chapter).
+3. **Main Quest — MVP Chronicle** — table of 7 chapters with progress bars.
+4. **Open Locations** — cards + LOC bar chart, sorted descending.
+5. **Legendary Artifacts** — top-5 PRs with rarity frames.
+6. **Hot Battles / Heavy Marches** — two PR statistics tables.
+7. **Current Chapter — Sprint N** — title + list of quests.
+8. **Quest Map** — summary + D3 graph + legends (colours and schools).
+9. **Seal of Debt** — planned vs improvised with date filter.
+10. **Glory of Days** — stacked area chart of daily valour (feature + infra) + three cards (total/average/peak).
+11. **Artifact Spread** — doughnut of PR sizes.
+12. **Book of Knowledge** — formulae.
 
-### Дайджест в чат
+### Digest in chat
 
-После HTML — выведи **запись в дневнике искателя приключений**, 6–10 строк от первого лица. Форма:
+After the HTML — output an **adventurer's diary entry**, 6–10 lines in first person. Form:
 
-- открывающая строка с датой записи в стилизованном летоисчислении (день + месяц из набора Skyrim-style: Утренней Звезды / Восхода Солнца / Огня Очага / Звёздного Заката и т.п.) + одна предложение-настроение;
-- одна строка про класс и уровень;
-- что выросло сильнее всего по тренду;
-- какая глава главного квеста ближе всего к завершению, какая буксует;
-- одно тёмное предзнаменование (блокер) или вызов впереди;
-- финальная строка «впереди — <следующий MVP-пункт>. Пусть Восемь хранят сборку».
+- opening line with the entry date in a stylised calendar system (day + month from a Skyrim-style set: Morning Star / Sunrise / Hearthfire / Starset and so on) + one mood sentence;
+- one line about class and level;
+- what grew the most by trend;
+- which main quest chapter is closest to completion, which is stalled;
+- one dark omen (blocker) or challenge ahead;
+- final line "ahead — <next MVP item>. May the Eight protect the build."
 
-Запрещено в нарративных блоках: голые проценты без RPG-обёртки, «KPI», «velocity», «throughput», смайлы 😀, эмодзи флагов. Разрешено: ✦ ✧ ⚔ ☠ ❧ ◈ — сдержанно.
+Forbidden in narrative blocks: bare percentages without RPG framing, "KPI", "velocity", "throughput", 😀 emoji, flag emoji. Allowed: ✦ ✧ ⚔ ☠ ❧ ◈ — use sparingly.
 
-## Чего не делать
+## What not to do
 
-- Не запускай Gradle, тесты, smoke — чистая аналитика.
-- Не пиши отчёт в `docs/` — снапшот живёт в `/tmp/`.
-- Не категоризируй вручную >10 PR — пиши Python-скрипт в `/tmp/build_progress.py`.
-- Не оценивай локацию если LOC = 0 — пиши «не открыто», скрывай из диаграммы.
-- Не выдумывай школы/локации/классы/цвета сверх перечисленных в `assets/` — фиксированная палитра обеспечивает сравнимость снапшотов между запусками. Нужна новая школа — добавь её в `schools.json`, не в инструкцию.
-- Не используй REST `/pulls` list endpoint для PR-статистики — он не возвращает commits/comments/review_comments. Только GraphQL или per-PR detail.
+- Don't run Gradle, tests, smoke — pure analytics.
+- Don't write a report to `docs/` — the snapshot lives in `/tmp/`.
+- Don't categorise >10 PRs manually — write a Python script to `/tmp/build_progress.py`.
+- Don't assess a location if LOC = 0 — write "not opened", hide from the chart.
+- Don't invent schools/locations/classes/colours beyond those listed in `assets/` — the fixed palette ensures snapshot comparability between runs. Need a new school — add it to `schools.json`, not to the instructions.
+- Don't use the REST `/pulls` list endpoint for PR statistics — it doesn't return commits/comments/review_comments. GraphQL or per-PR detail only.
 
-## Когда нужна сухая версия — `/progress-boring`
+## When the dry version is needed — `/progress-boring`
 
-Если нужны цифры без RPG-обёртки (для статус-репорта, ретро, копипасты в документ) — используй `/progress-boring` (`.claude/commands/progress-boring.md`). Тот же датасет, обычный dashboard.
+If numbers without RPG framing are needed (for a status report, retro, document paste) — use `/progress-boring` (`.claude/commands/progress-boring.md`). Same dataset, a regular dashboard.

--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -1,29 +1,29 @@
 ---
 name: smoke-test
-description: Прогон базового smoke-теста (happy-path) по платформам Tether — Desktop CLI (cli jar + /health + mDNS + stdin commands), Desktop↔Desktop send через CLI, Android (если adb-устройство подключено) с send-from-Desktop, iOS simulator (xcodebuild + simctl) с mDNS publish + cross-discovery. Используй этот скилл, когда пользователь просит «прогони smoke», «прогони smoke-тест», «basic smoke», «basic regression», «проверь сборку по платформам перед merge», «дымовой тест». Не путать с unit-тестами (`./gradlew allTests`) — smoke это рантайм-проверка стартует ли всё и видят ли друг друга, не корректность логики.
+description: Run a basic smoke test (happy-path) across Tether platforms — Desktop CLI (cli jar + /health + mDNS + stdin commands), Desktop↔Desktop send via CLI, Android (if an adb device is connected) with send-from-Desktop, iOS simulator (xcodebuild + simctl) with mDNS publish + cross-discovery. Use this skill when the user says "run smoke", "run smoke test", "basic smoke", "basic regression", "check the build across platforms before merge", "smoke test". Not to be confused with unit tests (`./gradlew allTests`) — smoke is a runtime check that everything starts and peers can discover each other, not logic correctness.
 ---
 
 # Smoke-test skill
 
-Прогоняет базовые smoke-сценарии по таргетам Tether и выдаёт human-readable отчёт.
+Runs basic smoke scenarios across Tether targets and produces a human-readable report.
 
-**Это smoke, не регресс.** Цель — за 1-3 минуты увидеть, что ничего фундаментально не сломано (CLI стартует, FileServer отвечает, mDNS публикуется, stdin-команды работают, send roundtrip OK, нативные таргеты компилируются). Корректность бизнес-логики — задача `./gradlew allTests`.
+**This is smoke, not regression.** The goal — in 1–3 minutes — is to see that nothing is fundamentally broken (CLI starts, FileServer responds, mDNS is published, stdin commands work, send roundtrip OK, native targets compile). Business logic correctness is the job of `./gradlew allTests`.
 
-## Чего скилл НЕ проверяет (вне скоупа автоматизации)
+## What the skill does NOT check (out of scope for automation)
 
-В начале прогона **проговори это пользователю** — границы покрытия:
+At the start of the run **tell the user** — coverage boundaries:
 
-- **Физический iPhone** — нет, требует ручной подписи и доверия сертификата.
-- **macOS** — ship'ится через Desktop JVM-таргет; smoke покрывается Desktop-блоком (этот же jar пакуется в `.app`/`.dmg` через `packageReleaseDistributionForCurrentOS`).
-- **iOS Local Network Privacy prompt** — на первом запуске приложения на симуляторе iOS может показать «Allow Local Network access». Без Allow `NSNetService.publish()` молча не публикуется. Если iOS-блок упал на publish — проверить prompt вручную, дать Allow, перезапустить смоук.
-- **Android-инициированный send (Android → Desktop)** — на Android нет программного триггера отправки (intent / UI-кнопка / broadcast). Скилл проверяет обратное направление: Desktop → Android через CLI `send`.
-- **Тап по Notification «Stop»** — заменяется на `am force-stop` или broadcast. Что *кнопка нарисована и работает* — проверить вручную.
-- **Sleep/wake реального девайса** — `adb shell input keyevent SLEEP/WAKEUP` это аппроксимация, не настоящий power state.
-- **Rotation effects на FGS-выживаемость** — на эмуляторе ≠ на реальном устройстве.
+- **Physical iPhone** — no, requires manual signing and certificate trust.
+- **macOS** — ships through the Desktop JVM target; smoke is covered by the Desktop block (the same jar is packaged into `.app`/`.dmg` via `packageReleaseDistributionForCurrentOS`).
+- **iOS Local Network Privacy prompt** — on the first app launch on the simulator iOS may show "Allow Local Network access". Without Allow, `NSNetService.publish()` silently fails. If the iOS block fails on publish — check the prompt manually, grant Allow, restart the smoke.
+- **Android-initiated send (Android → Desktop)** — Android has no programmatic send trigger (intent / UI button / broadcast). The skill checks the reverse direction: Desktop → Android via CLI `send`.
+- **Tapping the Notification "Stop" button** — replaced by `am force-stop` or broadcast. That the *button is rendered and works* — verify manually.
+- **Sleep/wake of a real device** — `adb shell input keyevent SLEEP/WAKEUP` is an approximation, not a real power state.
+- **Rotation effects on FGS survivability** — emulator ≠ real device.
 
-В отчёте все эти позиции должны быть в секции **«Manual verification required»**.
+All these items must appear in the **"Manual verification required"** section of the report.
 
-## Запуск CLI
+## Starting the CLI
 
 ```bash
 ./gradlew :composeApp:cliJar -q
@@ -32,31 +32,31 @@ JAR=$(ls composeApp/build/libs/tether-cli*.jar 2>/dev/null | head -1)
 java -jar "$JAR" --name SmokeMacA --port 0 < fifo
 ```
 
-FIFO держит stdin открытым для команд `list`, `send`, `quit`.
+The FIFO keeps stdin open for `list`, `send`, `quit` commands.
 
-## План прогона
+## Run plan
 
-Скилл выполняет блоки последовательно. Падение блока не блокирует следующие. Cleanup выполняется **всегда**, даже если ранее были FAIL.
+The skill executes blocks sequentially. A block failure does not prevent subsequent blocks from running. Cleanup is performed **always**, even if there were earlier FAILs.
 
-### Блок 0: Подготовка
+### Block 0: Preparation
 
-1. Убедись, что нет работающих инстансов CLI:
+1. Make sure no CLI instances are running:
    ```bash
    pgrep -fl 'com.tubetoast.tether-.*\.jar|composeApp:run' || echo "clean"
    ```
-   Если есть — `kill` их: внешние mDNS-сервисы интерферируют с прогоном.
-2. Собрать CLI jar:
+   If there are — `kill` them: external mDNS services interfere with the run.
+2. Build the CLI jar:
    ```bash
    ./gradlew :composeApp:cliJar -q
    JAR=$(ls composeApp/build/libs/tether-cli-*.jar composeApp/build/libs/tether-cli.jar 2>/dev/null | head -1)
    ```
-   Запомни путь.
+   Remember the path.
 
-Если build падает или JAR не найден — все остальные блоки SKIP с причиной «cli jar build failed».
+If the build fails or the JAR is not found — all remaining blocks SKIP with reason "cli jar build failed".
 
-### Блок 1: Desktop CLI (инстанс A)
+### Block 1: Desktop CLI (instance A)
 
-Запуск через FIFO (stdin keeper). Имя — `SmokeMacA`, должно совпадать с тем, что Блок 2 ищет в логе инстанса B.
+Launch via FIFO (stdin keeper). Name — `SmokeMacA`, must match what Block 2 looks for in instance B's log.
 
 ```bash
 LOG_A=/tmp/smoke-cliA.log
@@ -70,16 +70,16 @@ JPID_A=$!; disown $JPID_A
 echo $JPID_A > /tmp/smoke-cliA.pid
 ```
 
-Wait до 30 сек, поллим лог:
+Wait up to 30 sec, polling the log:
 ```bash
 for i in $(seq 1 30); do grep -q 'FileServer started' $LOG_A && break; sleep 1; done
 PORT_A=$(grep -oE 'port[[:space:]]*:[[:space:]]*[0-9]+' $LOG_A | grep -oE '[0-9]+' | head -1)
 ```
 
-Сценарии:
-1. **Startup** — port распарсен, java pid жив (`ps -p $JPID_A`). PASS если оба условия.
-2. **`/health`** — `curl -sf --max-time 5 http://localhost:$PORT_A/health` → должно вернуть `Tether OK`.
-3. **`/pair` — формат публичного ключа.** Эндпоинт возвращает X.509-encoded EC P-256 SubjectPublicKeyInfo: ровно 91 байт, первый байт `0x30` (DER `SEQUENCE`), байт 26 — `0x04` (uncompressed EC point marker). Проверяем форму, а не «непустой ответ» — placeholder проскочил бы поверхностную проверку.
+Scenarios:
+1. **Startup** — port parsed, java pid is alive (`ps -p $JPID_A`). PASS if both conditions met.
+2. **`/health`** — `curl -sf --max-time 5 http://localhost:$PORT_A/health` → must return `Tether OK`.
+3. **`/pair` — public key format.** The endpoint returns an X.509-encoded EC P-256 SubjectPublicKeyInfo: exactly 91 bytes, first byte `0x30` (DER `SEQUENCE`), byte 26 — `0x04` (uncompressed EC point marker). We check the shape, not "non-empty response" — a placeholder would pass a superficial check.
    ```bash
    PAIR_RESP=$(curl -sf --max-time 5 -X POST http://localhost:$PORT_A/pair \
      -H "Content-Type: application/json" \
@@ -88,18 +88,18 @@ PORT_A=$(grep -oE 'port[[:space:]]*:[[:space:]]*[0-9]+' $LOG_A | grep -oE '[0-9]
      && echo "PASS: X.509 EC P-256 SubjectPublicKeyInfo" \
      || { echo "FAIL: bad publicKey shape: $PAIR_RESP"; }
    ```
-4. **Port LISTEN** — `lsof -nP -iTCP:$PORT_A | head -3` показывает java listener.
-5. **mDNS publish (primary)** — поллим CLI-лог, ищем `mDNS started → advertising 'SmokeMacA' on port`.
-6. **mDNS publish (secondary, опционально)** — `( dns-sd -B _tether._tcp. local. 2>&1 & DNSSD_PID=$!; sleep 8; kill $DNSSD_PID 2>/dev/null ) | grep SmokeMacA`. Если `dns-sd` нет (Linux) — этот шаг SKIP, общий результат всё равно PASS по primary.
-7. **stdin `list`** — `echo "list" > /tmp/smoke-cliA-in &; sleep 1; tail $LOG_A` — должен напечатать `[list]` или `[peers]` строку.
+4. **Port LISTEN** — `lsof -nP -iTCP:$PORT_A | head -3` shows a java listener.
+5. **mDNS publish (primary)** — poll the CLI log, look for `mDNS started → advertising 'SmokeMacA' on port`.
+6. **mDNS publish (secondary, optional)** — `( dns-sd -B _tether._tcp. local. 2>&1 & DNSSD_PID=$!; sleep 8; kill $DNSSD_PID 2>/dev/null ) | grep SmokeMacA`. If `dns-sd` is unavailable (Linux) — this step SKIP, the overall result is still PASS via primary.
+7. **stdin `list`** — `echo "list" > /tmp/smoke-cliA-in &; sleep 1; tail $LOG_A` — must print a `[list]` or `[peers]` line.
 
-Инстанс A держим живым до конца Блока 3. Проверка graceful `quit` — в Блоке 4.
+Keep instance A alive until the end of Block 3. Graceful `quit` check — in Block 4.
 
-### Блок 2: Desktop ↔ Desktop send (через CLI)
+### Block 2: Desktop ↔ Desktop send (via CLI)
 
-**Важно:** send должен идти через **CLI команду `send`**, а не через `curl POST /upload`. Это смоук-тест пользовательского сценария, а не endpoint'а.
+**Important:** send must go via the **CLI `send` command**, not via `curl POST /upload`. This is a smoke test of the user scenario, not of the endpoint.
 
-Поднимаешь второй CLI-инстанс (`SmokeMacB`) параллельно с A, ждёшь, пока mDNS даст обоим увидеть друг друга, шлёшь `send SmokeMacB <path>` в stdin A.
+Start a second CLI instance (`SmokeMacB`) in parallel with A, wait until mDNS lets both see each other, send `send SmokeMacB <path>` to stdin A.
 
 ```bash
 LOG_B=/tmp/smoke-cliB.log
@@ -110,7 +110,7 @@ nohup java -jar "$JAR" --name SmokeMacB --port 0 < /tmp/smoke-cliB-in > "$LOG_B"
 JPID_B=$!; disown $JPID_B
 echo $JPID_B > /tmp/smoke-cliB.pid
 
-# Имена должны точно совпадать с --name выше.
+# Names must exactly match the --name above.
 for i in $(seq 1 30); do
   grep -q 'SmokeMacA' $LOG_B 2>/dev/null && \
   grep -q 'SmokeMacB' $LOG_A 2>/dev/null && break
@@ -127,7 +127,7 @@ done
 SEND_LINE=$(grep -E "^\[send\] (OK|FAIL)" $LOG_A | tail -1)
 echo "$SEND_LINE"
 
-# savedPath парсим из строки "[send] OK — <ms> ms → <savedPath>", не угадываем директорию.
+# Parse savedPath from the line "[send] OK — <ms> ms → <savedPath>", don't guess the directory.
 SAVED_B=$(echo "$SEND_LINE" | sed -nE 's/.*→[[:space:]]+(.+)$/\1/p')
 if [ -n "$SAVED_B" ] && [ -f "$SAVED_B" ]; then
   diff /tmp/smoke-send.txt "$SAVED_B" && echo PASS || echo FAIL
@@ -136,15 +136,15 @@ else
 fi
 ```
 
-PASS если:
-1. в логе A есть `[send] OK — <ms> ms → <savedPath>`
-2. файл по `savedPath` идентичен оригиналу
+PASS if:
+1. log A contains `[send] OK — <ms> ms → <savedPath>`
+2. the file at `savedPath` is identical to the original
 
-Cleanup инстанса B — в Блоке 7.
+Cleanup of instance B — in Block 7.
 
-### Блок 3: Same-name discovery
+### Block 3: Same-name discovery
 
-Проверяет, что три peer'а с одинаковым requested service-name видят друг друга после mDNS conflict-rename: третий инстанс запускается с тем же `--name SmokeMacA`, что и A, параллельно с A и B.
+Verifies that three peers with the same requested service name see each other after mDNS conflict-rename: a third instance is launched with the same `--name SmokeMacA` as A, in parallel with A and B.
 
 ```bash
 LOG_C=/tmp/smoke-cliC.log
@@ -160,8 +160,8 @@ for i in $(seq 1 20); do
   echo "list" > /tmp/smoke-cliB-in &
   echo "list" > /tmp/smoke-cliC-in &
   sleep 1
-  # Строка `[peers]` начинается с ANSI-escape (`\x1b[1A\r\x1b[K`); имя ловим до `@`,
-  # чтобы захватить renamed-форму `SmokeMacA (2)`.
+  # The `[peers]` line starts with an ANSI escape (`\x1b[1A\r\x1b[K`); catch name up to `@`,
+  # to capture the renamed form `SmokeMacA (2)`.
   A_OK=$(grep -aE "\[peers\]" $LOG_A | tail -1 | grep -oE 'SmokeMac[A-Z][^@]*' | sort -u | wc -l | tr -d ' ')
   B_OK=$(grep -aE "\[peers\]" $LOG_B | tail -1 | grep -oE 'SmokeMac[A-Z][^@]*' | sort -u | wc -l | tr -d ' ')
   C_OK=$(grep -aE "\[peers\]" $LOG_C | tail -1 | grep -oE 'SmokeMac[A-Z][^@]*' | sort -u | wc -l | tr -d ' ')
@@ -169,13 +169,13 @@ for i in $(seq 1 20); do
 done
 ```
 
-PASS если каждый из A/B/C видит ≥ 2 уникальных SmokeMac-peer'ов в течение 20 сек. FAIL — приложить последние `[peers]` строки из всех трёх логов в Details.
+PASS if each of A/B/C sees ≥ 2 unique SmokeMac peers within 20 sec. FAIL — attach the last `[peers]` lines from all three logs in Details.
 
-Cleanup инстанса C — в Блоке 7.
+Cleanup of instance C — in Block 7.
 
-### Блок 3.5: Device name rename — peer видит новое имя
+### Block 3.5: Device name rename — peer sees the new name
 
-stdin `name <new>` на A; B должен увидеть новое имя через mDNS republish.
+stdin `name <new>` on A; B must see the new name via mDNS republish.
 
 ```bash
 echo "name RenamedA" > /tmp/smoke-cliA-in &
@@ -186,20 +186,20 @@ done
 grep -q "RenamedA" $LOG_B && echo PASS || echo FAIL
 ```
 
-### Блок 4: graceful quit инстанса A
+### Block 4: Graceful quit of instance A
 
-`echo "quit" > /tmp/smoke-cliA-in &`, ждать до 8 сек, проверить `ps -p $JPID_A`. PASS если процесс умер. Если не умер — FAIL «не graceful», `kill -9` и идти дальше.
+`echo "quit" > /tmp/smoke-cliA-in &`, wait up to 8 sec, check `ps -p $JPID_A`. PASS if the process exited. If not — FAIL "not graceful", `kill -9` and move on.
 
-### Блок 5: Android (условно)
+### Block 5: Android (conditional)
 
-Сначала проверка устройства:
+First check for a device:
 ```bash
 adb devices | awk '/device$/ && !/List/ {print $1}'
 ```
 
-Если пусто — весь блок SKIP с причиной «no adb device connected».
+If empty — the entire block SKIP with reason "no adb device connected".
 
-Если есть устройство:
+If a device is present:
 
 1. **Install:** `./gradlew -q :composeApp:installDebug`
 2. **Logcat clear:** `adb logcat -c`
@@ -207,8 +207,8 @@ adb devices | awk '/device$/ && !/List/ {print $1}'
    ```bash
    adb shell am start -n com.tubetoast.tether/.MainActivity
    ```
-4. **Ждём `NSD service registered` как anchor готовности.**
-   Anchor для метрики cross-discovery ставится **после** того как Android-сторона опубликовалась — дельта мерит только пропагацию через сеть + JmDNS resolve, без Android boot/init:
+4. **Wait for `NSD service registered` as the readiness anchor.**
+   The anchor for the cross-discovery metric is placed **after** the Android side has published — the delta measures only network propagation + JmDNS resolve, without Android boot/init:
    ```bash
    DEADLINE=$(($(date +%s) + 12))
    while [ $(date +%s) -lt $DEADLINE ]; do
@@ -217,16 +217,16 @@ adb devices | awk '/device$/ && !/List/ {print $1}'
    done
    NSD_READY_MS=$(python3 -c "import time; print(int(time.time() * 1000))")
    ```
-   Парсим:
+   Parse:
    - `TetherFGService: FileServer started on port <N>` → `ANDROID_PORT`
-   - `Starting NSD: name=Tether-...` и `NSD service registered: ...` — разница времён = NSD probing latency, выводим в Details.
-5. **Получить IP** через `ip addr`, не `ip route` — формат у части вендоров (ColorOS, MIUI) отличается:
+   - `Starting NSD: name=Tether-...` and `NSD service registered: ...` — time difference = NSD probing latency, output in Details.
+5. **Get IP** via `ip addr`, not `ip route` — the format differs on some vendors (ColorOS, MIUI):
    ```bash
    ANDROID_IP=$(adb shell ip addr show wlan0 2>&1 | grep "inet " | awk '{print $2}' | cut -d/ -f1 | head -1)
    ```
-   Если эмулятор и IP `10.0.2.x` — host-доступ через `adb forward tcp:18080 tcp:$ANDROID_PORT` и `localhost:18080`. Для физ. устройства — прямо `$ANDROID_IP:$ANDROID_PORT`.
-6. **`/health` sanity:** `curl -sf http://$ANDROID_IP:$ANDROID_PORT/health` → `Tether OK`. Это единственное место, где curl допустим — endpoint sanity, не пользовательский flow.
-7. **Cross-discovery с замером времени:** поллим лог Desktop CLI на `Tether-<MODEL>`. Дельта от `NSD_READY_MS`, не от `am start`:
+   If emulator and IP is `10.0.2.x` — host access via `adb forward tcp:18080 tcp:$ANDROID_PORT` and `localhost:18080`. For a physical device — directly `$ANDROID_IP:$ANDROID_PORT`.
+6. **`/health` sanity:** `curl -sf http://$ANDROID_IP:$ANDROID_PORT/health` → `Tether OK`. This is the only place where curl is acceptable — endpoint sanity, not a user flow.
+7. **Cross-discovery with timing:** poll the Desktop CLI log for `Tether-<MODEL>`. Delta from `NSD_READY_MS`, not from `am start`:
    ```bash
    for i in $(seq 1 30); do
      sleep 1
@@ -237,8 +237,8 @@ adb devices | awk '/device$/ && !/List/ {print $1}'
    ANDROID_NAME=$(grep -oE 'Tether-[A-Za-z0-9_]+' $LOG_A | head -1)
    echo "cross-discovery: ${DELTA_MS}ms, peer=$ANDROID_NAME"
    ```
-   В отчёт: `Android | cross-discovery | ✓ PASS | 250 ms` — network-propagation + JmDNS resolve.
-8. **Send Desktop → Android (через CLI):**
+   In the report: `Android | cross-discovery | ✓ PASS | 250 ms` — network-propagation + JmDNS resolve.
+8. **Send Desktop → Android (via CLI):**
    ```bash
    if echo "$ANDROID_IP" | grep -q "^10\.0\.2\."; then
      echo "SKIP: Android emulator detected — QEMU user-mode NAT drops host→guest TCP payload; see docs/knowledge/android-emulator-networking.md"
@@ -252,25 +252,25 @@ adb devices | awk '/device$/ && !/List/ {print $1}'
        sleep 1
      done
      SEND_LINE=$(grep -E "^\[send\] (OK|FAIL)" $LOG_A | tail -1)
-     # На Android savedPath абсолютный — `cat` его напрямую через adb shell
+     # On Android savedPath is absolute — cat it directly via adb shell
      SAVED_PATH=$(echo "$SEND_LINE" | sed -nE 's/.*→[[:space:]]+(.+)$/\1/p')
      adb shell cat "$SAVED_PATH" 2>/dev/null | diff - /tmp/smoke-android.txt && echo PASS || echo FAIL
    fi
    ```
-   PASS если в логе Desktop CLI `[send] OK` И файл на Android по распарсенному savedPath идентичен. SKIP если `10.0.2.x` (QEMU NAT) или ANDROID_NAME пустой — не FAIL.
-9. **Stop service:** `adb shell am force-stop com.tubetoast.tether`. PASS если приложение умерло. (Тап Notification «Stop» — manual.)
+   PASS if Desktop CLI log has `[send] OK` AND the file on Android at the parsed savedPath is identical. SKIP if `10.0.2.x` (QEMU NAT) or ANDROID_NAME is empty — not FAIL.
+9. **Stop service:** `adb shell am force-stop com.tubetoast.tether`. PASS if the app exited. (Notification "Stop" tap — manual.)
 
-Помечай каждый под-сценарий отдельно: install, FGS+mDNS up (с NSD probing latency), /health sanity, cross-discovery (с ms), send-desktop-to-android, stop.
+Mark each sub-scenario separately: install, FGS+mDNS up (with NSD probing latency), /health sanity, cross-discovery (with ms), send-desktop-to-android, stop.
 
-### Блок 5.5: iOS simulator runtime (условно)
+### Block 5.5: iOS simulator runtime (conditional)
 
-Pre-checks (любой fail → весь блок SKIP с причиной):
-- `xcrun simctl help >/dev/null 2>&1` — Xcode CLI tools установлены.
-- `[ -d iosApp/iosApp.xcodeproj ]` — проект есть.
+Pre-checks (any fail → entire block SKIP with reason):
+- `xcrun simctl help >/dev/null 2>&1` — Xcode CLI tools installed.
+- `[ -d iosApp/iosApp.xcodeproj ]` — project exists.
 
-Иначе:
+Otherwise:
 
-1. **Resolve+boot симулятора.** Дефолт `iPhone 17` (как в `scripts/run-all.sh`). Если другой нужен — переменная `IOS_DEVICE`.
+1. **Resolve + boot the simulator.** Default `iPhone 17` (as in `scripts/run-all.sh`). If another is needed — variable `IOS_DEVICE`.
    ```bash
    IOS_DEVICE="${IOS_DEVICE:-iPhone 17}"
    UDID=$(xcrun simctl list devices available \
@@ -279,7 +279,7 @@ Pre-checks (любой fail → весь блок SKIP с причиной):
    xcrun simctl boot "$UDID" 2>/dev/null || true
    open -a Simulator
    ```
-2. **Build + install + launch.** Используем `build/ios` под derivedDataPath, чтобы переиспользовать кеш между прогонами.
+2. **Build + install + launch.** Use `build/ios` as derivedDataPath to reuse the cache between runs.
    ```bash
    IOS_DERIVED=build/ios
    IOS_APP="$IOS_DERIVED/Build/Products/Debug-iphonesimulator/Tether.app"
@@ -292,8 +292,8 @@ Pre-checks (любой fail → весь блок SKIP с причиной):
    xcrun simctl install "$UDID" "$IOS_APP"
    xcrun simctl launch "$UDID" "$IOS_BUNDLE_ID" > /tmp/smoke-ios-launch.log 2>&1
    ```
-   PASS если build exit=0, install exit=0, launch exit=0. FAIL — tail `/tmp/smoke-ios-build.log`.
-3. **mDNS publish.** До 30 сек поллим `dns-sd`:
+   PASS if build exit=0, install exit=0, launch exit=0. FAIL — tail `/tmp/smoke-ios-build.log`.
+3. **mDNS publish.** Poll `dns-sd` for up to 30 sec:
    ```bash
    IOS_NAME=""
    for i in $(seq 1 30); do
@@ -303,36 +303,36 @@ Pre-checks (любой fail → весь блок SKIP с причиной):
      sleep 1
    done
    ```
-   PASS если `IOS_NAME` непуст. FAIL причина — скорее всего Local Network Privacy prompt (см. «Чего скилл НЕ проверяет»).
-4. **TXT publish.** `dns-sd -q "${IOS_NAME}._tether._tcp.local." TXT` за ~3 сек, должно вернуть `4 bytes: 03 76 3D 31` (`v=1`). PASS если бинарный паттерн совпал.
-5. **Cross-discovery.** До 30 сек ждать появления iOS-peer'a в логе Desktop CLI A:
+   PASS if `IOS_NAME` is non-empty. FAIL reason — most likely a Local Network Privacy prompt (see "What the skill does NOT check").
+4. **TXT publish.** `dns-sd -q "${IOS_NAME}._tether._tcp.local." TXT` for ~3 sec, must return `4 bytes: 03 76 3D 31` (`v=1`). PASS if the binary pattern matched.
+5. **Cross-discovery.** Wait up to 30 sec for the iOS peer to appear in Desktop CLI A's log:
    ```bash
    for i in $(seq 1 30); do grep -q "$IOS_NAME" "$LOG_A" && break; sleep 1; done
    ```
-   PASS если в логе A появилась строка с `IOS_NAME`.
+   PASS if a line with `IOS_NAME` appeared in log A.
 
-Cleanup iOS — в Блоке 7.
+iOS cleanup — in Block 7.
 
-### Блок 7: Cleanup
+### Block 7: Cleanup
 
-Выполняется **всегда**:
+Executed **always**:
 - `kill $(cat /tmp/smoke-cliA.pid /tmp/smoke-cliB.pid /tmp/smoke-cliC.pid /tmp/smoke-cliA-keeper.pid /tmp/smoke-cliB-keeper.pid /tmp/smoke-cliC-keeper.pid 2>/dev/null) 2>/dev/null`
-- `pkill -f 'com.tubetoast.tether.*\.jar'` (страховка)
+- `pkill -f 'com.tubetoast.tether.*\.jar'` (safety net)
 - `rm -f /tmp/smoke-cli*-in /tmp/smoke-cli*.log /tmp/smoke-cli*.pid /tmp/smoke-cli*-keeper.pid /tmp/smoke-send.txt /tmp/smoke-android.txt`
-- Файлы в `~/Downloads/Tether/`, которые сами создали — убираем по `savedPath` из лога A.
-- `adb shell rm -f /sdcard/Android/data/com.tubetoast.tether/files/Tether/smoke-android.txt` (или по `SAVED_PATH` если парсили)
+- Files in `~/Downloads/Tether/` that we created — clean up by `savedPath` from log A.
+- `adb shell rm -f /sdcard/Android/data/com.tubetoast.tether/files/Tether/smoke-android.txt` (or by `SAVED_PATH` if parsed)
 - `adb shell am force-stop com.tubetoast.tether`
-- `xcrun simctl terminate "$UDID" com.tubetoast.tether.Tether 2>/dev/null || true` (если `UDID` был резолвлен в Блоке 5.5)
+- `xcrun simctl terminate "$UDID" com.tubetoast.tether.Tether 2>/dev/null || true` (if `UDID` was resolved in Block 5.5)
 - `rm -f /tmp/smoke-ios-build.log /tmp/smoke-ios-launch.log`
 
-## Формат отчёта
+## Report format
 
-В конце прогона печатаешь markdown-отчёт:
+At the end of the run print a markdown report:
 
 ```markdown
 # Smoke test report
 
-**Дата:** YYYY-MM-DD HH:MM
+**Date:** YYYY-MM-DD HH:MM
 **Branch:** <git branch>
 **Commit:** <short sha>
 **CLI Jar:** <auto-detected name> (built in Ns)
@@ -343,7 +343,7 @@ Cleanup iOS — в Блоке 7.
 - **FAIL:** M
 - **SKIP:** K
 - **Total:** N+M+K
-- **Verdict:** 🟢 GREEN | 🟡 YELLOW (есть SKIP, FAIL=0) | 🔴 RED (есть FAIL)
+- **Verdict:** 🟢 GREEN | 🟡 YELLOW (SKIPs present, FAIL=0) | 🔴 RED (FAIL present)
 
 ## Results
 
@@ -355,7 +355,7 @@ Cleanup iOS — в Блоке 7.
 | Desktop CLI A | /pair X.509 EC P-256 | ✓ PASS | 91 bytes, DER prefix OK |
 | Desktop CLI A | port LISTEN | ✓ PASS | java *:49507 |
 | Desktop CLI A | mDNS publish (log) | ✓ PASS | advertising 'SmokeMacA' |
-| Desktop CLI A | mDNS publish (dns-sd) | ✓ PASS | SmokeMacA в browse |
+| Desktop CLI A | mDNS publish (dns-sd) | ✓ PASS | SmokeMacA in browse |
 | Desktop CLI A | stdin `list` | ✓ PASS | peer printed |
 | Desktop↔Desktop | send via CLI | ✓ PASS | savedPath parsed, diff empty |
 | Same-name discovery | A/B/C convergence | ✓ PASS | each sees 2 SmokeMac peers in 3s |
@@ -377,56 +377,56 @@ Cleanup iOS — в Блоке 7.
 
 ## Failures
 
-(подробности FAIL: команда, stderr tail, гипотеза причины)
+(FAIL details: command, stderr tail, hypothesised cause)
 
-## Manual verification required (не покрыто smoke)
+## Manual verification required (not covered by smoke)
 
-- Физический iPhone — установить через Xcode, проверить кросс-обнаружение с Desktop.
-- iOS receive (FileServer.apple — stub) — пропускаем по дизайну.
-- **Android-инициированный send (Android → Desktop)** — нет CLI на Android, скилл проверяет обратное направление.
-- Notification «Stop» button on Android — проверить тап вручную; smoke использует `am force-stop`.
-- Sleep/wake real device — `adb input keyevent` ≠ реальный power state.
-- Rotation persistence — на реальном устройстве, эмулятор недостаточен.
+- Physical iPhone — install via Xcode, verify cross-discovery with Desktop.
+- iOS receive (FileServer.apple — stub) — skipped by design.
+- **Android-initiated send (Android → Desktop)** — no CLI on Android, the skill checks the reverse direction.
+- Notification "Stop" button on Android — verify tap manually; smoke uses `am force-stop`.
+- Sleep/wake real device — `adb input keyevent` ≠ real power state.
+- Rotation persistence — on a real device; emulator is insufficient.
 
 ## Environment
 
 - OS: Darwin <version> arm64
 - Java: <java -version>
-- adb device: <serial / model / API> или "none"
+- adb device: <serial / model / API> or "none"
 - Xcode: <xcodebuild -version | head -1>
-- dns-sd: <path> или "not available"
+- dns-sd: <path> or "not available"
 ```
 
-## Как вызывать
+## How to invoke
 
-Когда пользователь просит «прогони smoke»:
+When the user asks to "run smoke":
 
-1. Печатаешь короткий план (1-2 строки): «прогоню Desktop CLI через cli jar, Desktop↔Desktop send, Android если есть устройство, native compile. Что не проверяю — см. отчёт».
-2. Запускаешь блоки.
-3. Печатаешь отчёт.
-4. Если verdict 🔴 — даёшь recommend: какой блок упал и куда смотреть.
+1. Print a short plan (1–2 lines): "I'll run Desktop CLI via cli jar, Desktop↔Desktop send, Android if a device is connected, native compile. What I don't check — see the report."
+2. Run the blocks.
+3. Print the report.
+4. If verdict is 🔴 — give a recommendation: which block failed and where to look.
 
-Не уточняй у пользователя — скилл должен быть «zero-question»: всё, что неавтоматизируемо, идёт в Manual verification.
+Don't ask the user for clarification — the skill must be "zero-question": everything non-automatable goes into Manual verification.
 
-## Edge cases при прогоне
+## Edge cases during the run
 
-- **Gradle daemon занят** — не убивай его, переиспользуется.
-- **CLI jar устаревший (изменился код)** — `cliJar` сам пересоберёт что нужно. Не делай `clean`.
-- **Имя jar может содержать версию** — определяй динамически через glob `composeApp/build/libs/tether-cli-*.jar composeApp/build/libs/tether-cli.jar | head -1`. Не хардкодь имя файла.
-- **`dns-sd` не на macOS** — Linux нет; secondary mDNS check SKIP с причиной «dns-sd not available». Primary check (grep CLI лога на `mDNS started`) всё равно работает.
-- **`timeout` на macOS отсутствует** — pattern `( cmd & PID=$!; sleep N; kill $PID )` вместо `timeout`.
-- **FIFO writer keeper умер раньше времени** — readLine() вернёт null, CLI выйдет; проверяй `ps -p $KEEPER`.
-- **Эмулятор Android в NAT (10.0.2.x)** — cross-discovery работает в обе стороны (multicast проходит). Host→guest TCP payload QEMU user-mode NAT не проксирует: handshake проходит, данные не доходят. Send-блок (шаг 8) — SKIP при `10.0.2.x`, не FAIL. Health доступен через `adb forward`. См. `docs/knowledge/android-emulator-networking.md`.
-- **`ip route` ненадёжен на части вендоров** (ColorOS, MIUI отдают подсеть вместо src) — используй `ip addr show wlan0`.
-- **Несколько adb-устройств** — выбирай первое или fail с уточнением. Не вешай скилл на специфичный serial.
-- **`savedPath` всегда парсить из лога**, не угадывать `$HOME/Downloads/Tether/...` — директория загрузок настраивается пользователем.
+- **Gradle daemon busy** — don't kill it, it will be reused.
+- **CLI jar stale (code changed)** — `cliJar` will rebuild what's needed. Don't run `clean`.
+- **Jar name may contain version** — determine dynamically via glob `composeApp/build/libs/tether-cli-*.jar composeApp/build/libs/tether-cli.jar | head -1`. Don't hardcode the filename.
+- **`dns-sd` not on macOS** — unavailable on Linux; secondary mDNS check SKIP with reason "dns-sd not available". Primary check (grep CLI log for `mDNS started`) still works.
+- **`timeout` absent on macOS** — use pattern `( cmd & PID=$!; sleep N; kill $PID )` instead of `timeout`.
+- **FIFO writer keeper died early** — readLine() returns null, CLI exits; check `ps -p $KEEPER`.
+- **Android emulator in NAT (10.0.2.x)** — cross-discovery works both ways (multicast passes). QEMU user-mode NAT does not proxy host→guest TCP payload: handshake passes, data doesn't arrive. Send block (step 8) — SKIP at `10.0.2.x`, not FAIL. Health is accessible via `adb forward`. See `docs/knowledge/android-emulator-networking.md`.
+- **`ip route` unreliable on some vendors** (ColorOS, MIUI return subnet instead of src) — use `ip addr show wlan0`.
+- **Multiple adb devices** — pick the first or fail with a clarification. Don't hang the skill on a specific serial.
+- **`savedPath` must always be parsed from the log**, don't guess `$HOME/Downloads/Tether/...` — the downloads directory is user-configurable.
 
-## Что НЕ делать
+## What NOT to do
 
-- **Не используй `./gradlew :composeApp:run`** — это Compose UI, не CLI.
-- **Не запускай `allTests`** — это другой инструмент. Smoke ≤3 минуты.
-- **Не модифицируй код приложения** даже если видишь проблему. Сообщай в отчёте, заводи issue отдельно.
-- **Не лезь в `~/Downloads`** дальше своих файлов — там пользовательский контент.
-- **Не запускай `./gradlew clean`** — съест кеш и замедлит следующий прогон.
-- **Не отправляй ничего в сеть** кроме localhost и `$ANDROID_IP` (последний — только если adb-устройство подключено).
-- **Не угадывай пути назначения файлов** — всегда парси из `[send] OK — ... → <savedPath>`.
+- **Don't use `./gradlew :composeApp:run`** — that is the Compose UI, not the CLI.
+- **Don't run `allTests`** — that is a different tool. Smoke ≤3 minutes.
+- **Don't modify application code** even if you see a problem. Report it in the report, file a separate issue.
+- **Don't go into `~/Downloads`** beyond your own files — that is user content.
+- **Don't run `./gradlew clean`** — it will eat the cache and slow down the next run.
+- **Don't send anything over the network** other than localhost and `$ANDROID_IP` (the latter — only if an adb device is connected).
+- **Don't guess file destination paths** — always parse from `[send] OK — ... → <savedPath>`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,21 +1,21 @@
 <!--
-Цель — ревьюер быстро видит суть + места, где автор не уверен.
-Пустые секции удаляй. `Closes #N` — обязательно.
+Goal — the reviewer quickly sees the essence + places where the author is uncertain.
+Delete empty sections. `Closes #N` — required.
 
-Антипаттерны (не пиши такое):
-- AC-чек-лист, повторяющий issue DoD
-- «Test plan» / «Smoke: N/A» для тривиальных и DOCS-only PR
-- Пересказ diff'а файл за файлом
-- Длинная преамбула — начинай сразу с «зачем»
+Anti-patterns (do not write these):
+- AC checklist that duplicates the issue DoD
+- "Test plan" / "Smoke: N/A" for trivial and DOCS-only PRs
+- A file-by-file retelling of the diff
+- A long preamble — start straight with "why"
 -->
 
-**Что / зачем.** 1-2 предложения. Какой эффект или инвариант меняется.
+**What / why.** 1-2 sentences. What effect or invariant changes.
 
-**👀 Sanity-check.** Выборы, где не уверен; defer-решения («отложил X в follow-up» / TODO в Y) — выноси сюда, не в Notes внизу; неочевидные места `file:line`. Удали секцию, если нечего.
+**👀 Sanity-check.** Choices you are uncertain about; defer decisions ("deferred X to follow-up" / TODO in Y) — put them here, not in Notes below; non-obvious spots `file:line`. Delete the section if there is nothing.
 - 
 
-**Scope.** Опускай для локальных PR.
-- ❌ не трогал: X (живёт в Y / отложено в #N)
-- 📎 задето: #M / doc Z — обновлено / отложено
+**Scope.** Omit for local PRs.
+- ❌ not touched: X (lives in Y / deferred to #N)
+- 📎 affected: #M / doc Z — updated / deferred
 
 Closes #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,30 +22,32 @@ Read on demand. Match what you're touching to the corresponding canon:
 
 ## Architecture invariants
 
-- **Common-first.** Всё, что может жить в `commonMain` — там и лежит. Платформенные source sets (`androidMain`, `appleMain`, `jvmMain`, `desktopMain`, `iosMain`) — только для кода, требующего platform API. При выборе между `expect/actual` в `commonMain` и копированием в `platformMain` — `expect/actual`.
-- **Source set hierarchy и Desktop UI/CLI split** — см. [`modules.md`](docs/engineering/modules.md).
+- **Common-first.** Everything that can live in `commonMain` — lives there. Platform source sets (`androidMain`, `appleMain`, `jvmMain`, `desktopMain`, `iosMain`) — only for code that requires platform API. When choosing between `expect/actual` in `commonMain` and copying into `platformMain` — `expect/actual`.
+- **Source set hierarchy and Desktop UI/CLI split** — see [`modules.md`](docs/engineering/modules.md).
 
 ## Git conventions
 
-All git naming in English. **Все commit messages обязаны начинаться с номера issue:** `#<issue>: <message>` (например, `#42: add mDNS discovery for Android`).
+All git naming in English. **All commit messages must start with the issue number:** `#<issue>: <message>` (e.g., `#42: add mDNS discovery for Android`).
 
-Перед коммитом убедись, что issue существует. Если нет — попроси пользователя создать.
+All issue titles, issue bodies, and PR titles and descriptions must be written in English. Russian is only permitted in interactive chat.
 
-Подтянуть main в ветку — `/rebase` (ребейзит на свежий main и показывает, что заехало). Запускается и в `/close-issue`, и mid-flight.
+Before committing, make sure the issue exists. If it does not — ask the user to create it.
+
+To pull main into the branch — `/rebase` (rebases onto fresh main and shows what came in). Run both in `/close-issue` and mid-flight.
 
 ## Common commands
 
-Все Gradle команды запускай с `-q`. KtLint вручную не запускай — git hook делает это сам при коммите, стилевые ошибки тоже не правь руками.
+Run all Gradle commands with `-q`. Do not run KtLint manually — the git hook does it automatically on commit; do not fix style errors by hand either.
 
-Полный список команд по платформам — [README.md](README.md). Тестовые команды — [`testing.md`](docs/engineering/testing.md). Параллельный запуск всех таргетов — `scripts/run-all.sh`.
+Full list of commands by platform — [README.md](README.md). Test commands — [`testing.md`](docs/engineering/testing.md). Parallel run of all targets — `scripts/run-all.sh`.
 
-## Slash commands и скиллы
+## Slash commands and skills
 
-Индекс и правила выбора (skill vs command) — [`.claude/README.md`](.claude/README.md).
+Index and selection rules (skill vs command) — [`.claude/README.md`](.claude/README.md).
 
 ## Code style
 
-- **Минимум комментариев.** Перед тем как добавить — попробуй вынести блок в приватный метод: имя метода часто делает комментарий ненужным. Комментарий — только там, где код не может выразить намерение (намеренно проглоченное исключение, неочевидный инвариант внешней библиотеки).
-- **KDoc vs `//`.** KDoc — только для контрактов (nullable-семантика, неочевидные пред-/постусловия, неочевидное WHY). Не пересказывай имя метода или сигнатуру — это шум. Если KDoc не добавляет информации относительно кода — сноси его.
+- **Minimal comments.** Before adding one — try extracting the block into a private method: the method name often makes the comment unnecessary. A comment only where code cannot express intent (deliberately swallowed exception, non-obvious external-library invariant).
+- **KDoc vs `//`.** KDoc — only for contracts (nullable semantics, non-obvious pre-/postconditions, non-obvious WHY). Do not restate the method name or signature — that is noise. If KDoc adds no information relative to the code — remove it.
 - **Kotlin official style** (enforced by KtLint).
-- **Дисциплина долгоживущих артефактов** (CLAUDE.md, `docs/`, `.claude/`, KDoc, inline-комментарии) — [`long-lived-artifacts.md`](docs/engineering/long-lived-artifacts.md).
+- **Long-lived artifacts discipline** (CLAUDE.md, `docs/`, `.claude/`, KDoc, inline comments) — [`long-lived-artifacts.md`](docs/engineering/long-lived-artifacts.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ All issue titles, issue bodies, and PR titles and descriptions must be written i
 
 Before committing, make sure the issue exists. If it does not — ask the user to create it.
 
-To pull main into the branch — `/rebase` (rebases onto fresh main and shows what came in). Run both in `/close-issue` and mid-flight.
+To pull main into the branch — `/rebase` (rebases onto fresh main and shows what came in). It runs from both `/close-issue` and mid-flight.
 
 ## Common commands
 

--- a/README.md
+++ b/README.md
@@ -1,49 +1,49 @@
 # Tether
 
-P2P-передача файлов между устройствами на разных OS — по локальной Wi-Fi сети, без облака, без аккаунтов, без сжатия.
+P2P file transfer between devices on different OSes — over a local Wi-Fi network, no cloud, no accounts, no compression.
 
-**Сценарий, который Tether закрывает:** фото с Android-телефона на MacBook сегодня едет через мессенджер (сжатие), почту (лимиты) или кабель. Tether заменяет это двумя тапами на одной Wi-Fi — оригинальный файл идёт напрямую между устройствами.
+**The scenario Tether solves:** a photo from an Android phone to a MacBook today travels via messenger (compression), email (limits), or a cable. Tether replaces this with two taps on the same Wi-Fi — the original file goes directly between devices.
 
-**Таргеты:** Android, iOS, Desktop (JVM на Windows / Linux / macOS). Kotlin Multiplatform + Compose Multiplatform.
+**Targets:** Android, iOS, Desktop (JVM on Windows / Linux / macOS). Kotlin Multiplatform + Compose Multiplatform.
 
-**Статус:** ранний MVP. Дискавери, базовый протокол передачи и Desktop CLI работают; UI и pairing в работе.
+**Status:** early MVP. Discovery, the basic transfer protocol, and Desktop CLI work; UI and pairing are in progress.
 
-## Документация
+## Documentation
 
-- [Vision & принципы](docs/product/vision.md) — что мы строим и почему.
-- [Roadmap](docs/product/roadmap.md) — что в MVP, что после, что отложено.
-- [Фичи](docs/product/features/README.md) — статус по каждой фиче и ссылки на спеки.
-- [Tech stack](docs/product/tech-stack.md) — выбор стека.
-- [Security](docs/product/security.md) — модель угроз, pairing, шифрование.
-- [Engineering docs](docs/engineering/README.md) — архитектура, модули, DI, тестирование.
+- [Vision & principles](docs/product/vision.md) — what we are building and why.
+- [Roadmap](docs/product/roadmap.md) — what is in MVP, what comes after, what is deferred.
+- [Features](docs/product/features/README.md) — status per feature and links to specs.
+- [Tech stack](docs/product/tech-stack.md) — stack choices.
+- [Security](docs/product/security.md) — threat model, pairing, encryption.
+- [Engineering docs](docs/engineering/README.md) — architecture, modules, DI, testing.
 
 ## Quick start
 
-Требуется JDK 21 (Temurin).
+Requires JDK 21 (Temurin).
 
-### Desktop CLI (отладочный раннер)
+### Desktop CLI (debug runner)
 
-Стартует `FileServer` + mDNS-дискавери, читает команды из stdin (`list`, `send <peer> <path>`, `quit`).
+Starts `FileServer` + mDNS discovery, reads commands from stdin (`list`, `send <peer> <path>`, `quit`).
 
 ```bash
-# первый раз — собрать uber JAR и поставить wrapper в ~/.local/bin
+# first time — build the uber JAR and install the wrapper to ~/.local/bin
 ./gradlew :composeApp:installCli -q
 
-# убедись, что ~/.local/bin в PATH
+# make sure ~/.local/bin is in PATH
 export PATH="$PATH:$HOME/.local/bin"
 
-# запуск с дефолтами (случайный порт, имя устройства = "Tether-$USER")
+# run with defaults (random port, device name = "Tether-$USER")
 tether
 
-# свои имя и порт
+# custom name and port
 tether --name MyMac --port 8080
 ```
 
-Проверка, что сервер живой: `curl http://localhost:<port>/health` → `Tether OK`.
+Check the server is alive: `curl http://localhost:<port>/health` → `Tether OK`.
 
-Подробные логи (DEBUG): `TETHER_LOG_DEBUG=true tether` или `-Dtether.log.debug=true`. Полные правила и платформенные гейты — [`docs/engineering/logging.md`](docs/engineering/logging.md).
+Verbose logs (DEBUG): `TETHER_LOG_DEBUG=true tether` or `-Dtether.log.debug=true`. Full rules and platform gates — [`docs/engineering/logging.md`](docs/engineering/logging.md).
 
-Пример сессии:
+Example session:
 ```
 > send Phone /tmp/photo.jpg
 [send] 12.3 MB / 50.0 MB  (3.4 MB/s)
@@ -64,38 +64,38 @@ Native app bundle: `./gradlew :composeApp:packageReleaseDistributionForCurrentOS
 ./gradlew :composeApp:assembleDebug
 ```
 
-APK — в `composeApp/build/outputs/apk/debug/`. Или запускай run-конфигурацию `composeApp` из Android Studio.
+APK — in `composeApp/build/outputs/apk/debug/`. Or run the `composeApp` run configuration from Android Studio.
 
 ### iOS
 
-Открой `iosApp/` в Xcode и запусти, либо используй iOS run-конфигурацию из IDE (Android Studio / Fleet с KMP-плагином).
+Open `iosApp/` in Xcode and run, or use the iOS run configuration from the IDE (Android Studio / Fleet with the KMP plugin).
 
 ### macOS
 
-Через Desktop JVM-таргет (как Windows / Linux): `./gradlew :composeApp:run -q` для дев-запуска, `./gradlew :composeApp:packageReleaseDistributionForCurrentOS` для `.app`/`.dmg`-бандла с встроенным JRE. Почему не Kotlin/Native — см. [`adr-macos-native-vs-jvm.md`](docs/engineering/adr/adr-macos-native-vs-jvm.md).
+Via the Desktop JVM target (same as Windows / Linux): `./gradlew :composeApp:run -q` for a dev run, `./gradlew :composeApp:packageReleaseDistributionForCurrentOS` for an `.app`/`.dmg` bundle with an embedded JRE. Why not Kotlin/Native — see [`adr-macos-native-vs-jvm.md`](docs/engineering/adr/adr-macos-native-vs-jvm.md).
 
-### Все таргеты разом
+### All targets at once
 
-`scripts/run-all.sh` параллельно поднимает CLI (в отдельном окне Terminal — нужен интерактивный stdin), Desktop UI, iOS-симулятор и Android-эмулятор. Логи каждого таргета — в `scripts/.run-all/<target>.log`, агрегированный `tail -F` в основном окне. Ctrl-C глушит всех.
+`scripts/run-all.sh` starts the CLI in parallel (in a separate Terminal window — interactive stdin required), Desktop UI, iOS simulator, and Android emulator. Logs for each target — in `scripts/.run-all/<target>.log`, aggregated `tail -F` in the main window. Ctrl-C shuts everything down.
 
 ```bash
-./scripts/run-all.sh                          # всё
-./scripts/run-all.sh --no-android             # без эмулятора
+./scripts/run-all.sh                          # everything
+./scripts/run-all.sh --no-android             # without emulator
 ./scripts/run-all.sh --ios-device "iPhone 17 Pro"
 ```
 
-Требует: `tether` в `PATH` (см. Desktop CLI выше), хотя бы один AVD (создать в Android Studio один раз — сам Studio при запуске скрипта не нужен), установленный Xcode с симуляторами. Это dev-удобство для параллельной проверки руками; не заменяет `./gradlew allTests` и `/smoke-test`.
+Requires: `tether` in `PATH` (see Desktop CLI above), at least one AVD (create in Android Studio once — Studio itself is not needed when running the script), Xcode installed with simulators. This is a dev convenience for parallel manual verification; it does not replace `./gradlew allTests` and `/smoke-test`.
 
-## Для контрибьюторов
+## For contributors
 
-- [CLAUDE.md](CLAUDE.md) — что обязан знать AI-агент или новый контрибьютор: архитектурные инварианты, git conventions, worktree-дисциплина.
-- [docs/engineering/](docs/engineering/README.md) — архитектура и правила написания кода (DI, modules, testing).
-- [.claude/skills/](.claude/skills/) — multi-agent скиллы: `/implement` (issue → PR оркестратор), `/code-review` (параллельный multi-agent review).
-- [.claude/commands/](.claude/commands/) — slash-команды для типовых workflow (`/close-issue`, `/check-review`, `/grooming`, `/retro`, `/quick-issue`).
+- [CLAUDE.md](CLAUDE.md) — what an AI agent or new contributor must know: architecture invariants, git conventions, worktree discipline.
+- [docs/engineering/](docs/engineering/README.md) — architecture and code-writing rules (DI, modules, testing).
+- [.claude/skills/](.claude/skills/) — multi-agent skills: `/implement` (issue → PR orchestrator), `/code-review` (parallel multi-agent review).
+- [.claude/commands/](.claude/commands/) — slash commands for common workflows (`/close-issue`, `/check-review`, `/grooming`, `/retro`, `/quick-issue`).
 
-Тесты:
+Tests:
 ```bash
 ./gradlew allTests -q
 ```
 
-KtLint запускается автоматически через git hook — руками не вызывай.
+KtLint runs automatically via a git hook — do not invoke it manually.

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -15,10 +15,10 @@ Product-side docs (vision, audience, features) live in [`docs/product/`](../prod
 - [Local-network availability](wifi-availability.md) — single common stream gating discovery and the no-local-network UI; per-platform sources (Android `NetworkCallback`, Apple `NWPathMonitor`, Desktop `NetworkInterface` polling).
 - [UI Style Guide](ui-style-guide.md) — token tables, `TetherTheme` rule, Tabler Icons usage, motion specs, accessibility checklist.
 - [UI Brand Mark](ui-brand-mark.md) — `•—•` geometry, animation states, where the mark appears, and design rationale (why a line, not a knot or arrow).
-- [Testing](testing.md) — структура тестов по source sets, стиль (`runTest`/виртуальное время), особенности Apple-таргетов.
-- [Logging](logging.md) — KydraLog как единый KMP-фасад; именование `Tether.<Subsystem>`, уровни, DEBUG-гейтинг по платформам, тестовая тишина, политика sensitive-данных.
+- [Testing](testing.md) — test structure by source set, style (`runTest` / virtual time), Apple-target specifics.
+- [Logging](logging.md) — KydraLog as the single KMP façade; `Tether.<Subsystem>` naming, levels, per-platform DEBUG gating, test silence, sensitive-data policy.
 - [Persistence](persistence.md) — key-value store contract and DataStore backend.
-- [Glossary discipline](glossary-discipline.md) — `docs/glossary.md` как единый словарь (product / technical); `review-glossary` как сабагент, который ловит drift и недокументированные термины в PR-диффе.
+- [Glossary discipline](glossary-discipline.md) — `docs/glossary.md` as the single dictionary (product / technical); `review-glossary` as a subagent that catches drift and undocumented terms in a PR diff.
 - [Long-lived artifacts](long-lived-artifacts.md) — writing discipline for prose that outlives the task. Applies to `CLAUDE.md`, `docs/`, `.claude/`, KDoc, comments, error messages.
 
 ## Writing style for these guides
@@ -38,7 +38,7 @@ ADRs in [`adr/`](adr/) capture the *why* behind one-time architectural choices. 
 - [Presentation & Navigation](adr/adr-presentation-and-navigation.md) — chose Decompose over Voyager / custom thin layer / Compose Navigation MP / Premo.
 - [macOS target — Desktop JVM (reversed from Native)](adr/adr-macos-native-vs-jvm.md) — originally chose `macosArm64` Kotlin/Native; reversed 2026-05-25 to Desktop JVM because Compose-MP macOS-native UI is unsupported.
 - [Visual Identity](adr/adr-visual-identity.md) — palette, typography, iconography, brand mark `•—•`; dropped Material 3 in favour of custom `TetherTheme`.
-- [Network stack](adr/adr-network-stack.md) — chose Ktor CIO across all targets tactically; engine swaps under TLS forced upstream. Living-doc сторона — [`transport.md`](transport.md).
+- [Network stack](adr/adr-network-stack.md) — chose Ktor CIO across all targets tactically; engine swaps under TLS forced upstream. Living-doc side — [`transport.md`](transport.md).
 - [Apple FileServer engine](adr/adr-apple-fileserver-engine.md) — chose Ktor CIO Native over hand-rolled HTTP for the Apple-side `FileServer.actual`.
 - [Channel encryption](adr/adr-channel-encryption.md) — chose TLS-with-paired-key-pinning + SecureTransport on Apple. Includes 2026-05-16 Amendment with implementation-plan corrections.
 - [Hotspot-first Discovery](adr/adr-hotspot-discovery.md) — chose layered mDNS + `/hello` rendezvous + HTTP-subnet-scan + UDP-broadcast over raw-multicast-as-primary or Wi-Fi Direct / NAN. Motivated primarily by phone-hotspot transfer.

--- a/docs/engineering/adr/adr-logging-kydra.md
+++ b/docs/engineering/adr/adr-logging-kydra.md
@@ -57,7 +57,7 @@ Closes the SLF4J warning trivially (real provider present on JVM). Costs: the Ap
 
 No external dependency. `expect fun logger(tag: String): Logger` in `commonMain`; `actual` per source set wraps Logcat / OSLog / `println`. Filtering and tagging written by us.
 
-Closes the common-side gap minimally. Costs: maintenance — every level enum, every decorator, every filter is ours to keep working across Kotlin / Native upgrades; the existing KMP libraries are exactly this code, already vendored. The "don't write your own KMP logger" sentence in the issue ("своё писать не надо") rejects this explicitly.
+Closes the common-side gap minimally. Costs: maintenance — every level enum, every decorator, every filter is ours to keep working across Kotlin / Native upgrades; the existing KMP libraries are exactly this code, already vendored. The "don't write your own KMP logger" sentence in the issue ("no need to write our own") rejects this explicitly.
 
 ## Decision
 

--- a/docs/engineering/architecture-principles.md
+++ b/docs/engineering/architecture-principles.md
@@ -30,15 +30,15 @@ Clean Architecture and adjacent patterns are full of ceremony that doesn't pay r
 
 ## Common-first across KMP targets
 
-Всё, что может жить в `commonMain` — там и лежит; платформенные source sets только для кода, требующего platform API. Это применимо ко всему — domain, network, presentation, UI. Реализация в `commonMain` поставляется на все активные таргеты одной кодовой базой.
+Everything that can live in `commonMain` lives there; platform source sets are for code that requires platform API only. This applies to everything — domain, network, presentation, UI. An implementation in `commonMain` ships to all active targets from a single codebase.
 
-- Компиляция ≠ корректность: код едет на все таргеты, но визуальная/runtime-корректность на каждом не гарантирована билдом. **Ручной smoke обязателен на каждой платформе** перед запросом ревью (`/implement` Step 7).
+- Compilation ≠ correctness: code runs on all targets, but visual / runtime correctness on each is not guaranteed by the build. **A manual smoke test is mandatory on every platform** before requesting review (`/implement` Step 7).
 
-**UI specifically** — самый видимый multiplier: Compose Multiplatform в `commonMain` едет на Android, iOS и Desktop (когда entry point вызывает `App()`) одной имплементацией.
+**UI specifically** is the most visible multiplier: Compose Multiplatform in `commonMain` ships to Android, iOS, and Desktop (when the entry point calls `App()`) as a single implementation.
 
-Per-platform composables / `actual`-имплементации — исключение и требуют обоснования реальным API-ограничением (system share sheet, hardware sensor), не предпочтением.
+Per-platform composables / `actual` implementations are the exception and require justification by a real API constraint (system share sheet, hardware sensor), not by preference.
 
-**Перед своим `expect`/`actual` проверь, не закрыт ли вопрос upstream KMP-артефактом.** Если библиотека уже шипит `expect val` / `expect class` (`Dispatchers.IO`, `androidx.datastore-preferences-core`, …) — используй её напрямую, не оборачивай. Свой `expect`-wrapper поверх чужого — no-op слой, который только маскирует, что задача уже решена. Триггер для своих `expect/actual` — реально отсутствующий в библиотеках платформенный API, а не «единообразие в этом проекте».
+**Before writing your own `expect`/`actual`, check whether an upstream KMP artefact already covers it.** If a library already ships `expect val` / `expect class` (`Dispatchers.IO`, `androidx.datastore-preferences-core`, …) — use it directly, do not wrap it. Your own `expect`-wrapper on top of someone else's is a no-op layer that merely hides that the problem is already solved. The trigger for your own `expect/actual` is a platform API that genuinely has no library coverage — not "consistency within this project".
 
 ## Domain identity over display labels
 

--- a/docs/engineering/testing.md
+++ b/docs/engineering/testing.md
@@ -1,43 +1,43 @@
 # Testing
 
-Тесты обязательны. При реализации любой функциональности пиши unit и/или интеграционные тесты — ориентируйся на краевые случаи из issue.
+Tests are mandatory. When implementing any functionality, write unit and/or integration tests — use the edge cases from the issue as a guide.
 
-**Behavior fix — regression test в том же коммите.** Если коммит чинит наблюдаемое поведение (баг, регрессия, не-feature), в том же коммите должен быть тест, который падал бы без фикса. Это применимо одинаково к BUGFIX-issue и к багам, найденным mid-flight у FEATURE-задачи (ручной тест пользователя, ревью, smoke). Если регрессионный тест дороже самого фикса — это сигнал, что seam для тестируемости нужно доработать в том же change (выделить функцию, вынести зависимость в параметр), а не отложить.
+**Behaviour fix — regression test in the same commit.** If a commit fixes an observable behaviour (bug, regression, non-feature), the same commit must include a test that would have failed without the fix. This applies equally to BUGFIX issues and to bugs found mid-flight on a FEATURE task (manual user test, review, smoke). If the regression test costs more than the fix itself — that is a signal that the testability seam needs to be improved in the same change (extract a function, move a dependency into a parameter), not deferred.
 
-## Где что лежит
+## Where things live
 
-- `commonTest/` — протокол и shared-логика.
-- `jvmTest/` — тесты, общие для Android и Desktop (например, `FileServerTest`); прогоняются в `desktopTest` и `androidUnitTest`.
+- `commonTest/` — protocol and shared logic.
+- `jvmTest/` — tests shared by Android and Desktop (e.g. `FileServerTest`); run in `desktopTest` and `androidUnitTest`.
 - `desktopTest/` — Desktop-only (`FileClientTest`, `MdnsDiscoveryTest`).
-- `appleTest/` — Apple-таргеты (см. ниже про NSRunLoop).
+- `appleTest/` — Apple targets (see NSRunLoop note below).
 
-## Стиль
+## Style
 
 - `kotlin.test`.
-- Для корутин — `runTest` + `TestDispatcher` (из `kotlinx-coroutines-test`), **не `runBlocking`**.
-- Управляй временем виртуально через `advanceTimeBy()` / `advanceUntilIdle()` — это ускоряет тесты и делает их детерминированными.
-- Правило `tether:no-run-blocking-in-tests` (`:ktlint-rules`) автоматически запрещает `runBlocking` в test source set'ах. Для легитимных integration-тестов на реальных потоках добавляй `@Suppress("ktlint:tether:no-run-blocking-in-tests")` — на класс, когда класс целиком — integration-suite вокруг одного внешнего API (real CIO server, JmDNS), даже если отдельные тесты этого класса не используют `runBlocking`; на функцию, когда integration-метод стоит в неинтеграционном по природе классе. Рядом с suppress'ом — `//`-комментарий, какое именно real-thread событие ждём.
+- For coroutines — `runTest` + `TestDispatcher` (from `kotlinx-coroutines-test`), **not `runBlocking`**.
+- Control time virtually via `advanceTimeBy()` / `advanceUntilIdle()` — this speeds tests up and makes them deterministic.
+- The `tether:no-run-blocking-in-tests` rule (`:ktlint-rules`) automatically forbids `runBlocking` in test source sets. For legitimate integration tests on real threads, add `@Suppress("ktlint:tether:no-run-blocking-in-tests")` — on the class when the entire class is an integration suite around a single external API (real CIO server, JmDNS), even if individual tests in that class do not use `runBlocking`; on the function when an integration method sits inside a class that is not an integration suite by nature. Alongside the suppress — a `//` comment naming the specific real-thread event being awaited.
 
-## Реальное время vs виртуальное
+## Real time vs virtual time
 
-- `Thread.sleep` и `System.currentTimeMillis`-polling допустимы **только** для ожидания событий от внешних нативных API (JmDNS, NsdManager и т.п.), которые работают на реальных потоках вне нашего `CoroutineScope`. Внутри тела теста всё остальное — виртуальное время.
-- `withTimeout` внутри `runTest` использует **виртуальные** часы даже на `Dispatchers.IO` — не рассчитывай на него как на реальный таймаут.
+- `Thread.sleep` and `System.currentTimeMillis`-polling are permissible **only** when waiting for events from external native APIs (JmDNS, NsdManager, etc.) that run on real threads outside our `CoroutineScope`. Everything else inside the test body uses virtual time.
+- `withTimeout` inside `runTest` uses **virtual** clocks even on `Dispatchers.IO` — do not rely on it as a real-time timeout.
 
 ## Apple targets
 
-NSRunLoop нужно качать вручную — подробнее в [`docs/knowledge/apple-platform.md`](../knowledge/apple-platform.md).
+NSRunLoop must be pumped manually — see [`docs/knowledge/apple-platform.md`](../knowledge/apple-platform.md) for details.
 
-## Test seams для `expect` классов
+## Test seams for `expect` classes
 
-Если actual-имплементация в принципе не может failить в тесте без мока платформенного API (`NSUserDefaults.synchronize()` всегда true в Robolectric/sim, DataStore не валится по запросу) — объявляй `expect open class` с `open fun` для методов, которые нужно подменять. Тест объявляет анонимный `object : TrustedDeviceStore(...)` с `override fun saveTrustedKey(...) = throw ...` и подкладывает в production-код через тот же DI-вход, что и реальный store. Это сохраняет DI-граф (тот же тип течёт в `FileServer`) и не плодит интерфейс-обёртку ради одной точки подмены.
+If an `actual` implementation fundamentally cannot fail in a test without mocking a platform API (`NSUserDefaults.synchronize()` is always true in Robolectric / simulator, DataStore does not throw on demand) — declare `expect open class` with `open fun` for the methods that need to be substituted. The test declares an anonymous `object : TrustedDeviceStore(...)` with `override fun saveTrustedKey(...) = throw ...` and supplies it through the same DI entry point as the real store. This preserves the DI graph (the same type flows into `FileServer`) and avoids creating an interface wrapper for a single substitution point.
 
-Не делай это превентивно — только когда контракт «при ошибке actual должен бросить» нужно проверить end-to-end (HTTP-уровень в нашем случае), а триггер ошибки на платформе недостижим. Пример — `TrustedDeviceStore` в #9: HTTP `/pair → 500` тестируется на каждом actual через throwing-subclass.
+Do not do this preemptively — only when the contract "the actual must throw on error" needs to be verified end-to-end (the HTTP level in our case), and the error trigger on the platform is unreachable. Example — `TrustedDeviceStore` in #9: HTTP `/pair → 500` is tested on every actual via a throwing subclass.
 
-## HTTP-клиент в unit-тестах
+## HTTP client in unit tests
 
-Класс, держащий `HttpClient`, принимает его через конструктор; production-конфиг строится в `companion object { fun default() }`. Тест передаёт `HttpClient(MockEngine)` с handler'ом, отвечающим на запросы.
+A class holding an `HttpClient` accepts it via constructor; the production config is built in `companion object { fun default() }`. The test passes `HttpClient(MockEngine)` with a handler that responds to requests.
 
-Чтобы `delay()` в handler'е и внутренние таймеры клиента подчинялись `TestCoroutineScheduler` под `runTest`, пинь dispatcher на engine:
+To make `delay()` in the handler and the client's internal timers obey the `TestCoroutineScheduler` under `runTest`, pin the dispatcher on the engine:
 
 ```kotlin
 private fun TestScope.httpFor(handler: ...): HttpClient =
@@ -49,21 +49,21 @@ private fun TestScope.httpFor(handler: ...): HttpClient =
     }
 ```
 
-Без `dispatcher = ...` handler'ы поднимают свой engine dispatcher (real-time) — virtual time `runTest`'а игнорируется, тест становится либо медленным, либо flaky.
+Without `dispatcher = ...`, handlers spin up their own engine dispatcher (real-time) — `runTest`'s virtual time is ignored, and the test becomes either slow or flaky.
 
-Real-CIO server (`embeddedServer(CIO)`) под virtual time **не приводится**: `CIOApplicationEngine` хардкодит `userDispatcher = Dispatchers.IOBridge` и оборачивает route handler'ы в `withContext(userDispatcher)`. Если тест требует именно реального CIO — это integration-уровень, держи его в `FileServerTest` с `runBlocking` и реальным временем.
+A real CIO server (`embeddedServer(CIO)`) does **not** submit to virtual time: `CIOApplicationEngine` hard-codes `userDispatcher = Dispatchers.IOBridge` and wraps route handlers in `withContext(userDispatcher)`. If a test specifically requires a real CIO server — that is integration-level; keep it in `FileServerTest` with `runBlocking` and real time.
 
-## Удаление тестов
+## Removing tests
 
-Удалять тесты нежелательно — они защищают инварианты, часть из которых не очевидна по имени теста. До удаления:
+Removing tests is undesirable — they protect invariants, some of which are not obvious from the test name. Before removing:
 
-1. Перечисли все инварианты, которые тест проверял (не только те, что в имени).
-2. Для каждого укажи, чем он защищён после удаления: другим тестом, контрактом типа, property кода.
-3. Если хотя бы один инвариант остаётся без защиты — либо не удаляй тест, либо в том же коммите добавь защиту (тест / тип / проверку).
+1. List every invariant the test was checking (not only those in the name).
+2. For each, state what protects it after removal: another test, a type contract, a code property.
+3. If even one invariant is left unprotected — either do not remove the test, or add protection (test / type / assertion) in the same commit.
 
-Эта инвентаризация — обязательная часть commit message / PR description при удалении теста.
+This inventory is a mandatory part of the commit message / PR description when removing a test.
 
-Альтернативы удалению: `@Ignore` со ссылкой на tracking issue (тест поломан временно), упрощение теста (слишком тяжёлый), вынос в отдельный source set (платформ-специфичен).
+Alternatives to removal: `@Ignore` with a link to a tracking issue (test is temporarily broken), simplifying the test (too heavy), moving it to a separate source set (platform-specific).
 
 ## Screenshot tests
 
@@ -84,11 +84,11 @@ PNGs land in `composeApp/build/outputs/roborazzi/`. Filenames encode the composa
 - Wrap every preview in `PreviewSurface { }` from `com.tubetoast.tether.ui.preview` for consistent theme + background.
 - Use fake state from `PreviewFixtures` in the same package — no inline data fabrication.
 
-## Запуск
+## Running
 
 ```bash
-./gradlew allTests -q                                    # все тесты; pre-commit / pre-push хуки прогонят их сами
-./gradlew :composeApp:desktopTest -q                     # только Desktop JVM
-./gradlew :composeApp:commonTest -q                      # только common
+./gradlew allTests -q                                    # all tests; pre-commit / pre-push hooks run them automatically
+./gradlew :composeApp:desktopTest -q                     # Desktop JVM only
+./gradlew :composeApp:commonTest -q                      # common only
 ./gradlew :composeApp:desktopTest --tests "com.tubetoast.tether.network.FileServerTest"
 ```

--- a/docs/knowledge/gradle-compose-desktop-run.md
+++ b/docs/knowledge/gradle-compose-desktop-run.md
@@ -1,19 +1,19 @@
-# Gradle JavaExec + non-TTY → CLI выходит до bind порта
+# Gradle JavaExec + non-TTY → CLI exits before port bind
 
-В non-TTY (subprocess агента, CI) `JavaExec`-таска отдаёт worker'у `NullInputStream` вместо `System.in`. `readLine()` мгновенно возвращает null, `runBlocking` отматывается, `System.exit(0)` срабатывает раньше, чем Netty успевает забиндить порт. Симптом: в логе печатается `FileServer started → http://...`, но `curl /health` отвечает `connection refused`.
+In a non-TTY environment (agent subprocess, CI) a `JavaExec` task passes `NullInputStream` instead of `System.in` to the worker. `readLine()` returns null immediately, `runBlocking` unwinds, and `System.exit(0)` fires before Netty has a chance to bind the port. Symptom: `FileServer started → http://...` is printed in the log, but `curl /health` responds with `connection refused`.
 
-Затрагивает `:composeApp:runDesktopCli` (CLI dev runner). Workaround для автоматизации (smoke, CI, тесты с stdin) — CLI fat jar:
+Affects `:composeApp:runDesktopCli` (CLI dev runner). Workaround for automation (smoke tests, CI, tests with stdin) — CLI fat jar:
 
 ```bash
 ./gradlew :composeApp:cliJar -q
 java -jar "$(ls composeApp/build/libs/tether-cli*.jar | head -1)" --name X --port 0 < fifo
 ```
 
-Прямой `java` наследует stdin от bash; FIFO-keeper держит fd открытым.
+Plain `java` inherits stdin from bash; the FIFO keeper keeps the fd open.
 
-Альтернатива — починить task в `composeApp/build.gradle.kts`:
+Alternative — fix the task in `composeApp/build.gradle.kts`:
 ```kotlin
 tasks.named<JavaExec>("runDesktopCli") { standardInput = System.`in` }
 ```
 
-В IDE «Run» → не воспроизводится (TTY есть).
+In IDE "Run" → not reproducible (TTY is present).

--- a/docs/knowledge/macos-mdns-bonjour.md
+++ b/docs/knowledge/macos-mdns-bonjour.md
@@ -1,71 +1,71 @@
-# macOS-host JVM discovery должен идти через Bonjour, не JmDNS
+# macOS-host JVM discovery must go through Bonjour, not JmDNS
 
-## Симптом
+## Symptom
 
-Desktop CLI на macOS-сборке через JmDNS не видит mDNS-пиров с других устройств в той же
-сети (например, реальный Android-телефон) — `[peers]` пустой даже за минуты ожидания.
-Параллельно `dns-sd -B _tether._tcp local.` тех же пиров видит мгновенно. Mac↔Mac через
-JmDNS работает.
+The Desktop CLI on a macOS build via JmDNS does not see mDNS peers from other devices on the same
+network (e.g., a real Android phone) — `[peers]` stays empty even after minutes of waiting.
+At the same time, `dns-sd -B _tether._tcp local.` sees the same peers instantly. Mac↔Mac via
+JmDNS works.
 
-## Причина
+## Cause
 
-На macOS ядро направляет входящие multicast mDNS-пакеты с внешних интерфейсов
-исключительно `mDNSResponder` через привилегированный путь (BPF / kernel control
-socket). User-space сокеты, joined в multicast-группу `224.0.0.251` через стандартный
-`IP_ADD_MEMBERSHIP`, **их не получают** — даже с `SO_REUSEPORT`. Loopback-multicast
-(пакеты, отправленные с того же Mac) ядро доставляет всем подписчикам нормально, поэтому
-Mac↔Mac discovery через JmDNS работает за счёт loopback-пути.
+On macOS the kernel routes incoming multicast mDNS packets from external interfaces
+exclusively to `mDNSResponder` via a privileged path (BPF / kernel control
+socket). User-space sockets joined to the multicast group `224.0.0.251` via the standard
+`IP_ADD_MEMBERSHIP` **do not receive them** — even with `SO_REUSEPORT`. Loopback multicast
+(packets sent from the same Mac) is delivered by the kernel to all subscribers normally, which is
+why Mac↔Mac discovery via JmDNS works through the loopback path.
 
-`mDNSResponder` хранит внешние записи в кеше, но не ре-публикует их в локальный
-multicast самостоятельно. Запрос через `dns-sd -B` его «прокачает», и cached PTR
-действительно появятся в локальном multicast — но SRV/TXT для внешних устройств в
-multicast не выходят даже через `dns-sd -L`. То есть subprocess-обходом до `serviceResolved`
-с реальным IP/портом дойти нельзя.
+`mDNSResponder` stores external records in its cache but does not re-publish them into local
+multicast on its own. A query via `dns-sd -B` will "pump" it, and cached PTR records will
+indeed appear in local multicast — but SRV/TXT for external devices do not reach multicast even
+via `dns-sd -L`. That is, reaching `serviceResolved` with a real IP/port via a subprocess
+workaround is not possible.
 
-Воспроизводится в чистом Python (`socket.SOCK_DGRAM` на UDP 5353 с `IP_ADD_MEMBERSHIP`)
-без JmDNS — это не баг JmDNS, а архитектурное поведение macOS. Полный сброс
-`mDNSResponder` (`sudo killall mDNSResponder`) ничего не меняет — кеш строится заново
-тем же путём.
+Reproducible in pure Python (`socket.SOCK_DGRAM` on UDP 5353 with `IP_ADD_MEMBERSHIP`)
+without JmDNS — this is not a JmDNS bug but an architectural behaviour of macOS. A full reset of
+`mDNSResponder` (`sudo killall mDNSResponder`) changes nothing — the cache is rebuilt by the
+same path.
 
-## Решение
+## Solution
 
-На macOS-host JVM-сборке `MdnsDiscovery` использует Apple DNS-SD API через JNA-биндинг
-к libSystem (`DNSServiceBrowse` → `DNSServiceResolve` → `DNSServiceGetAddrInfo`), и
-публикует свой сервис через `DNSServiceRegister`. Это делает процесс клиентом
-mDNSResponder, а не его конкурирующим multicast-слушателем.
+On a macOS-host JVM build, `MdnsDiscovery` uses the Apple DNS-SD API via a JNA binding
+to libSystem (`DNSServiceBrowse` → `DNSServiceResolve` → `DNSServiceGetAddrInfo`), and
+publishes its own service via `DNSServiceRegister`. This makes the process a client of
+mDNSResponder rather than a competing multicast listener.
 
-На Linux/Windows никакого системного mDNS-демона нет, и JmDNS работает напрямую через
-raw multicast — там оставляем JmDNS. Дисптач — по `os.name` в `MdnsDiscovery.jvm.kt`.
+On Linux/Windows there is no system mDNS daemon, and JmDNS works directly via
+raw multicast — JmDNS is kept there. Dispatch is done by `os.name` in `MdnsDiscovery.jvm.kt`.
 
-## Native Apple-таргеты этой проблемы не имеют
+## Native Apple targets are not affected by this problem
 
-Описанное выше — про **JVM-сборку на macOS-хосте**. Нативный iOS-таргет
-(`appleMain` / `iosMain` через `NSNetServiceBrowser`) ходит к тому же
-`mDNSResponder` через системный Foundation API, то есть оказывается по
-правильную сторону kernel-фильтра по умолчанию. JmDNS на JVM был проблемой
-**именно** потому, что он независимый user-space multicast listener, а не
-клиент mDNSResponder.
+The above is about the **JVM build on a macOS host**. The native iOS target
+(`appleMain` / `iosMain` via `NSNetServiceBrowser`) reaches the same
+`mDNSResponder` through the system Foundation API, meaning it sits on the
+correct side of the kernel filter by default. JmDNS on JVM was a problem
+**precisely** because it is an independent user-space multicast listener, not
+a mDNSResponder client.
 
-**Канонизация имени при конфликте.** mDNSResponder может переименовать
-опубликованный сервис (`Self` → `Self (2)`), и self-фильтр должен
-использовать имя из publish callback'а, а не запрошенное. В JVM-Bonjour
-это сделано через `Event.OwnNameAssigned` ([`MdnsDiscoveryBonjour.kt`](../../composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/bonjour/MdnsDiscoveryBonjour.kt)).
-В native-Apple ровно тот же паттерн уже реализован — `ownServiceName = sender.name`
-в `netServiceDidPublish` callback'е [`MdnsDiscovery.apple.kt:154`](../../composeApp/src/appleMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.apple.kt:154).
-Не повторяй ошибку «фильтровать по запрошенному имени» в новых
-Apple-таргет-местах.
+**Name canonicalisation on conflict.** mDNSResponder may rename a
+published service (`Self` → `Self (2)`), and the self-filter must use
+the name from the publish callback, not the requested one. In JVM-Bonjour
+this is done via `Event.OwnNameAssigned` ([`MdnsDiscoveryBonjour.kt`](../../composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/bonjour/MdnsDiscoveryBonjour.kt)).
+In native Apple exactly the same pattern is already implemented — `ownServiceName = sender.name`
+in the `netServiceDidPublish` callback in [`MdnsDiscovery.apple.kt:154`](../../composeApp/src/appleMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.apple.kt:154).
+Do not repeat the mistake of "filter by requested name" in new
+Apple-target locations.
 
-См. также [`apple-platform.md`](apple-platform.md) — там собраны
-платформо-специфичные патерны (ObjC delegate GC, NSRunLoop в тестах,
-Local Network Privacy на iOS), которые остаются актуальны для всех
-NSNetService-based реализаций.
+See also [`apple-platform.md`](apple-platform.md) — it covers
+platform-specific patterns (ObjC delegate GC, NSRunLoop in tests,
+Local Network Privacy on iOS) that remain relevant for all
+NSNetService-based implementations.
 
-## Где смотреть
+## Where to look
 
-- [`MdnsDiscovery.jvm.kt`](../../composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt) — фабрика по `os.name`
-- [`bonjour/DnsSd.kt`](../../composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/bonjour/DnsSd.kt) — JNA-биндинги к libSystem
-- [`bonjour/MdnsDiscoveryBonjour.kt`](../../composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/bonjour/MdnsDiscoveryBonjour.kt) — реализация browse/resolve/addrinfo через DNS-SD
-- [`bonjour/BonjourState.kt`](../../composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/bonjour/BonjourState.kt) — pure-Kotlin state-machine, переносимый паттерн для других Bonjour-реализаций
-- [`MdnsDiscoveryJmdns.kt`](../../composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscoveryJmdns.kt) — JmDNS-вариант для Linux/Windows
-- [`MdnsDiscovery.apple.kt`](../../composeApp/src/appleMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.apple.kt) — native-Apple discovery (NSNetServiceBrowser → mDNSResponder)
-- Issue [#47](https://github.com/khmelevartem/tether/issues/47) — диагностические комментарии с экспериментальными данными
+- [`MdnsDiscovery.jvm.kt`](../../composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.jvm.kt) — factory by `os.name`
+- [`bonjour/DnsSd.kt`](../../composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/bonjour/DnsSd.kt) — JNA bindings to libSystem
+- [`bonjour/MdnsDiscoveryBonjour.kt`](../../composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/bonjour/MdnsDiscoveryBonjour.kt) — browse/resolve/addrinfo implementation via DNS-SD
+- [`bonjour/BonjourState.kt`](../../composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/bonjour/BonjourState.kt) — pure-Kotlin state machine, a portable pattern for other Bonjour implementations
+- [`MdnsDiscoveryJmdns.kt`](../../composeApp/src/desktopMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscoveryJmdns.kt) — JmDNS variant for Linux/Windows
+- [`MdnsDiscovery.apple.kt`](../../composeApp/src/appleMain/kotlin/com/tubetoast/tether/discovery/MdnsDiscovery.apple.kt) — native Apple discovery (NSNetServiceBrowser → mDNSResponder)
+- Issue [#47](https://github.com/khmelevartem/tether/issues/47) — diagnostic comments with experimental data

--- a/ktlint-rules/src/main/kotlin/com/tubetoast/tether/ktlint/NoRunBlockingInTestsRule.kt
+++ b/ktlint-rules/src/main/kotlin/com/tubetoast/tether/ktlint/NoRunBlockingInTestsRule.kt
@@ -21,8 +21,8 @@ class NoRunBlockingInTestsRule : Rule(RuleId("tether:no-run-blocking-in-tests"),
         if (calleeName == "runBlocking") {
             emit(
                 node.startOffset,
-                "runBlocking запрещён в тестах (testing.md§Стиль) — используй runTest + TestDispatcher. " +
-                    "Suppress с обоснованием для integration-тестов на реальных потоках.",
+                "runBlocking is not allowed in tests (testing.md§Style) — use runTest + TestDispatcher. " +
+                    "Suppress with justification for integration tests on real coroutines.",
                 false,
             )
         }


### PR DESCRIPTION
**Что / зачем.** Translates 27 .md files across `docs/engineering/`, `docs/knowledge/`, `.claude/agents/`, `.claude/commands/`, `.claude/skills/`, and `CLAUDE.md` from mixed Russian/English to pure English. Adds an explicit rule to `CLAUDE.md §Git conventions`: all issue and PR titles/descriptions must be in English; Russian is only permitted in interactive chat.

**👀 Sanity-check.**
- `github-issue-author/SKILL.md` language default flipped from "Default: Russian" to "Default: English" — intentional, not pure translation. Keeping the old default would directly contradict the new CLAUDE.md language rule.
- Out-of-DoD files left as-is (Russian remains): `.claude/skills/github-issue-author/EXAMPLES.md`, `TEMPLATE.md`, `.claude/skills/progress/assets/*.json`, `docs/sprints/**`, `docs/interview-prep-checklist.md`.

**Scope.**
- ❌ не трогал: `docs/product/**` (already fully in English), `README.md`, sprint docs, `.claude/README.md`, `docs/glossary.md`

Closes #247