### PR TITLE
retro from #280: commit interview-prep-checklist edit into the PR branch

### DIFF
--- a/.claude/skills/close-issue/SKILL.md
+++ b/.claude/skills/close-issue/SKILL.md
@@ -70,7 +70,7 @@ One question to the user to check understanding of principles actually applied i
 **After the user's answer:**
 - Assess correctness: what is right, what is missing, what is imprecise or wrong. Without leniency and without aggression — like a technical interviewer giving honest feedback.
 - If the answer was based on an item from the checklist — mark it as completed (`- [ ]` → `- [x]`) directly in `docs/interview-prep-checklist.md` via Edit. If the question was your own (not from the checklist) — add it to the "Additional questions from tasks" section at the end of the checklist as `- [x] <question>` via Edit.
-- **Commit the checklist edit into the current PR branch and push, before Step 6 merge.** Direct pushes to `main` are blocked; landing the edit separately afterwards forces a redundant follow-up PR for one line. The checklist update is part of closing this issue, not a separate concern.
+- **Commit the checklist edit into the current PR branch and push, before Step 6 merge.**
 
 **This is not a stop-point based on the content of the answer** — a weak answer does not block the merge. The user decides themselves whether to proceed or explore the topic further. The stop-point is only the fact that the question was asked and an answer was received.
 

--- a/.claude/skills/close-issue/SKILL.md
+++ b/.claude/skills/close-issue/SKILL.md
@@ -70,6 +70,7 @@ One question to the user to check understanding of principles actually applied i
 **After the user's answer:**
 - Assess correctness: what is right, what is missing, what is imprecise or wrong. Without leniency and without aggression — like a technical interviewer giving honest feedback.
 - If the answer was based on an item from the checklist — mark it as completed (`- [ ]` → `- [x]`) directly in `docs/interview-prep-checklist.md` via Edit. If the question was your own (not from the checklist) — add it to the "Additional questions from tasks" section at the end of the checklist as `- [x] <question>` via Edit.
+- **Commit the checklist edit into the current PR branch and push, before Step 6 merge.** Direct pushes to `main` are blocked; landing the edit separately afterwards forces a redundant follow-up PR for one line. The checklist update is part of closing this issue, not a separate concern.
 
 **This is not a stop-point based on the content of the answer** — a weak answer does not block the merge. The user decides themselves whether to proceed or explore the topic further. The stop-point is only the fact that the question was asked and an answer was received.
 


### PR DESCRIPTION
**What / why.** Closing #274 surfaced a small gap in the `close-issue` skill: Step 2.3 says "Edit `docs/interview-prep-checklist.md` via Edit" but doesn't say *which branch*. An agent following the literal instructions edits the file on `main`'s working tree, then can't push (direct-push blocked), then opens a one-line follow-up PR. Clarifies that the checklist entry rides along with the closing PR before merge.