### PR TITLE
retro from #284: architect no-doc default, issue layering rule, by-agent re-entry routing, test-at-seam canon

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,6 +1,6 @@
 ---
 name: architect
-description: Designs the technical system for a Tether subsystem (mechanism, libraries, protocols, lifecycle, cross-platform invariants), then records the converged decision as a living engineering doc (`docs/engineering/<name>.md`) and, when warranted, an Architecture Decision Record (`docs/engineering/adr/adr-<name>.md`). Also captures solved-problem knowledge (`docs/knowledge/<name>.md`) when a platform quirk / library trap / workaround is worth saving for the next person. Symmetric to spec-writer (decides user needs) and ux-expert (decides interaction) — this agent decides the technical realisation. Owns the design palette, asks the user trade-off questions, picks the choice, then writes.
+description: Designs the technical system for a Tether subsystem (mechanism, libraries, protocols, lifecycle, cross-platform invariants) and returns the converged decision as a chat summary. Codification — living engineering doc (`docs/engineering/<name>.md`), Architecture Decision Record (`docs/engineering/adr/adr-<name>.md`), or knowledge entry (`docs/knowledge/<name>.md`) — happens only when the orchestrator's dispatch brief explicitly requests an artifact and the user has approved the underlying decision. Symmetric to spec-writer (decides user needs) and ux-expert (decides interaction) — this agent decides the technical realisation. Owns the design palette, asks the user trade-off questions, picks the choice.
 tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch
 model: opus
 ---
@@ -80,6 +80,8 @@ If during convergence you realise the palette was incomplete or the answers reve
 
 ### Step 5 — Decide artifact scope
 
+**Default: produce a chat summary, no on-disk artifact.** Steps 5–7 below run only when both (a) the orchestrator's dispatch brief explicitly asks for an artifact, AND (b) the user has approved the underlying architectural decision in the current run. Otherwise skip to Step 8 and hand the converged decision back to the orchestrator as a chat summary; the orchestrator decides whether and when to codify. A pending user objection to a decision invalidates any prior approval — the brief must ask again if it wants an artifact written.
+
 **Route each rule from your converged design to the layer that owns it:**
 
 - product framing → the spec
@@ -152,6 +154,7 @@ Do not commit. The orchestrator decides when to commit.
 - Write product specs (that's `spec-writer`) or UX briefs (that's `ux-expert`).
 - Write an ADR without a parent living doc.
 - Outsource your architectural judgement to the orchestrator or to the user. The user answers trade-off questions you pose; they don't pre-design for you. If you find yourself waiting for the user to tell you which library to use without giving them a palette and a recommendation — you skipped Step 2.
+- Write docs to disk without an explicit orchestrator request in the dispatch brief. Default deliverable is the chat summary; codification is the orchestrator's decision, made after the user has approved the underlying choice in this run.
 
 ## Output to caller
 

--- a/.claude/skills/github-issue-author/SKILL.md
+++ b/.claude/skills/github-issue-author/SKILL.md
@@ -283,3 +283,4 @@ Full issue creation examples — see [EXAMPLES.md](EXAMPLES.md).
 - **Don't apply labels that don't exist in the repository** — first check `gh label list --repo OWNER/REPO` if unsure.
 - **Don't invent files and modules** if the user didn't mention them and they're not obvious from the repository. Better to write `(clarify during breakdown)`.
 - **Don't ignore `size:L`** — it's a signal to "split into an epic", not "write a big issue".
+- **Don't pre-commit layering in the body** — file paths and module names are landmarks, not architectural commitments. Where a new top-level type lives in the layering (which package, what depends on what) is `/implement`'s decision via the architect agent, against `docs/engineering/architecture-principles.md`. Issue bodies that fix `com.example.foo.bar.NewRepository` as the home of a new top-level type pre-empt that decision and produce churn when the assignee disagrees.

--- a/.claude/skills/github-issue-author/TEMPLATE.md
+++ b/.claude/skills/github-issue-author/TEMPLATE.md
@@ -115,6 +115,8 @@ Without this note the implementer may treat the first hypothesis as fact and wri
 
 List of classes / modules / files / endpoints / DB tables expected to be touched. If not known precisely — state the presumed location and mark `(to confirm)`.
 
+**Pre-bake behaviour and contracts, not packages or layer placement.** File paths and module names are landmarks for the implementer to verify, not architectural commitments. Choosing the layer / package for a new top-level type, and the dependency direction between layers, is the architect's job during `/implement` (against `docs/engineering/architecture-principles.md`). Body wording: "touches the file-server boundary" — not "lives in `com.example.network.foo`". Naming a concrete package is fine for an existing type the task only modifies; for a new top-level type, leave placement to `/implement`.
+
 ### Code landmarks
 
 (optional, but greatly helps the implementing agent)

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -25,6 +25,20 @@ Step 8 (commit + push + final summary) is simplified on re-entry: the commit goe
 
 **After push on re-entry — reply to every addressed inline comment** via `gh api -X POST repos/<owner>/<repo>/pulls/<PR>/comments/<comment_id>/replies -f body="<reply>"`. For each comment: what was done + the commit SHA (or explicit reasoning if the comment was deliberately declined). Without a reply the reviewer cannot see the loop closed and the thread stays "hanging"; the next re-entry will read it again as unaddressed and uselessly re-run the inner loop. A reply is the "addressed" signal, not a courtesy.
 
+### Re-entry routing — by-agent attribution
+
+When a PR comment is scoped to work produced by a specific upstream agent (architectural decision, UX brief, UI implementation, spec, etc.), route the comment back to that agent first — not to the coder. The agent owns its work surface; the coder applies the resulting decision.
+
+Attribution heuristics:
+- Comment objects to a layering / placement / dependency-direction / mechanism choice → `architect`.
+- Comment objects to a spec gap, AC scope, or product framing → `spec-writer`.
+- Comment objects to a screen / interaction / state-flow decision → `ux-expert`.
+- Comment objects to UI rendering, theme, accessibility specifics → `ui-expert`.
+- Comment objects to a glossary / docs entry that the architect wrote → `architect`.
+- Comment is a pointwise correctness or style issue with no architectural element → `coder` via the existing inner-loop path.
+
+The originating agent returns its revised work as a chat summary to the orchestrator. The orchestrator then decides next steps: dispatch `coder` to apply the revision, dispatch `ui-expert` for a re-render, re-run reviewers, or escalate to the user when the revision changes scope (new top-level types, layer crossings, deleted contracts). A structural revision is not an inner-loop iteration on the coder's output; running it through the coder skips the agent who owns the decision and risks repackaging the comment incorrectly (see `## No-deflection principle` §Review transmission accuracy).
+
 ## No-deflection principle
 
 When someone — the user or a reviewer — asks a question about an artifact or demands a change, the answer must be **substantive**: either a justification for why the artifact stays as-is, or a genuine edit to the artifact itself. Intermediate actions — precautionary destruction, a half-fix, justifying via KDoc / comment / documentation instead of changing the code — are deflection. Forbidden.

--- a/docs/engineering/testing.md
+++ b/docs/engineering/testing.md
@@ -4,6 +4,8 @@ Tests are mandatory. When implementing any functionality, write unit and/or inte
 
 **Behaviour fix — regression test in the same commit.** If a commit fixes an observable behaviour (bug, regression, non-feature), the same commit must include a test that would have failed without the fix. This applies equally to BUGFIX issues and to bugs found mid-flight on a FEATURE task (manual user test, review, smoke). If the regression test costs more than the fix itself — that is a signal that the testability seam needs to be improved in the same change (extract a function, move a dependency into a parameter), not deferred.
 
+**Assert at the stable external seam.** Behavioural invariants — concurrency rules, lifecycle bookkeeping, ordering, error mapping — assert at the public API of the unit under test (constructor / DI entry point used in production, exposed flows, returned values, emitted events), not at internals. Tests bound to private state, internal classes, or reflection pay a refactor tax: every layer move or rename rewrites them. Tests at the external seam survive refactors as long as the contract holds, which is the test's job to check. If a test cannot be expressed at the external seam without touching internals, the seam is wrong — fix the seam, not the test.
+
 A test lives in the most general source set across whose targets every referenced type has an identical signature; types with platform-divergent signatures (different constructor, different `expect/actual` shape) force the test into a more specific source set.
 
 ## Style


### PR DESCRIPTION
**What / why.** Four small canon/skill edits from the retro on closed PR #284 (Phase-A refactor that ended up restarted). Each addresses a systemic gap surfaced during that run; one rebuild-task was filed separately.

- `.claude/agents/architect.md` — architect's default deliverable is now a chat summary, not on-disk docs. Steps 5–7 (write living doc / ADR / knowledge entry, update indexes) run only when the orchestrator's dispatch brief explicitly requests an artifact AND the user has approved the underlying decision in the current run. Addresses: docs got committed across a user objection in iter-3 because nothing in the agent definition prevented it.
- `.claude/skills/github-issue-author/TEMPLATE.md` + `SKILL.md` — issue bodies describe behaviour and contracts, not package placement. File paths are landmarks for the implementer, not architectural commitments. Where a new top-level type lives in the layering is `/implement`'s call (architect agent vs `architecture-principles.md`), not the issue's. Addresses: #191's body pre-baked `com.tubetoast.tether.presentation.transfer.PeerTransferRepository` which the user then rejected at PR review.
- `.claude/skills/implement/SKILL.md` — re-entry contract now distinguishes pointwise comments (route to coder via inner loop) from comments scoped to a specific upstream agent's work (route back to that agent first; orchestrator decides next steps after the agent returns its revision). Addresses: a structural revision in #191's PR review was handled as a coder iteration, which is the wrong path for "this top-level type belongs in a different layer".
- `docs/engineering/testing.md` — "Assert at the stable external seam" added as a rule. Behavioural invariants test at the public API (constructor / DI entry point, exposed flows, returned values, emitted events), not at internals. Addresses: a systemic success — #284's behavioural tests survived two structural moves intact because they asserted at the Repository's external seam, and that pattern was nowhere documented.

**👀 Sanity-check.**
- `architect.md`'s description field at the top now reads as "returns a chat summary; codification on request"; the existing Steps 5–7 procedure stays in place, gated by a one-paragraph "default = chat summary" preface. Reviewers should check the gate wording is unambiguous — if it's read as "skip Step 5–7 entirely whenever the brief doesn't mention them", that's correct; if it's read as "ask the user inline mid-procedure", that's wrong.
- The "by-agent re-entry routing" addition lives in the re-entry contract; the attribution list of which comment type goes to which agent is heuristic, not exhaustive. A judgement call from the orchestrator is still required when a comment crosses agent boundaries.
- Action 4 from the retro draft (worktree-cwd discipline codified in the skill) was declined — user said it's a one-off slip; not in this PR.
- Action 1 (architect agent rebuild) was filed as #289 — out of scope here. This PR only changes the default; #289 will reshape the procedure.

**Scope.**
- 📎 affected: 5 files, 23 insertions / 1 deletion.
- 📎 follow-up: #289 (architect agent rebuild) — companion task surfaced by this retro.

(No `Closes` — this PR is a retro from PR #284, not from an issue. #289 stays open as the follow-up.)
