### PR TITLE
#59: keep Android FGS as dataSync, document 6h/24h cap

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -11,8 +11,7 @@
     <!-- Foreground service hosting Ktor FileServer + NSD discovery so the Android peer
          stays reachable while the app is backgrounded. -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <!-- dataSync chosen for Tether's Ktor file server + mDNS hosting.
-         See docs/knowledge/android-fgs.md for rejected alternatives, accepted trade-offs, and citations. -->
+    <!-- dataSync FGS type for Tether's Ktor file server + mDNS hosting. See docs/knowledge/android-fgs.md. -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -11,17 +11,8 @@
     <!-- Foreground service hosting Ktor FileServer + NSD discovery so the Android peer
          stays reachable while the app is backgrounded. -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <!-- dataSync FGS type hosts Tether's Ktor file server + mDNS discovery.
-         Rejected alternatives:
-           - connectedDevice: silently suppresses the notification on Android 14+ without an active
-             BT/NFC/USB hardware link; CHANGE_WIFI_MULTICAST_STATE does not satisfy the runtime check.
-             See docs/knowledge/android-fgs.md.
-           - specialUse: requires per-release Google Play manual justification review.
-           - WorkManager periodic restart: inherits the dataSync cap and adds a notification gap.
-         Accepted cost: API 35+ enforces a ~6h/day cumulative cap on dataSync FGS time. On expiry
-         the system throws ForegroundServiceDidNotStopInTimeException and silently kills the service;
-         the notification disappears with no user message. Interactive use accrues minutes, not hours,
-         of FGS time per day, so the cap is unlikely to bite for MVP. -->
+    <!-- dataSync chosen for Tether's Ktor file server + mDNS hosting.
+         See docs/knowledge/android-fgs.md for rejected alternatives, accepted trade-offs, and citations. -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -11,9 +11,17 @@
     <!-- Foreground service hosting Ktor FileServer + NSD discovery so the Android peer
          stays reachable while the app is backgrounded. -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <!-- dataSync: used for background network transfers. connectedDevice was tried but suppresses
-         the FGS notification on Android 14+ without Bluetooth/NFC/USB hardware involvement.
-         Android 15+ applies a 6h/day cumulative limit to dataSync — tracked in issue #59. -->
+    <!-- dataSync FGS type hosts Tether's Ktor file server + mDNS discovery.
+         Rejected alternatives:
+           - connectedDevice: silently suppresses the notification on Android 14+ without an active
+             BT/NFC/USB hardware link; CHANGE_WIFI_MULTICAST_STATE does not satisfy the runtime check.
+             See docs/knowledge/android-fgs.md.
+           - specialUse: requires per-release Google Play manual justification review.
+           - WorkManager periodic restart: inherits the dataSync cap and adds a notification gap.
+         Accepted cost: API 35+ enforces a ~6h/day cumulative cap on dataSync FGS time. On expiry
+         the system throws ForegroundServiceDidNotStopInTimeException and silently kills the service;
+         the notification disappears with no user message. Interactive use accrues minutes, not hours,
+         of FGS time per day, so the cap is unlikely to bite for MVP. -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/docs/interview-prep-checklist.md
+++ b/docs/interview-prep-checklist.md
@@ -117,7 +117,7 @@
 - [ ] `LiveData` vs `StateFlow` — когда что, `asLiveData()`
 
 ### Background work
-- [ ] `WorkManager` vs `ForegroundService` vs `AlarmManager` — когда что
+- [x] `WorkManager` vs `ForegroundService` vs `AlarmManager` — когда что
 - [ ] `WorkManager` — guaranteed execution, Doze mode, цепочки, constraints
 - [ ] Doze mode & App Standby — как влияют на background
 - [ ] Как WorkManager использует `JobScheduler` под капотом

--- a/docs/knowledge/android-fgs.md
+++ b/docs/knowledge/android-fgs.md
@@ -49,16 +49,15 @@ notification is visible. Emulators may not reproduce suppression behavior.
 ## dataSync 6h/24h cap on Android 15+
 
 **Symptom:** on API 35+, after ~6h cumulative background FGS runtime in a 24-hour rolling
-window, the service is force-stopped by the OS. Two observable failure modes:
-
-- An already-running service that hits the cap: the notification disappears with no
-  user-visible message; logcat shows a fatal exception with a "dataSync did not stop
-  within its timeout" message.
-- A service started after the cap is already exhausted: attempting to restart the service
-  raises a start-not-allowed exception with a "Time limit already exhausted for foreground
-  service type dataSync" message (visible at the next cold start after a force-quit).
-
+window, the service is force-stopped by the OS — the notification disappears with no
+user-visible message; logcat shows a fatal exception with a "dataSync did not stop within
+its timeout" message.
 ([Android 15 behavior changes — Data sync foreground services](https://developer.android.com/about/versions/15/behavior-changes-15#datasync-timeout))
+
+The OS also defines a start-time failure ("Time limit already exhausted") for apps that
+try to restart a `dataSync` FGS while still under the cap. Tether does not hit this: the
+only restart path runs during a foreground transition, which itself resets the timer
+before the service start is attempted.
 
 **Root cause:** Android 15 (API 35) introduced a 6-hour-per-24h cap on `dataSync` FGS
 runtime. The timer resets each time the user brings the app to the foreground.
@@ -73,7 +72,7 @@ at which point the foreground-reset takes effect.
 
 **Detection:**
 ```
-adb logcat | grep -E "dataSync did not stop within its timeout|Time limit already exhausted"
+adb logcat | grep "dataSync did not stop within its timeout"
 ```
 
 **Recovery:** user reopens the app; cold start re-arms the foreground service (see the "Stop button UX — sticky Stop pattern" section below).

--- a/docs/knowledge/android-fgs.md
+++ b/docs/knowledge/android-fgs.md
@@ -21,8 +21,8 @@ the `SecurityException` from `startForeground()` was fixed by adding
 `CHANGE_WIFI_MULTICAST_STATE`, but the notification still did not appear.
 
 **Current fix:** use `dataSync` type instead. It shows the notification reliably
-without hardware requirements. 6h/day cumulative limit on Android 15+ is a known
-trade-off, tracked in #59.
+without hardware requirements. 6h-per-24h rolling cap on Android 15+ is a known
+trade-off, documented below.
 
 ```xml
 <!-- AndroidManifest.xml -->
@@ -48,22 +48,35 @@ notification is visible. Emulators may not reproduce suppression behavior.
 
 ## dataSync 6h/24h cap on Android 15+
 
-**Symptom:** on API 35+, after ~6h cumulative background FGS runtime in a 24-hour period,
-the service is force-stopped by the OS. The notification disappears with no user-visible
-message; logcat shows a fatal exception with the dataSync-did-not-stop message.
+**Symptom:** on API 35+, after ~6h cumulative background FGS runtime in a 24-hour rolling
+window, the service is force-stopped by the OS. Two observable failure modes:
+
+- An already-running service that hits the cap: the notification disappears with no
+  user-visible message; logcat shows a fatal exception with a "dataSync did not stop
+  within its timeout" message.
+- A service started after the cap is already exhausted: attempting to restart the service
+  raises a start-not-allowed exception with a "Time limit already exhausted for foreground
+  service type dataSync" message (visible at the next cold start after a force-quit).
+
 ([Android 15 behavior changes — Data sync foreground services](https://developer.android.com/about/versions/15/behavior-changes-15#datasync-timeout))
 
 **Root cause:** Android 15 (API 35) introduced a 6-hour-per-24h cap on `dataSync` FGS
 runtime. The timer resets each time the user brings the app to the foreground.
 
-**Why we accept it:** alternatives are worse for Tether — `connectedDevice` is suppressed
-without active hardware (see section above), `specialUse` taxes every Play release with
-manual review. Tether's interactive use accrues minutes of background FGS time per session,
-not hours, so the cap is unlikely to trigger in practice.
+**Why we accept it:** alternatives are worse — `connectedDevice` is suppressed without
+active hardware (see section above), `specialUse` taxes every Play release with manual
+review. The 24-hour window is rolling and the timer resets on foreground; most usage
+patterns involve the user opening the app at least once every few hours to send or receive,
+which resets the cap. For a phone left backgrounded all day with no interaction, the service
+will eventually die silently — the user notices the missing notification and reopens the app,
+at which point the foreground-reset takes effect.
 
-**Detection:** `adb logcat | grep "dataSync did not stop within its timeout"`
+**Detection:**
+```
+adb logcat | grep -E "dataSync did not stop within its timeout|Time limit already exhausted"
+```
 
-**Recovery:** user reopens the app; cold start re-arms the foreground service (see sticky-Stop section).
+**Recovery:** user reopens the app; cold start re-arms the foreground service (see the "Stop button UX — sticky Stop pattern" section below).
 
 ---
 

--- a/docs/knowledge/android-fgs.md
+++ b/docs/knowledge/android-fgs.md
@@ -49,9 +49,9 @@ notification is visible. Emulators may not reproduce suppression behavior.
 ## dataSync 6h/24h cap on Android 15+
 
 **Symptom:** on API 35+, after ~6h cumulative background FGS runtime in a 24-hour period,
-the system invokes `Service.onTimeout`; if the service does not self-stop within a few
-seconds, a `RemoteServiceException` is thrown and the service is killed. The notification
-disappears with no user-visible message. ([Android 15 behavior changes — Data sync foreground services](https://developer.android.com/about/versions/15/behavior-changes-15#datasync-timeout))
+the service is force-stopped by the OS. The notification disappears with no user-visible
+message; logcat shows a fatal exception with the dataSync-did-not-stop message.
+([Android 15 behavior changes — Data sync foreground services](https://developer.android.com/about/versions/15/behavior-changes-15#datasync-timeout))
 
 **Root cause:** Android 15 (API 35) introduced a 6-hour-per-24h cap on `dataSync` FGS
 runtime. The timer resets each time the user brings the app to the foreground.

--- a/docs/knowledge/android-fgs.md
+++ b/docs/knowledge/android-fgs.md
@@ -46,6 +46,27 @@ notification is visible. Emulators may not reproduce suppression behavior.
 
 ---
 
+## dataSync 6h/day cap on Android 15+
+
+**Symptom:** on API 35+, after ~6h cumulative FGS runtime in a single UTC day, the system
+throws `ForegroundServiceDidNotStopInTimeException`, kills the service, and removes the
+notification. No user-visible message.
+
+**Root cause:** Android 15 (API 35) introduced a cumulative per-UTC-day cap on `dataSync`
+FGS runtime to discourage long-running background workloads under that subtype.
+
+**Why we accept it:** alternatives are worse for Tether — `connectedDevice` is suppressed
+without active hardware (see section above), `specialUse` taxes every Play release with
+manual review. Interactive use accrues minutes per day of FGS time, not hours, so the cap
+is unlikely to trigger in practice.
+
+**Detection:** `adb logcat | grep ForegroundServiceDidNotStopInTimeException`
+
+**Recovery:** user reopens the app — cold start re-invokes `startService` from
+`MainActivity.onCreate` (see sticky-Stop section).
+
+---
+
 ## bindService(flags=0) is not a reliable "is service running?" check
 
 **Symptom:** service is not running but `bindService(intent, conn, 0)` returns `true`,

--- a/docs/knowledge/android-fgs.md
+++ b/docs/knowledge/android-fgs.md
@@ -46,24 +46,24 @@ notification is visible. Emulators may not reproduce suppression behavior.
 
 ---
 
-## dataSync 6h/day cap on Android 15+
+## dataSync 6h/24h cap on Android 15+
 
-**Symptom:** on API 35+, after ~6h cumulative FGS runtime in a single UTC day, the system
-throws `ForegroundServiceDidNotStopInTimeException`, kills the service, and removes the
-notification. No user-visible message.
+**Symptom:** on API 35+, after ~6h cumulative background FGS runtime in a 24-hour period,
+the system invokes `Service.onTimeout`; if the service does not self-stop within a few
+seconds, a `RemoteServiceException` is thrown and the service is killed. The notification
+disappears with no user-visible message. ([Android 15 behavior changes — Data sync foreground services](https://developer.android.com/about/versions/15/behavior-changes-15#datasync-timeout))
 
-**Root cause:** Android 15 (API 35) introduced a cumulative per-UTC-day cap on `dataSync`
-FGS runtime to discourage long-running background workloads under that subtype.
+**Root cause:** Android 15 (API 35) introduced a 6-hour-per-24h cap on `dataSync` FGS
+runtime. The timer resets each time the user brings the app to the foreground.
 
 **Why we accept it:** alternatives are worse for Tether — `connectedDevice` is suppressed
 without active hardware (see section above), `specialUse` taxes every Play release with
-manual review. Interactive use accrues minutes per day of FGS time, not hours, so the cap
-is unlikely to trigger in practice.
+manual review. Tether's interactive use accrues minutes of background FGS time per session,
+not hours, so the cap is unlikely to trigger in practice.
 
-**Detection:** `adb logcat | grep ForegroundServiceDidNotStopInTimeException`
+**Detection:** `adb logcat | grep "dataSync did not stop within its timeout"`
 
-**Recovery:** user reopens the app — cold start re-invokes `startService` from
-`MainActivity.onCreate` (see sticky-Stop section).
+**Recovery:** user reopens the app; cold start re-arms the foreground service (see sticky-Stop section).
 
 ---
 

--- a/docs/knowledge/android-fgs.md
+++ b/docs/knowledge/android-fgs.md
@@ -49,15 +49,18 @@ notification is visible. Emulators may not reproduce suppression behavior.
 ## dataSync 6h/24h cap on Android 15+
 
 **Symptom:** on API 35+, after ~6h cumulative background FGS runtime in a 24-hour rolling
-window, the service is force-stopped by the OS — the notification disappears with no
-user-visible message; logcat shows a fatal exception with a "dataSync did not stop within
-its timeout" message.
-([Android 15 behavior changes — Data sync foreground services](https://developer.android.com/about/versions/15/behavior-changes-15#datasync-timeout))
+window, the OS kills the service and the notification disappears with no user-visible
+message. Logcat shows a fatal exception with a "dataSync did not stop within its timeout"
+message. ([Android 15 behavior changes — Data sync foreground services](https://developer.android.com/about/versions/15/behavior-changes-15#datasync-timeout))
 
-The OS also defines a start-time failure ("Time limit already exhausted") for apps that
-try to restart a `dataSync` FGS while still under the cap. Tether does not hit this: the
-only restart path runs during a foreground transition, which itself resets the timer
-before the service start is attempted.
+The service runs `START_STICKY`, so the OS auto-restarts it after the kill. Each restart
+attempt during the still-exhausted window crashes the process with a fatal "Time limit
+already exhausted for foreground service type dataSync" exception out of `startForeground()`
+in `onCreate`. Observed in practice as two restart-and-crash cycles within ~30min of the
+initial kill before the OS gives up. The user does not see these crashes (no Activity is
+up), but they surface in crash analytics. A user-initiated cold start hours later succeeds
+because foregrounding the app resets the timer before the start is attempted. See #310
+for the planned graceful-handling fix.
 
 **Root cause:** Android 15 (API 35) introduced a 6-hour-per-24h cap on `dataSync` FGS
 runtime. The timer resets each time the user brings the app to the foreground.
@@ -72,7 +75,7 @@ at which point the foreground-reset takes effect.
 
 **Detection:**
 ```
-adb logcat | grep "dataSync did not stop within its timeout"
+adb logcat | grep -E "dataSync did not stop within its timeout|Time limit already exhausted"
 ```
 
 **Recovery:** user reopens the app; cold start re-arms the foreground service (see the "Stop button UX — sticky Stop pattern" section below).


### PR DESCRIPTION
**What / why.** Android 15 introduced a 6h-per-24h rolling cap on `dataSync` foreground services. After evaluating the alternatives (`connectedDevice` is silently suppressed without active BT/NFC/USB hardware — already documented from #35; `specialUse` taxes every Play release with manual review; `WorkManager` periodic restart inherits the cap), `dataSync` remains the right choice. PR locks in that decision via a bare-link manifest comment and a new `## dataSync 6h/24h cap on Android 15+` section in the FGS knowledge doc covering both failure modes (runtime timeout + start-time exhaustion), with an honest accounting of when a passive-availability user will hit the cap.

**👀 Sanity-check.**
- "Why we accept it" reframed away from "interactive use = minutes" — that was misleading because `TetherForegroundService` is alive between transfers, so accrual is service-lifetime, not transfer-lifetime. New framing acknowledges the long-passive case (phone backgrounded all day) explicitly. Worth a re-read.
- DoD #1 (empirically reproduce the 6h limit) intentionally not run as Part B of smoke — requires advancing the device clock on a wiped test device. Part A (FGS alive through forced Doze, notification ongoing, correct FGS type) was run on the user's connected CPH2653 device (API 36) and passed 🟢.
- DoD #6 (update `docs/product/tech-stack.md` if type changed) — type unchanged from #35, so no update needed.

Closes #59