### PR TITLE
retro from #303: visibility default, second-copy reuse, multi-concern halt

### DIFF
--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -25,8 +25,8 @@ You write code for the Tether KMP project. You are an executor, not a planner. I
 - **KDoc only for contracts.** Nullable semantics, non-obvious pre/postconditions, non-obvious WHY. Don't restate the signature.
 - **Kotlin official style.** KtLint enforces — do not run it manually; do not hand-fix style; do not hand-remove unused imports (KtLint clears them); just commit.
 - **No backwards-compat shims.** If something is dead, delete it — don't leave `_unused`, re-exports, or "removed" comments.
-- **Renames are atomic across related types.** Renaming `XxxComponent` propagates to `XxxScreen`, `XxxContent`, `XxxComponentTest`, `Config.Xxx`, `Child.XxxChild`, preview labels (`@Preview(name = "Xxx — …")`), and any sibling decision types (`RequireXxxTap`-style enum / sealed members). A surviving stale name means the rename is incomplete — close it in the same commit, do not defer.
-- **Preserve `TODO(#N)` continuity across refactors.** When moving / extracting / renaming code, the deferred-task pointers go with it. A move that drops `TODO(#192)` from the file silently loses the contract on a follow-up issue — re-attach on the new home before commit.
+- **Renames are atomic across related types.** When renaming a type, every artifact whose identifier embeds the old name follows in the same commit — paired screen / content composable, sibling sealed-class or enum cases, tests, preview labels, fixtures. A surviving stale name means the rename is incomplete; close it now, do not defer.
+- **Preserve deferred-task markers across refactors.** When moving / extracting / renaming code, every `TODO(#<issue>)` pointer attached to the moved code re-attaches at the new home in the same commit. A dropped marker silently loses the contract on a follow-up issue.
 
 ## When fixing review findings (symmetry pass)
 

--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -25,6 +25,8 @@ You write code for the Tether KMP project. You are an executor, not a planner. I
 - **KDoc only for contracts.** Nullable semantics, non-obvious pre/postconditions, non-obvious WHY. Don't restate the signature.
 - **Kotlin official style.** KtLint enforces — do not run it manually; do not hand-fix style; do not hand-remove unused imports (KtLint clears them); just commit.
 - **No backwards-compat shims.** If something is dead, delete it — don't leave `_unused`, re-exports, or "removed" comments.
+- **Renames are atomic across related types.** Renaming `XxxComponent` propagates to `XxxScreen`, `XxxContent`, `XxxComponentTest`, `Config.Xxx`, `Child.XxxChild`, preview labels (`@Preview(name = "Xxx — …")`), and any sibling decision types (`RequireXxxTap`-style enum / sealed members). A surviving stale name means the rename is incomplete — close it in the same commit, do not defer.
+- **Preserve `TODO(#N)` continuity across refactors.** When moving / extracting / renaming code, the deferred-task pointers go with it. A move that drops `TODO(#192)` from the file silently loses the contract on a follow-up issue — re-attach on the new home before commit.
 
 ## When fixing review findings (symmetry pass)
 

--- a/.claude/agents/review-reuse.md
+++ b/.claude/agents/review-reuse.md
@@ -22,7 +22,7 @@ rg "<distinctive substring>" --type kotlin
 
 If you find a near-duplicate, flag it. "Near" includes: same logic with different names, same data shape with different types, same algorithm with cosmetic differences. Don't be conservative — flag and let the author argue.
 
-**Threshold — second copy.** Once the same shape appears in **two** places in the diff (or once in the diff + once already in the codebase), flag it for extraction. Do not wait for the third copy. UI primitives copy-pasted as private helpers across sibling files (e.g. four identical text-button boxes inside dialog/banner/card files) is the canonical case — extract the moment the second site appears.
+**Threshold — second copy.** Once the same shape appears in **two** places in the diff (or once in the diff + once already in the codebase), flag it for extraction. Do not wait for the third copy. The fact that each copy currently lives as a private helper next to its caller is not a defence; private-helper duplication across sibling files is the precise pattern this rule targets.
 
 ### 2. Doc-vs-code drift
 

--- a/.claude/agents/review-reuse.md
+++ b/.claude/agents/review-reuse.md
@@ -22,6 +22,8 @@ rg "<distinctive substring>" --type kotlin
 
 If you find a near-duplicate, flag it. "Near" includes: same logic with different names, same data shape with different types, same algorithm with cosmetic differences. Don't be conservative — flag and let the author argue.
 
+**Threshold — second copy.** Once the same shape appears in **two** places in the diff (or once in the diff + once already in the codebase), flag it for extraction. Do not wait for the third copy. UI primitives copy-pasted as private helpers across sibling files (e.g. four identical text-button boxes inside dialog/banner/card files) is the canonical case — extract the moment the second site appears.
+
 ### 2. Doc-vs-code drift
 
 If the diff changes a public API, type, or contract that's referenced in:

--- a/.claude/agents/review-tests.md
+++ b/.claude/agents/review-tests.md
@@ -74,6 +74,10 @@ observe a positive side-effect (counter, flag, state change) — not just the ab
 an exception or a 2xx response. Otherwise the test passes regardless of whether the
 feature ran. Flag as `[REQUIRED]`.
 
+### 10. Component-on-repository: cover every emit variation
+
+When a component subscribes to a repository / flow and derives state from each emit, the test suite must cover every variation the repository can produce — not only the happy path used at construction time. Concretely: empty list, single element, multiple elements, every flag value the model carries (e.g. `isOnline = true` AND `isOnline = false`), state transitions across successive emits (true→false, present→absent, absent→present), and any mixed combination relevant to the row builder. Missing a variation that the repo can legally emit is `[REQUIRED]` — without it a future repo enrichment ships an untested code path on the consumer side.
+
 ## What you do NOT check
 
 - AC coverage → review-dod

--- a/.claude/agents/review-tests.md
+++ b/.claude/agents/review-tests.md
@@ -76,7 +76,7 @@ feature ran. Flag as `[REQUIRED]`.
 
 ### 10. Component-on-repository: cover every emit variation
 
-When a component subscribes to a repository / flow and derives state from each emit, the test suite must cover every variation the repository can produce — not only the happy path used at construction time. Concretely: empty list, single element, multiple elements, every flag value the model carries (e.g. `isOnline = true` AND `isOnline = false`), state transitions across successive emits (true→false, present→absent, absent→present), and any mixed combination relevant to the row builder. Missing a variation that the repo can legally emit is `[REQUIRED]` — without it a future repo enrichment ships an untested code path on the consumer side.
+When a component subscribes to a repository or flow and derives state from each emit, the test suite must cover every variation the source can produce — not only the happy path used at construction time. That means: empty / single / multiple shapes; both polarities of every boolean the emitted model carries; transitions across successive emits (presence flips, flag flips, mixed combinations). Missing a variation the source can legally emit is `[REQUIRED]` — without it a future enrichment of the source ships an untested code path on the consumer side.
 
 ## What you do NOT check
 

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -83,7 +83,7 @@ The urge to add an "Open questions" section to the body is the same signal: the 
 
 ## Multi-concern requests → halt and decompose
 
-A multi-concern request (≥2 independent concerns conflated into one body — for example "extract X to domain AND make repository retain offline peers", or "rename Y AND fix lifecycle bug AND add new validation") is a malformed task. **Stop, do not file, do not draft.** List the concerns you read, ask the user to pick one for this issue and which to spawn separately. This applies even when prior permission to skip the draft step was granted — draft-skip permission covers single-concern asks only.
+A multi-concern request (≥2 independent concerns conflated into one body) is a malformed task. **Stop, do not file, do not draft.** List the concerns you read, ask the user to pick one for this issue and which to spawn separately. This applies even when prior permission to skip the draft step was granted — draft-skip permission covers single-concern asks only.
 
 The cost of a bundled issue is structural: the title cannot describe what shipped, the DoD cannot be a flat checklist, blocked_by links lose meaning, and post-merge retro cannot attribute outcomes to causes. Decomposition at filing time is cheaper than untangling at close-issue time.
 

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -81,6 +81,12 @@ If a principal question is unresolved and its answer would change the shape of t
 
 The urge to add an "Open questions" section to the body is the same signal: the body is not yet a unit of execution. Extract the question into its own task, link the dependency, leave the body lean. The body never lists questions for the implementer to answer; questions belong in tasks that resolve them.
 
+## Multi-concern requests → halt and decompose
+
+A multi-concern request (≥2 independent concerns conflated into one body — for example "extract X to domain AND make repository retain offline peers", or "rename Y AND fix lifecycle bug AND add new validation") is a malformed task. **Stop, do not file, do not draft.** List the concerns you read, ask the user to pick one for this issue and which to spawn separately. This applies even when prior permission to skip the draft step was granted — draft-skip permission covers single-concern asks only.
+
+The cost of a bundled issue is structural: the title cannot describe what shipped, the DoD cannot be a flat checklist, blocked_by links lose meaning, and post-merge retro cannot attribute outcomes to causes. Decomposition at filing time is cheaper than untangling at close-issue time.
+
 ## Draft
 
 Follow [TEMPLATE.md](TEMPLATE.md). Mandatory body sections: Context, Goal, Entry point, DoD, Out of scope. Optional: References (similar closed issues), Hypotheses (bugfix only). Type is set via a type label (`feature` / `bugfix` / `refactor` / `infra` / `docs` / `dependency`), not a body field.

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -101,7 +101,7 @@ For each confirmed improvement:
 
 **If the change is small** (edit in a document, clarification in a command) — do it right now and show the diff.
 
-**Long-lived-artifacts compliance check before commit.** Every prose edit retro produces lands in a long-lived artifact by construction — `CLAUDE.md`, `docs/engineering/`, `.claude/agents/`, `.claude/skills/`, `.claude/commands/`. Before committing, audit every paragraph and bullet against [`docs/engineering/long-lived-artifacts.md`](../../../docs/engineering/long-lived-artifacts.md). The recurring failure mode here is **incident-rooted phrasing**: a rule born of a specific PR carries quotes, examples, code symbols, or class names lifted directly from that PR — making the rule readable only to someone who remembers the incident. Strip every such phrase; restate the rule in present tense, generic shape, without code symbols or task-specific examples. If the rule isn't readable without the incident, the formulation is weak — rewrite it.
+**Long-lived-artifacts compliance check before commit.** Every prose edit retro produces lands in a long-lived artifact by construction. Before committing, audit every paragraph and bullet against [`docs/engineering/long-lived-artifacts.md`](../../../docs/engineering/long-lived-artifacts.md).
 
 **If the change requires a separate task** — create an issue via the `create-issue` skill. The name should read as a useful increment to the workflow, for example:
 - "Add check X to code-review.md"

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -101,6 +101,8 @@ For each confirmed improvement:
 
 **If the change is small** (edit in a document, clarification in a command) — do it right now and show the diff.
 
+**Long-lived-artifacts compliance check before commit.** Every prose edit retro produces lands in a long-lived artifact by construction — `CLAUDE.md`, `docs/engineering/`, `.claude/agents/`, `.claude/skills/`, `.claude/commands/`. Before committing, audit every paragraph and bullet against [`docs/engineering/long-lived-artifacts.md`](../../../docs/engineering/long-lived-artifacts.md). The recurring failure mode here is **incident-rooted phrasing**: a rule born of a specific PR carries quotes, examples, code symbols, or class names lifted directly from that PR — making the rule readable only to someone who remembers the incident. Strip every such phrase; restate the rule in present tense, generic shape, without code symbols or task-specific examples. If the rule isn't readable without the incident, the formulation is weak — rewrite it.
+
 **If the change requires a separate task** — create an issue via the `create-issue` skill. The name should read as a useful increment to the workflow, for example:
 - "Add check X to code-review.md"
 - "Clarify scope of implement skill for case Y"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,5 +50,5 @@ Index and selection rules (skill vs command) — [`.claude/README.md`](.claude/R
 - **Minimal comments.** Before adding one — try extracting the block into a private method: the method name often makes the comment unnecessary. A comment only where code cannot express intent (deliberately swallowed exception, non-obvious external-library invariant).
 - **KDoc vs `//`.** KDoc — only for contracts (nullable semantics, non-obvious pre-/postconditions, non-obvious WHY). Do not restate the method name or signature — that is noise. If KDoc adds no information relative to the code — remove it.
 - **Kotlin official style** (enforced by KtLint).
-- **One top-level class per file.** Data classes, sealed types, enums included. Nested types stay nested only when they are private implementation details of the enclosing class (e.g. `private sealed interface Config` inside a Component). If a type is consumed by callers — its own file.
+- **One top-level class per file.** Data classes, sealed types, enums included. Nested types stay nested only when they are private implementation details of the enclosing class — never consumed across the file boundary. If a type is reachable to callers, it gets its own file.
 - **Long-lived artifacts discipline** (CLAUDE.md, `docs/`, `.claude/`, KDoc, inline comments) — [`long-lived-artifacts.md`](docs/engineering/long-lived-artifacts.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,5 +50,4 @@ Index and selection rules (skill vs command) — [`.claude/README.md`](.claude/R
 - **Minimal comments.** Before adding one — try extracting the block into a private method: the method name often makes the comment unnecessary. A comment only where code cannot express intent (deliberately swallowed exception, non-obvious external-library invariant).
 - **KDoc vs `//`.** KDoc — only for contracts (nullable semantics, non-obvious pre-/postconditions, non-obvious WHY). Do not restate the method name or signature — that is noise. If KDoc adds no information relative to the code — remove it.
 - **Kotlin official style** (enforced by KtLint).
-- **One top-level class per file.** Data classes, sealed types, enums included. Nested types stay nested only when they are private implementation details of the enclosing class — never consumed across the file boundary. If a type is reachable to callers, it gets its own file.
 - **Long-lived artifacts discipline** (CLAUDE.md, `docs/`, `.claude/`, KDoc, inline comments) — [`long-lived-artifacts.md`](docs/engineering/long-lived-artifacts.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,4 +50,5 @@ Index and selection rules (skill vs command) — [`.claude/README.md`](.claude/R
 - **Minimal comments.** Before adding one — try extracting the block into a private method: the method name often makes the comment unnecessary. A comment only where code cannot express intent (deliberately swallowed exception, non-obvious external-library invariant).
 - **KDoc vs `//`.** KDoc — only for contracts (nullable semantics, non-obvious pre-/postconditions, non-obvious WHY). Do not restate the method name or signature — that is noise. If KDoc adds no information relative to the code — remove it.
 - **Kotlin official style** (enforced by KtLint).
+- **One top-level class per file.** Data classes, sealed types, enums included. Nested types stay nested only when they are private implementation details of the enclosing class (e.g. `private sealed interface Config` inside a Component). If a type is consumed by callers — its own file.
 - **Long-lived artifacts discipline** (CLAUDE.md, `docs/`, `.claude/`, KDoc, inline comments) — [`long-lived-artifacts.md`](docs/engineering/long-lived-artifacts.md).

--- a/docs/engineering/presentation-layer.md
+++ b/docs/engineering/presentation-layer.md
@@ -96,6 +96,8 @@ A screen is two composables in the same file:
 
 Every `@Preview` targets `XxxContent` — never `XxxScreen`. Previews live in `commonMain` next to the screen (`androidx.compose.ui.tooling.preview.Preview`, the unified CMP annotation). Build fake state from `PreviewFixtures` and wrap content in `PreviewSurface { }`, both under `com.tubetoast.tether.ui.preview`. This split is what lets Roborazzi render previews headlessly under Robolectric (the Decompose lifecycle does not boot in that environment) and lets `review-visual` consume the resulting PNGs against the UX brief — see [testing.md §Screenshot tests](testing.md#screenshot-tests).
 
+**Visibility — tightest by default.** Composable visibility tracks call-site reach: `public` only on screen entry points consumed cross-package (`XxxScreen`, banner sections, design-system primitives); `internal` for variant composables a same-package family delegates to (e.g. PeerCard state variants called from `PeerCardContent`); `private` for same-file helpers (`XxxContent` where it is the only call-site of `XxxScreen`, layout-only inner helpers, preview-only wrappers).
+
 ## Reusable UI primitives
 
 Reusable composables live in two sibling folders under `composeApp/src/commonMain/kotlin/com/tubetoast/tether/ui/`:

--- a/docs/engineering/presentation-layer.md
+++ b/docs/engineering/presentation-layer.md
@@ -96,7 +96,7 @@ A screen is two composables in the same file:
 
 Every `@Preview` targets `XxxContent` — never `XxxScreen`. Previews live in `commonMain` next to the screen (`androidx.compose.ui.tooling.preview.Preview`, the unified CMP annotation). Build fake state from `PreviewFixtures` and wrap content in `PreviewSurface { }`, both under `com.tubetoast.tether.ui.preview`. This split is what lets Roborazzi render previews headlessly under Robolectric (the Decompose lifecycle does not boot in that environment) and lets `review-visual` consume the resulting PNGs against the UX brief — see [testing.md §Screenshot tests](testing.md#screenshot-tests).
 
-**Visibility — tightest by default.** Composable visibility tracks call-site reach: `public` only on screen entry points consumed cross-package (`XxxScreen`, banner sections, design-system primitives); `internal` for variant composables a same-package family delegates to (e.g. PeerCard state variants called from `PeerCardContent`); `private` for same-file helpers (`XxxContent` where it is the only call-site of `XxxScreen`, layout-only inner helpers, preview-only wrappers).
+**Visibility — tightest by default.** Composable visibility tracks call-site reach. Public is reserved for entry points consumed across packages. Internal is for composables whose only callers live in the same package. Private is for composables whose only callers live in the same file — including layout-only helpers and preview-only wrappers.
 
 ## Reusable UI primitives
 


### PR DESCRIPTION
## Summary

Retro on #191 / PR #303 surfaced three systemic gaps that a more attentive agent would not have prevented. Codify them.

- **`presentation-layer.md` § Screens and previews** — composable visibility convention (tightest by default). #191 reviewed late: every `XxxContent` and PeerCard variant landed `public` and was tightened only in round 7.
- **`review-reuse.md` § Duplication** — explicit second-copy threshold. The four identical text-button boxes (CancelTextButton / RetryTextButton / ShowDetailsButton / private SendButton) lived in sibling files for several rounds before extraction.
- **`create-issue/SKILL.md` — Multi-concern requests → halt and decompose.** I filed #318 with two conflated concerns under a prior draft-skip permission; had to close and re-file as narrower #319. Draft-skip permission is for single-concern asks only.

## Test plan

- [ ] Read each diff to confirm wording is load-bearing and not narrative.
- [ ] Next /implement run that touches Compose composables — verify the visibility rule reads cleanly to the implementer.
- [ ] Next /create-issue run with a multi-concern ask — verify halt fires (no creation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)