### PR TITLE
retro from #282: tighten glossary admission rules and code-in-docs discipline

### DIFF
--- a/.claude/agents/review-glossary.md
+++ b/.claude/agents/review-glossary.md
@@ -29,7 +29,7 @@ Sample load-bearing nouns in the prose under review:
 For each sampled term:
 
 1. **Drift.** Term has a glossary entry but the diff uses it with a meaning that contradicts the definition, or uses a near-synonym the glossary explicitly lists under `_Avoid:_` (e.g. «node» where glossary says **Peer** + `_Avoid: node_`). Flag as `[REQUIRED]` with the canonical term and the avoidance note.
-2. **Missing entry.** The prose under review introduces a domain term recurring across two or more touched artifacts (or already used elsewhere in the repo) without a glossary entry. Flag as `[REQUIRED]`; the writing agent adds the entry as part of addressing the finding.
+2. **Missing entry.** The prose under review introduces a **domain term** — a concept that carries meaning outside the code and recurs in product / engineering discussions, not a code symbol — across two or more touched artifacts (or already used elsewhere in the repo) without a glossary entry. Flag as `[REQUIRED]`; the writing agent adds the entry as part of addressing the finding. Use the admission rule from [`docs/engineering/glossary-discipline.md`](../../docs/engineering/glossary-discipline.md#what-qualifies-as-a-term): Kotlin type names, function / method names, API / library symbol names, and implementation-technique labels do NOT qualify — do not flag them.
 3. **Glossary self-edit.** If the prose under review touches `docs/glossary.md`, treat new/changed entries as diff-internal: don't flag them as «undocumented term», but verify the entry shape declared in the glossary header. Malformed entries are `[REQUIRED]`.
 
 Skip from sampling:

--- a/.claude/agents/review-guides.md
+++ b/.claude/agents/review-guides.md
@@ -36,7 +36,7 @@ Always read `CLAUDE.md`. Then read the engineering doc that maps to the diff:
 5. **Commit naming** — every commit message starts with `#<issue>: `. Run `gh pr view <PR> --json commits --jq '.commits[].messageHeadline'`.
 6. **Idioms** — Kotlin official style is enforced by KtLint (do not flag style); flag non-idiomatic patterns: `!!` where nullable handling is expected, manual loops where `map`/`filter` fits, `runBlocking` anywhere (production: refactor to `suspend`; tests: `runTest` + `TestDispatcher` per `testing.md`).
 7. **Doc-vs-code drift** — if PR changes an architectural pattern documented in `docs/engineering/`, the doc must be updated in the same PR (especially "doc-as-spec" for first real implementation of a skeleton).
-8. **Long-lived-artifact discipline** for any touched prose in `docs/**`, `.claude/**`, KDoc, comments, error messages — apply the rules from `docs/engineering/long-lived-artifacts.md`. In particular: flag code symbols inside docs prose — class names, method names, API names in backticks (`File.createNewFile`, `UploadStorageBackend`, `expect/actual`) — unless the surrounding rule is genuinely about that symbol (glossary entry, doc whose subject is the library binding). Most occurrences are leakage from the writing session; the rule reads the same with the symbol removed.
+8. **Long-lived-artifact discipline** for any touched prose in `docs/**`, `.claude/**`, KDoc, comments, error messages — apply the rules from `docs/engineering/long-lived-artifacts.md`.
 
 ## What you do NOT check
 

--- a/.claude/agents/review-guides.md
+++ b/.claude/agents/review-guides.md
@@ -36,7 +36,7 @@ Always read `CLAUDE.md`. Then read the engineering doc that maps to the diff:
 5. **Commit naming** — every commit message starts with `#<issue>: `. Run `gh pr view <PR> --json commits --jq '.commits[].messageHeadline'`.
 6. **Idioms** — Kotlin official style is enforced by KtLint (do not flag style); flag non-idiomatic patterns: `!!` where nullable handling is expected, manual loops where `map`/`filter` fits, `runBlocking` anywhere (production: refactor to `suspend`; tests: `runTest` + `TestDispatcher` per `testing.md`).
 7. **Doc-vs-code drift** — if PR changes an architectural pattern documented in `docs/engineering/`, the doc must be updated in the same PR (especially "doc-as-spec" for first real implementation of a skeleton).
-8. **Long-lived-artifact discipline** for any touched prose in `docs/**`, `.claude/**`, KDoc, comments, error messages — apply the rules from `docs/engineering/long-lived-artifacts.md`.
+8. **Long-lived-artifact discipline** for any touched prose in `docs/**`, `.claude/**`, KDoc, comments, error messages — apply the rules from `docs/engineering/long-lived-artifacts.md`. In particular: flag code symbols inside docs prose — class names, method names, API names in backticks (`File.createNewFile`, `UploadStorageBackend`, `expect/actual`) — unless the surrounding rule is genuinely about that symbol (glossary entry, doc whose subject is the library binding). Most occurrences are leakage from the writing session; the rule reads the same with the symbol removed.
 
 ## What you do NOT check
 

--- a/docs/engineering/glossary-discipline.md
+++ b/docs/engineering/glossary-discipline.md
@@ -16,12 +16,12 @@ Lives at [`docs/glossary.md`](../glossary.md). Terms cross all three documentati
 A term must **carry meaning outside the code** — something product or engineering discussions reference by name. It recurs across long-lived artifacts (specs, engineering docs, ADRs, review comments) as a concept, not as a symbol reference.
 
 What does NOT qualify, even if it recurs in the diff:
-- Kotlin type names (`UploadHandle`, `FileServerRoutes`).
-- Function / method names (`atomicCreateFile`, `reserveDeduplicatedFile`, `dedupFilename`).
-- API / library symbol names (`File.createNewFile`, `fopen("wbx")`, `expect/actual`).
+- Kotlin type names.
+- Function / method names.
+- API / library symbol names.
 - Implementation techniques tied to a specific call site — describe them where the technique lives, not in the glossary.
 
-A symbol from the code that also names a stable engineering concept (`FileServer`, `UploadStorage`) does qualify — the entry is about the concept, the symbol name happens to match.
+A symbol from the code that also names a stable engineering concept (the server, the storage, a view, a test fixture) does qualify — the entry is about the concept, the symbol name happens to match.
 
 ## How drift is caught
 

--- a/docs/engineering/glossary-discipline.md
+++ b/docs/engineering/glossary-discipline.md
@@ -11,6 +11,18 @@ Two artifacts work together:
 
 Lives at [`docs/glossary.md`](../glossary.md). Terms cross all three documentation layers: product framing, engineering rules, platform knowledge. Entry shape is declared in the glossary's own header — defer there, do not restate.
 
+## What qualifies as a term
+
+A term must **carry meaning outside the code** — something product or engineering discussions reference by name. It recurs across long-lived artifacts (specs, engineering docs, ADRs, review comments) as a concept, not as a symbol reference.
+
+What does NOT qualify, even if it recurs in the diff:
+- Kotlin type names (`UploadHandle`, `FileServerRoutes`).
+- Function / method names (`atomicCreateFile`, `reserveDeduplicatedFile`, `dedupFilename`).
+- API / library symbol names (`File.createNewFile`, `fopen("wbx")`, `expect/actual`).
+- Implementation techniques tied to a specific call site — describe them where the technique lives, not in the glossary.
+
+A symbol from the code that also names a stable engineering concept (`FileServer`, `UploadStorage`) does qualify — the entry is about the concept, the symbol name happens to match.
+
 ## How drift is caught
 
 `review-glossary` runs in every PR review wave:

--- a/docs/engineering/long-lived-artifacts.md
+++ b/docs/engineering/long-lived-artifacts.md
@@ -12,7 +12,7 @@ If a rule is unreadable without referring to an incident, that's a weak formulat
 
 ## Code does not belong in long-lived artifacts
 
-A long-lived artifact describes a mechanism conceptually — what something is, why it exists, what invariants hold. It does not name the classes, methods, or library calls that implement it; those live in the code, where readers can see them in context. Class names in backticks, method signatures, API call examples (`File.createNewFile()`, `fopen("wbx")`, `expect/actual`) inside prose are signs the rule is being expressed through implementation, not as a rule.
+A long-lived artifact describes a mechanism conceptually — what something is, why it exists, what invariants hold. It does not name the classes, methods, or library calls that implement it; those live in the code, where readers can see them in context. Class names in backticks, method signatures, and concrete API calls inside prose are signs the rule is being expressed through implementation, not as a rule.
 
 If you find a code symbol in a long-lived artifact, check whether the surrounding sentence carries the same meaning with the symbol removed. Almost always it does — the symbol was leakage from the writing session, not a load-bearing reference. Remove it. Keep a code symbol only when the rule is genuinely about that symbol (e.g. a glossary entry whose subject is the symbol, or a doc whose subject is the library binding).
 

--- a/docs/engineering/long-lived-artifacts.md
+++ b/docs/engineering/long-lived-artifacts.md
@@ -10,6 +10,12 @@ A long-lived artifact states what is / what to do / what equals — in present t
 
 If a rule is unreadable without referring to an incident, that's a weak formulation. Rewrite the rule; do not append the incident.
 
+## Code does not belong in long-lived artifacts
+
+A long-lived artifact describes a mechanism conceptually — what something is, why it exists, what invariants hold. It does not name the classes, methods, or library calls that implement it; those live in the code, where readers can see them in context. Class names in backticks, method signatures, API call examples (`File.createNewFile()`, `fopen("wbx")`, `expect/actual`) inside prose are signs the rule is being expressed through implementation, not as a rule.
+
+If you find a code symbol in a long-lived artifact, check whether the surrounding sentence carries the same meaning with the symbol removed. Almost always it does — the symbol was leakage from the writing session, not a load-bearing reference. Remove it. Keep a code symbol only when the rule is genuinely about that symbol (e.g. a glossary entry whose subject is the symbol, or a doc whose subject is the library binding).
+
 ## Inline examples must be synthetic, not incident-rooted
 
 Either generalise the *shape* of the error (contrast «principle catches this, but not this other thing that looks similar») so the example is synthetic and covers the class — or leave the example out entirely.


### PR DESCRIPTION
## Summary

Three systemic gaps surfaced during the retro on #282 / issue #258. Each is addressed by a small text edit in `.claude/agents/**` or `docs/engineering/**`.

**Gap 1 — `review-glossary` repeatedly required entries for code symbols.** Two iterations of the agent BLOCK-ed PR #282 demanding glossary entries for `UploadHandle`, `atomicCreateFile`, and `reserveDeduplicatedFile`. The user pushed back: «это код, а не термины». The agent's brief mapped «load-bearing noun» onto any recurring symbol; the admission rule was implicit.

**Fix.** New section in `docs/engineering/glossary-discipline.md` — *What qualifies as a term* — codifies the rule: a term must carry meaning outside code; Kotlin types, function names, API symbols, and implementation-technique labels do NOT qualify. `review-glossary.md` brief updated to reference it.

**Gap 2 — code symbols leaked into long-lived docs.** `file-transfer-wire.md` §Storage seam and `testing.md` carried class names, API references, and `expect/actual` jargon inside prose. The principle «docs describe mechanism, not code» was not codified in any single place.

**Fix.** New section in `docs/engineering/long-lived-artifacts.md` — *Code does not belong in long-lived artifacts* — states the rule and offers a verification heuristic («does the sentence carry the same meaning with the symbol removed?»).

**Gap 3 — no reviewer agent explicitly flagged code-in-prose.** `review-guides` covered comment density and doc-vs-code drift, but had no flaggable item for «class name in backticks inside docs prose». The class of violations was caught only by manual user review across multiple rounds.

**Fix.** Extended `review-guides.md` §8 with an explicit flaggable item for code symbols inside docs prose.

Closes nothing (retro PR).

## Test plan

- [ ] Next PR touching `docs/**` triggers `review-guides` flagging code symbols if present.
- [ ] Next PR introducing a new Kotlin type (without a corresponding domain concept) does NOT receive a `[REQUIRED]` from `review-glossary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)