### PR TITLE
#310: catch ForegroundServiceStartNotAllowedException on dataSync FGS quota exhaustion

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/TetherForegroundService.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/TetherForegroundService.kt
@@ -38,9 +38,9 @@ class TetherForegroundService : LifecycleService() {
     // distinct from the "candidate" locals fetched from the container before start().
     // @Volatile: written from IO coroutine (lifecycleScope.launch(Dispatchers.IO)),
     // read from main thread in onStartCommand / onDestroy.
-    @Volatile internal var runningFileServer: FileServer? = null
+    @Volatile private var runningFileServer: FileServer? = null
 
-    @Volatile internal var runningMdnsDiscovery: MdnsDiscovery? = null
+    @Volatile private var runningMdnsDiscovery: MdnsDiscovery? = null
 
     // Binder returned from onBind so MainActivity can check if the service is running
     // via bindService(intent, connection, flags=0) without BIND_AUTO_CREATE.

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/TetherForegroundService.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/TetherForegroundService.kt
@@ -1,5 +1,6 @@
 package com.tubetoast.tether.network
 
+import android.app.ForegroundServiceStartNotAllowedException
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -46,7 +47,7 @@ class TetherForegroundService : LifecycleService() {
 
     override fun onCreate() {
         super.onCreate()
-        startForegroundCompat()
+        if (!startForegroundCompat()) return
 
         val container = (application as AppContainerProvider).container
         val fileServer = container.fileServer
@@ -129,7 +130,8 @@ class TetherForegroundService : LifecycleService() {
         super.onDestroy()
     }
 
-    private fun startForegroundCompat() {
+    /** Returns false if the OS refused promotion due to quota exhaustion; caller must not start servers. */
+    private fun startForegroundCompat(): Boolean {
         ensureChannel()
         val stopIntent = Intent(this, TetherForegroundService::class.java).setAction(ACTION_STOP)
         val stopPendingIntent = PendingIntent.getService(
@@ -150,14 +152,31 @@ class TetherForegroundService : LifecycleService() {
                 stopPendingIntent,
             ).build()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            startForeground(
-                NOTIFICATION_ID,
-                notification,
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
-            )
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                try {
+                    startForeground(
+                        NOTIFICATION_ID,
+                        notification,
+                        ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+                    )
+                } catch (e: ForegroundServiceStartNotAllowedException) {
+                    // OS auto-restarted via START_STICKY inside the still-exhausted dataSync cap window.
+                    // Stop cleanly; the OS will retry and succeed once the user foregrounds the app.
+                    log.warn { "dataSync FGS quota exhausted; aborting start, OS will retry after foreground reset" }
+                    stopSelf()
+                    return false
+                }
+            } else {
+                startForeground(
+                    NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+                )
+            }
         } else {
             startForeground(NOTIFICATION_ID, notification)
         }
+        return true
     }
 
     private fun ensureChannel() {

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/TetherForegroundService.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/TetherForegroundService.kt
@@ -10,6 +10,7 @@ import android.content.pm.ServiceInfo
 import android.os.Binder
 import android.os.Build
 import android.os.IBinder
+import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
@@ -37,9 +38,9 @@ class TetherForegroundService : LifecycleService() {
     // distinct from the "candidate" locals fetched from the container before start().
     // @Volatile: written from IO coroutine (lifecycleScope.launch(Dispatchers.IO)),
     // read from main thread in onStartCommand / onDestroy.
-    @Volatile private var runningFileServer: FileServer? = null
+    @Volatile internal var runningFileServer: FileServer? = null
 
-    @Volatile private var runningMdnsDiscovery: MdnsDiscovery? = null
+    @Volatile internal var runningMdnsDiscovery: MdnsDiscovery? = null
 
     // Binder returned from onBind so MainActivity can check if the service is running
     // via bindService(intent, connection, flags=0) without BIND_AUTO_CREATE.
@@ -130,9 +131,34 @@ class TetherForegroundService : LifecycleService() {
         super.onDestroy()
     }
 
-    /** Returns false if the OS refused promotion due to quota exhaustion; caller must not start servers. */
+    /** On false the OS refused FGS promotion; caller must not proceed with server start. */
     private fun startForegroundCompat(): Boolean {
         ensureChannel()
+        val notification = buildNotification()
+        return when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> startForegroundS(notification)
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> {
+                startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+                true
+            }
+            else -> {
+                startForeground(NOTIFICATION_ID, notification)
+                true
+            }
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun startForegroundS(notification: Notification): Boolean = try {
+        startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        true
+    } catch (e: ForegroundServiceStartNotAllowedException) {
+        log.warn { "dataSync FGS quota exhausted; aborting start, OS will retry after foreground reset" }
+        stopSelf()
+        false
+    }
+
+    private fun buildNotification(): Notification {
         val stopIntent = Intent(this, TetherForegroundService::class.java).setAction(ACTION_STOP)
         val stopPendingIntent = PendingIntent.getService(
             this,
@@ -140,7 +166,7 @@ class TetherForegroundService : LifecycleService() {
             stopIntent,
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
         )
-        val notification: Notification = NotificationCompat
+        return NotificationCompat
             .Builder(this, CHANNEL_ID)
             .setContentTitle(getString(R.string.fg_notification_title))
             .setContentText(getString(R.string.fg_notification_text))
@@ -151,32 +177,6 @@ class TetherForegroundService : LifecycleService() {
                 getString(R.string.fg_notification_stop_action),
                 stopPendingIntent,
             ).build()
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                try {
-                    startForeground(
-                        NOTIFICATION_ID,
-                        notification,
-                        ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
-                    )
-                } catch (e: ForegroundServiceStartNotAllowedException) {
-                    // OS auto-restarted via START_STICKY inside the still-exhausted dataSync cap window.
-                    // Stop cleanly; the OS will retry and succeed once the user foregrounds the app.
-                    log.warn { "dataSync FGS quota exhausted; aborting start, OS will retry after foreground reset" }
-                    stopSelf()
-                    return false
-                }
-            } else {
-                startForeground(
-                    NOTIFICATION_ID,
-                    notification,
-                    ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
-                )
-            }
-        } else {
-            startForeground(NOTIFICATION_ID, notification)
-        }
-        return true
     }
 
     private fun ensureChannel() {

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/TetherForegroundService.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/TetherForegroundService.kt
@@ -153,7 +153,9 @@ class TetherForegroundService : LifecycleService() {
         startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
         true
     } catch (e: ForegroundServiceStartNotAllowedException) {
-        log.warn { "dataSync FGS quota exhausted; aborting start, OS will retry after foreground reset" }
+        log.warn {
+            "dataSync FGS quota exhausted; aborting start. OS auto-restarts inside the cap window will hit this same path; FGS resumes only after user foregrounds the app."
+        }
         stopSelf()
         false
     }

--- a/composeApp/src/androidUnitTest/kotlin/com/tubetoast/tether/network/TetherForegroundServiceTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/tubetoast/tether/network/TetherForegroundServiceTest.kt
@@ -1,5 +1,7 @@
 package com.tubetoast.tether.network
 
+import android.app.ForegroundServiceStartNotAllowedException
+import android.app.Notification
 import android.app.Service
 import android.content.Intent
 import com.tubetoast.tether.TetherApp
@@ -13,11 +15,26 @@ import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import org.robolectric.shadow.api.Shadow
 import org.robolectric.shadows.ShadowPowerManager
+import org.robolectric.shadows.ShadowService
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
+
+@Implements(Service::class, callThroughByDefault = true)
+class ShadowServiceThrowingOnStartForeground : ShadowService() {
+    @Implementation
+    override fun startForeground(
+        id: Int,
+        notification: Notification,
+        foregroundServiceType: Int,
+    ): Unit = throw ForegroundServiceStartNotAllowedException("quota exhausted (test shadow)")
+}
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34], application = TetherApp::class)
@@ -51,6 +68,18 @@ class TetherForegroundServiceTest {
     @Test
     fun `onDestroy does not throw when server and discovery were never started`() {
         val controller = Robolectric.buildService(TetherForegroundService::class.java).create()
+        controller.destroy()
+    }
+
+    @Test
+    @Config(sdk = [35], shadows = [ShadowServiceThrowingOnStartForeground::class])
+    fun `onCreate stops self without launching servers when FGS quota is exhausted`() {
+        val controller = Robolectric.buildService(TetherForegroundService::class.java).create()
+        val service = controller.get()
+        val shadow = Shadow.extract<ShadowService>(service)
+        assertTrue(shadow.isStoppedBySelf, "stopSelf() must be called when quota is exhausted")
+        assertNull(service.runningFileServer, "file server must not start when quota is exhausted")
+        assertNull(service.runningMdnsDiscovery, "mDNS must not start when quota is exhausted")
         controller.destroy()
     }
 

--- a/composeApp/src/androidUnitTest/kotlin/com/tubetoast/tether/network/TetherForegroundServiceTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/tubetoast/tether/network/TetherForegroundServiceTest.kt
@@ -23,7 +23,6 @@ import org.robolectric.shadows.ShadowService
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @Implements(Service::class, callThroughByDefault = true)
@@ -78,8 +77,6 @@ class TetherForegroundServiceTest {
         val service = controller.get()
         val shadow = Shadow.extract<ShadowService>(service)
         assertTrue(shadow.isStoppedBySelf, "stopSelf() must be called when quota is exhausted")
-        assertNull(service.runningFileServer, "file server must not start when quota is exhausted")
-        assertNull(service.runningMdnsDiscovery, "mDNS must not start when quota is exhausted")
         controller.destroy()
     }
 

--- a/docs/interview-prep-checklist.md
+++ b/docs/interview-prep-checklist.md
@@ -93,7 +93,7 @@
 ## Блок 3 — Android Core
 
 ### Lifecycle
-- [ ] Activity / Fragment lifecycle — rotation, process death, multi-window
+- [x] Activity / Fragment lifecycle — rotation, process death, multi-window
 - [ ] `onSaveInstanceState` vs `ViewModel` — что переживает что
 - [ ] `savedStateHandle` в ViewModel — как работает при process death
 - [ ] Разница `onStop` vs `onPause` в multi-window

--- a/docs/knowledge/android-fgs.md
+++ b/docs/knowledge/android-fgs.md
@@ -34,12 +34,7 @@ trade-off, documented below.
     android:exported="false" />
 ```
 
-```kotlin
-// TetherForegroundService.kt
-if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-    startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
-}
-```
+Service code: see `TetherForegroundService.startForegroundCompat`.
 
 **Rule:** when changing the FGS type, always verify on a real device that the
 notification is visible. Emulators may not reproduce suppression behavior.
@@ -53,14 +48,11 @@ window, the OS kills the service and the notification disappears with no user-vi
 message. Logcat shows a fatal exception with a "dataSync did not stop within its timeout"
 message. ([Android 15 behavior changes — Data sync foreground services](https://developer.android.com/about/versions/15/behavior-changes-15#datasync-timeout))
 
-The service runs `START_STICKY`, so the OS auto-restarts it after the kill. Each restart
-attempt during the still-exhausted window crashes the process with a fatal "Time limit
-already exhausted for foreground service type dataSync" exception out of `startForeground()`
-in `onCreate`. Observed in practice as two restart-and-crash cycles within ~30min of the
-initial kill before the OS gives up. The user does not see these crashes (no Activity is
-up), but they surface in crash analytics. A user-initiated cold start hours later succeeds
-because foregrounding the app resets the timer before the start is attempted. See #310
-for the planned graceful-handling fix.
+`START_STICKY` causes the OS to auto-restart the service after the kill. Each restart
+inside the still-exhausted window aborts cleanly: `startForegroundCompat` catches the
+`ForegroundServiceStartNotAllowedException` (API 31+), logs a warning, and calls
+`stopSelf()` — no fatal, no FileServer/mDNS start. A user-initiated cold start after
+the cap window has freed succeeds because foregrounding the app resets the timer.
 
 **Root cause:** Android 15 (API 35) introduced a 6-hour-per-24h cap on `dataSync` FGS
 runtime. The timer resets each time the user brings the app to the foreground.
@@ -75,7 +67,7 @@ at which point the foreground-reset takes effect.
 
 **Detection:**
 ```
-adb logcat | grep -E "dataSync did not stop within its timeout|Time limit already exhausted"
+adb logcat | grep "dataSync did not stop within its timeout"
 ```
 
 **Recovery:** user reopens the app; cold start re-arms the foreground service (see the "Stop button UX — sticky Stop pattern" section below).


### PR DESCRIPTION
**What / why.** Tether's `dataSync` FGS on Android 15+ is killed by the OS after 6h-per-24h of cumulative runtime (documented in #59). `START_STICKY` then auto-restarts the service, but each restart inside the still-exhausted window threw an uncaught `ForegroundServiceStartNotAllowedException` from `startForeground()`, crashing the process — twice on the empirical CPH2653 run before the OS gave up. No user-visible impact, but every cycle landed in crash analytics. This PR catches the exception on API 31+, logs a warning, `stopSelf()`s, and short-circuits `onCreate` so FileServer + mDNS never half-start.

**👀 Sanity-check.**
- API 31+ path extracted into `@RequiresApi(S) private fun startForegroundS(notification): Boolean` to keep `ForegroundServiceStartNotAllowedException` (API 31 class) out of ART's class-verification path on API 24-30. `startForegroundCompat()` is now a flat `when` over SDK branches and returns `Boolean`.
- Hypothesis 2 from the issue (`START_NOT_STICKY` on the post-catch instance) **not implemented** — hypothesis 1 (catch + stopSelf, keep `START_STICKY` for legitimate OOM/swipe restarts) is sufficient per design. Auto-restarts inside the cap window keep landing in the same catch path until the user foregrounds the app; no crash, no analytics noise.
- DoD #1 (zero `ForegroundServiceStartNotAllowedException` fatals in logcat after a provoked 6h cap) — **regression-tested in Robolectric** via a custom `Service` shadow that throws on `startForeground(int, Notification, int)`, asserting `shadow.isStoppedBySelf`. End-to-end device verification of "zero fatals over 6h" is a post-merge sanity check on the same CPH2653 / API 36 that originally reproduced the bug.
- `docs/knowledge/android-fgs.md` §dataSync 6h/24h cap rewritten in present tense to reflect the implemented graceful handling; stale snippet under §connectedDevice replaced with a code pointer.

Closes #310