### PR TITLE
#17: require upfront reading of project guides in skills and agents

### DIFF
--- a/.claude/agents/review-architecture.md
+++ b/.claude/agents/review-architecture.md
@@ -28,7 +28,7 @@ Always read:
 - `docs/engineering/architecture-principles.md` — the load-bearing rules and the explicitly-skipped ceremonies.
 - `docs/engineering/modules.md` — module boundaries and ownership.
 
-Read on demand:
+Read upfront and strictly comply when the diff falls into the matching area:
 - `docs/engineering/presentation-layer.md` — if diff touches presentation/UI/Decompose.
 - `docs/engineering/dependency-injection.md` — if diff adds/restructures wiring.
 - The feature spec in `docs/product/features/<slug>/` — if linked from the issue. The spec sometimes fixes architectural choices; deviations must be deliberate.

--- a/.claude/agents/review-guides.md
+++ b/.claude/agents/review-guides.md
@@ -5,7 +5,7 @@ tools: Bash, Read, Grep, Glob
 model: sonnet
 ---
 
-You check whether a PR follows the project's documented conventions. The conventions live in `CLAUDE.md` and `docs/engineering/*.md`. Read them on demand — do not assume from memory.
+You check whether a PR follows the project's documented conventions. The conventions live in `CLAUDE.md` and `docs/engineering/*.md`. Read them upfront and strictly enforce them — do not assume from memory.
 
 ## Inputs
 

--- a/.claude/agents/ux-expert.md
+++ b/.claude/agents/ux-expert.md
@@ -11,7 +11,7 @@ You translate a feature spec (`docs/product/features/<slug>/spec.md`) into a UX 
 
 The visual system (palette, typography, iconography, spacing) is locked. Reference patterns by their conceptual name (e.g. "the empty searching state of the device list", "the transfer-progress bar") — do not specify color values, density tokens, or icon families. `ui-expert` maps concepts to tokens.
 
-Full reference (loaded on demand): [`docs/product/design.md`](../../docs/product/design.md), [`docs/engineering/ui-style-guide.md`](../../docs/engineering/ui-style-guide.md).
+Full reference — read upfront and strictly comply: [`docs/product/design.md`](../../docs/product/design.md), [`docs/engineering/ui-style-guide.md`](../../docs/engineering/ui-style-guide.md).
 
 ## When invoked
 

--- a/.claude/skills/document/SKILL.md
+++ b/.claude/skills/document/SKILL.md
@@ -75,7 +75,7 @@ gh pr list --search "issue:#<N>" --state open --json number,isDraft,headRefName
 Before layer-classification and any dispatch — scan the doc corpus and pull up topically-matching artifacts. Recon is cheap: filenames are designed for topic-match.
 
 - **Product features** — `ls docs/product/features/` (+ `docs/product/features/README.md` as the index). If the task targets a specific feature — read its `spec.md` (and `ux-brief.md` if present).
-- **Product context** — `docs/product/*.md` covers broad product framing (vision, audience, roadmap, tech stack, security, …). Read lazily, only when you have conceptual doubt about scope, audience or timing relative to that framing.
+- **Product context** — `docs/product/*.md` covers broad product framing (vision, audience, roadmap, tech stack, security, …). Read upfront and strictly comply with that framing when shaping scope, audience and timing decisions.
 - **Engineering living docs** — `ls docs/engineering/*.md`. These are **present-tense rules** for their subsystems — comply with the ones whose topic matches the task.
 - **ADR** — `ls docs/engineering/adr/adr-*.md`. These are **why it was chosen**. For every ADR matching the task's topic, also read its **Revisit if** section and explicitly assess whether your work has tripped a trigger. If it has — the artifact layer for this task must include a reversal-update of the ADR (see `docs/engineering/adr/README.md` §Reversing an ADR).
 - **Knowledge** — `ls docs/knowledge/*.md`. Solved-problem write-ups; pull relevant overlaps so you don't duplicate formulations.

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -115,7 +115,7 @@ When delegating to /document: "This task is docs-only. Running `/document <N>` a
 Before planning and any dispatch — scan the doc corpus and pull up topically-matching artifacts. Recon is cheap: filenames are designed for topic-match.
 
 - **Product features** — `ls docs/product/features/` (+ `docs/product/features/README.md` as the index). If a slug matches our scope — read its `spec.md` (and `ux-brief.md` if present).
-- **Product context** — `docs/product/*.md` covers broad product framing (vision, audience, roadmap, tech stack, security, …). Read lazily, only when you have conceptual doubt about scope, audience or timing relative to that framing.
+- **Product context** — `docs/product/*.md` covers broad product framing (vision, audience, roadmap, tech stack, security, …). Read upfront and strictly comply with that framing when shaping scope, audience and timing decisions.
 - **Engineering living docs** — `ls docs/engineering/*.md`. These are **present-tense rules** for their subsystems — comply with the ones whose topic matches the task.
 - **ADR** — `ls docs/engineering/adr/adr-*.md`. These are **why it was chosen**. For every ADR matching the task's topic, also read its **Revisit if** section and explicitly assess whether your work has tripped a trigger. If it has — the plan either confirms the ADR (false trigger) or includes a reversal with its own sub-plan (see `docs/engineering/adr/README.md` §Reversing an ADR).
 - **Knowledge** — `ls docs/knowledge/*.md`. Solved-problem write-ups (platform quirks, library traps, workarounds) — check before starting so you don't debug from scratch something already recorded.


### PR DESCRIPTION
## Summary
- Replace lazy / on-demand framing for project-guide loading with "read upfront and strictly comply" in `/implement`, `/document`, `review-architecture`, `review-guides`, and `ux-expert`.

Relates to #17.

## Test plan
- [ ] No code touched; review the wording of the 5 changed prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)