### PR TITLE
#17: note that KtLint also strips unused imports

### DIFF
--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -23,7 +23,7 @@ You write code for the Tether KMP project. You are an executor, not a planner. I
 
 - **Minimal comments.** Before writing a comment, try extracting the block into a named private method — the name often removes the need. Comment only where code cannot express intent (deliberately swallowed exception, non-obvious external-library invariant). No narrative comments restating method names.
 - **KDoc only for contracts.** Nullable semantics, non-obvious pre/postconditions, non-obvious WHY. Don't restate the signature.
-- **Kotlin official style.** KtLint enforces — do not run it manually; do not hand-fix style; just commit.
+- **Kotlin official style.** KtLint enforces — do not run it manually; do not hand-fix style; do not hand-remove unused imports (KtLint clears them); just commit.
 - **No backwards-compat shims.** If something is dead, delete it — don't leave `_unused`, re-exports, or "removed" comments.
 
 ## When fixing review findings (symmetry pass)

--- a/.claude/agents/review-guides.md
+++ b/.claude/agents/review-guides.md
@@ -40,7 +40,7 @@ Always read `CLAUDE.md`. Then read the engineering doc that maps to the diff:
 
 ## What you do NOT check
 
-- Style/formatting → KtLint (skip entirely)
+- Style/formatting and unused imports → KtLint (skip entirely)
 - Correctness/concurrency → `review-correctness`
 - Test quality → `review-tests`
 - Platform expect/actual completeness → `review-platform`

--- a/.claude/agents/ui-expert.md
+++ b/.claude/agents/ui-expert.md
@@ -88,4 +88,4 @@ These conventions ensure `./gradlew :composeApp:recordRoborazziDebug -q` can ren
 
 - Backend / network / discovery logic — that's not UI.
 - Make business decisions ("should the user see X here?"). If the spec doesn't say, ask back; don't invent UX.
-- Hand-fix KtLint style — the git hook handles it.
+- Hand-fix KtLint style or hand-remove unused imports — the git hook handles both.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ To pull main into the branch — `/rebase` (rebases onto fresh main and shows wh
 
 ## Common commands
 
-Run all Gradle commands with `-q`. Do not run KtLint manually — the git hook does it automatically on commit; do not fix style errors by hand either.
+Run all Gradle commands with `-q`. Do not run KtLint manually — the git hook does it automatically on commit; do not fix style errors by hand either. Do not clean up unused imports by hand either — KtLint removes them on commit.
 
 Full list of commands by platform — [README.md](README.md). Test commands — [`testing.md`](docs/engineering/testing.md). Parallel run of all targets — `scripts/run-all.sh`.
 

--- a/README.md
+++ b/README.md
@@ -98,4 +98,4 @@ Tests:
 ./gradlew allTests -q
 ```
 
-KtLint runs automatically via a git hook — do not invoke it manually.
+KtLint runs automatically via a git hook — do not invoke it manually, do not hand-fix style errors, and do not remove unused imports by hand (KtLint clears them too).


### PR DESCRIPTION
## Summary
- Extend existing "do not hand-fix KtLint style" guidance to also cover unused imports, which the pre-commit KtLint hook removes automatically.
- Touched: CLAUDE.md, README.md, and the coder / ui-expert / review-guides agents — the places that already mention the KtLint hook.

## Test plan
- [x] docs-only change; CI green
- [x] no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)