### PR TITLE
#274: promote close-issue, retro, check-review, sprint-pick to skills

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -6,25 +6,25 @@ How Tether extends Claude Code. Two artifact homes, both creating a `/slash-comm
 
 `.claude/skills/<name>/SKILL.md` — multi-agent orchestrations and procedures.
 
+- `check-review` — read latest PR comments, classify pointwise vs structural, fix + reply in-thread.
+- `close-issue` — finish an issue and merge its PR.
 - `code-review` — multi-agent review of a PR; fan-out + adversarial + GitHub post.
 - `document` — docs-only issue orchestrator (spec / ux-brief / tech-doc / ADR / knowledge / `.claude` prompt).
 - `github-issue-author` — strict-template GitHub issue creation via `gh`.
 - `grooming` — close current sprint by reality + gap-analysis + draft next sprint.
 - `implement` — issue-to-PR orchestrator (coder ↔ reviewers loop, smoke, PR).
 - `progress` — RPG-themed project snapshot.
+- `retro` — retrospective on an issue + its PR.
 - `smoke-test` — runtime happy-path across platforms.
+- `sprint-pick` — what to take next from the current sprint.
 
 ## Commands index
 
 `.claude/commands/<name>.md` — single-file prompt templates.
 
-- `check-review` — read latest PR comments and triage.
-- `close-issue` — finish an issue and merge its PR.
 - `progress-boring` — flat numbers variant of `/progress`.
 - `quick-issue` — lightweight `/gh issue create` (vs the full `github-issue-author` skill).
 - `rebase` — pull `origin/main` and assess semantic overlap.
-- `retro` — retrospective on an issue + its PR.
-- `sprint-pick` — what to take next from the current sprint.
 
 ## Agents index
 

--- a/.claude/skills/check-review/SKILL.md
+++ b/.claude/skills/check-review/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: check-review
+description: Read the latest review comments on the PR you are working on, classify each as pointwise or structural (re-auditing the whole diff for structural ones), reject reviewer-priority labels in favor of own value assessment, fix valid ones, reply to invalid ones in the original thread via `in_reply_to`, push. Use when the user says "check review", "process PR comments", "address review", "посмотри ревью", "обработай комменты", or invokes `/check-review`.
+---
+
 Review the latest comments on the PR you are working on. Assess which of them are valid, fix the valid ones. If there are invalid ones, reply to them explaining why you consider them invalid. Push the changes.
 
 ## Important: pointwise fix vs structural finding

--- a/.claude/skills/close-issue/SKILL.md
+++ b/.claude/skills/close-issue/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: close-issue
+description: Finish a GitHub issue and merge its PR — rebase, walk acceptance criteria, gate on manual smoke + user confirmation, ask one interview-prep comprehension question, sweep PR review comments, update docs touched by the change, record any engineering decisions made in chat, post-factum size label, squash-merge, follow-ups, optional retro. Use when the user says "close issue N", "merge the PR", "finish task N", "ship #N", or invokes `/close-issue`.
+---
+
 Complete task <issue number> and merge the PR.
 
 Work strictly step by step. Each step is a stop point: if something is not done, report it explicitly and wait for the user's confirmation or correction. Do not proceed to the next step without an explicit OK.
@@ -55,7 +60,7 @@ Ask the user explicitly:
 One question to the user to check understanding of principles actually applied in this task: architecture / code / mechanism / library / platform behavior. The goal is interview prep for Senior Android / KMP, not a merge-readiness audit.
 
 **Source of the question:**
-- First open the [interview prep checklist](../../docs/interview-prep-checklist.md) and find an uncompleted item (`- [ ]`) that thematically matches what changed in the PR. If there is a match — ask based on it.
+- First open the [interview prep checklist](../../../docs/interview-prep-checklist.md) and find an uncompleted item (`- [ ]`) that thematically matches what changed in the PR. If there is a match — ask based on it.
 - If no uncompleted item matches the context of the task — formulate your own question based on the actual implementation (what was specifically done in the PR and why).
 
 **Format:**

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: retro
+description: Run a retrospective on a GitHub task (issue + PR) to identify systemic gaps and systemic successes, propose changes to CLAUDE.md / docs / skills / commands / hooks, and apply approved ones on a separate retro branch with PR title `retro from #<PR>: …`. Use when the user says "retro", "retrospective", "разбор по задаче", "look back at task N", or invokes `/retro`.
+---
+
 Run a retrospective on task <issue number> (and the associated PR, if any).
 
 The goal is not a report for its own sake and not a catalog of pointwise mistakes, but **systemic improvements**: what in the prompts, commands, skills, documentation, or project structure needs to change so that future assignees can do quality work more easily. Every conclusion must end with an action.
@@ -58,8 +63,9 @@ Based on steps 2–3, identify specific systemic changes. Categories:
 
 | Category | When to touch |
 |----------|--------------|
-| `.claude/commands/*.md` | The command gave unclear instructions, didn't cover a scenario, or lacked a needed step |
-| `.claude/skills/` | The skill didn't cover the needed scenario or didn't prevent a class of errors |
+| `.claude/skills/<name>/SKILL.md` | The skill (workflow procedure or orchestration) didn't cover the needed scenario, didn't prevent a class of errors, or lacked a needed step |
+| `.claude/commands/*.md` | One of the remaining single-file templates (`rebase`, `quick-issue`, `progress-boring`) gave unclear instructions or missed a scenario |
+| `.claude/agents/<name>.md` | A sub-agent's brief is incomplete, allowed an out-of-scope decision, or missed a check |
 | `CLAUDE.md` | A convention / process / project structure is not recorded — the agent had to guess |
 | `docs/engineering/` | An architectural principle / pattern is recorded incorrectly, incompletely, or its examples diverge from reality |
 | `docs/product/features/` | A feature spec is incomplete or missing where it would have been useful |

--- a/.claude/skills/sprint-pick/SKILL.md
+++ b/.claude/skills/sprint-pick/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: sprint-pick
+description: Quick read-only look at the current `docs/sprints/sprint-NN.md` — pull issue numbers from Composition + Blocking chains, batch-check OPEN/PR status via `gh`, query `blocked_by` only for 🟢 items, and propose 1–3 candidates to start now with one-sentence justifications. No Gradle, no edits. Use when the user says "what to pick next", "next task from sprint", "что взять из спринта", "следующая задача", or invokes `/sprint-pick`.
+---
+
 Quick look: what to pick from the current sprint right now. Read-only and `gh` only, no Gradle.
 
 ## 1. Sprint

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ Requires: `tether` in `PATH` (see Desktop CLI above), at least one AVD (create i
 
 - [CLAUDE.md](CLAUDE.md) — what an AI agent or new contributor must know: architecture invariants, git conventions, worktree discipline.
 - [docs/engineering/](docs/engineering/README.md) — architecture and code-writing rules (DI, modules, testing).
-- [.claude/skills/](.claude/skills/) — multi-agent skills: `/implement` (issue → PR orchestrator), `/code-review` (parallel multi-agent review).
-- [.claude/commands/](.claude/commands/) — slash commands for common workflows (`/close-issue`, `/check-review`, `/grooming`, `/retro`, `/quick-issue`).
+- [.claude/skills/](.claude/skills/) — multi-agent skills and workflow orchestrations (`/implement`, `/code-review`, `/close-issue`, `/retro`, `/grooming`, …).
+- [.claude/commands/](.claude/commands/) — single-file prompt templates (`/rebase`, `/quick-issue`, `/progress-boring`).
 
 Tests:
 ```bash


### PR DESCRIPTION
**What / why.** Promotes four multi-step procedures from `.claude/commands/` to `.claude/skills/<name>/SKILL.md` so they auto-invoke by description (Anthropic criteria: multi-step procedure + trigger-phrase match), matching the discipline in `.claude/README.md`. Skill bodies are 1:1 from the deleted commands; only YAML frontmatter (name + description with trigger phrases) is added. `/close-issue`, `/retro`, `/check-review`, `/sprint-pick` continue to work — skills keep the same slash name.

**👀 Sanity-check.**
- Auto-invocation is verified ad-hoc post-merge by typing trigger phrases; not part of the diff.
- `.claude/skills/retro/SKILL.md` Step 4 table updated beyond verbatim copy: `.claude/commands/*.md` row demoted (now refers to the remaining single-file templates only), `.claude/skills/<name>/SKILL.md` and `.claude/agents/<name>.md` rows added — table reflects post-PR layout.

**Scope.**
- 📎 `.claude/README.md` Skills index +4, Commands index −4; `README.md` for-contributors line updated.

Closes #274