### PR TITLE
#309: auto-send to sole online paired peer on share-sheet entry

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -226,15 +226,15 @@ If a device is present:
    ```
    If emulator and IP is `10.0.2.x` — host access via `adb forward tcp:18080 tcp:$ANDROID_PORT` and `localhost:18080`. For a physical device — directly `$ANDROID_IP:$ANDROID_PORT`.
 6. **`/health` sanity:** `curl -sf http://$ANDROID_IP:$ANDROID_PORT/health` → `Tether OK`. This is the only place where curl is acceptable — endpoint sanity, not a user flow.
-7. **Cross-discovery with timing:** poll the Desktop CLI log for `Tether-<MODEL>`. Delta from `NSD_READY_MS`, not from `am start`:
+7. **Cross-discovery with timing:** parse the Desktop CLI's `[peers]` line by the Android device's IP — Android advertises under the device name (`CPH2653`, `Pixel 7`, vendor-specific), not under any `Tether-*` prefix. Match the entry that ends with `@$ANDROID_IP:port` and strip everything after `@`:
    ```bash
    for i in $(seq 1 30); do
      sleep 1
-     grep -E "\[peers\] .*Tether-" $LOG_A | grep -v "none" | tail -1 | grep -q . && break
+     grep -aE "\[peers\] .*@${ANDROID_IP}:" $LOG_A | tail -1 | grep -q . && break
    done
    NOW_MS=$(python3 -c "import time; print(int(time.time() * 1000))")
    DELTA_MS=$((NOW_MS - NSD_READY_MS))
-   ANDROID_NAME=$(grep -oE 'Tether-[A-Za-z0-9_]+' $LOG_A | head -1)
+   ANDROID_NAME=$(grep -aE "\[peers\]" $LOG_A | tail -1 | grep -oE '[^, ]+@'"$ANDROID_IP" | head -1 | sed 's/@.*//')
    echo "cross-discovery: ${DELTA_MS}ms, peer=$ANDROID_NAME"
    ```
    In the report: `Android | cross-discovery | ✓ PASS | 250 ms` — network-propagation + JmDNS resolve.
@@ -297,8 +297,12 @@ Otherwise:
    ```bash
    IOS_NAME=""
    for i in $(seq 1 30); do
+     # `dns-sd -B` prints each match as a tab-separated line ending with the instance name;
+     # the name is the trailing token after the last tab. The previous regex `[…]*iPhone[…]*`
+     # captured leading junk (`tcp.        iPhone 17 Pro`) and broke the subsequent TXT query.
      IOS_NAME=$( ( dns-sd -B _tether._tcp local. & DNSSD=$!; sleep 2; kill $DNSSD 2>/dev/null ) \
-       | grep -oE '[A-Za-z0-9 .-]*iPhone[A-Za-z0-9 .-]*' | head -1 | tr -d '\r')
+       | awk -F'\t' '/_tether._tcp/ && NF>1 { print $NF }' \
+       | grep -E 'iPhone|iPad' | head -1 | tr -d '\r' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
      [ -n "$IOS_NAME" ] && break
      sleep 1
    done

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/TetherApp.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/TetherApp.kt
@@ -18,5 +18,6 @@ class TetherApp :
         super.onCreate()
         val debuggable = (applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
         initTetherLogging(debugEnabled = debuggable)
+        container.autoSendDispatcher.start()
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/di/AndroidAppContainer.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/di/AndroidAppContainer.kt
@@ -49,4 +49,8 @@ class AndroidAppContainer(
         defaultSaveLocation = application.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)?.absolutePath ?: "",
         saveLocationWritable = true,
     )
+
+    init {
+        autoSendDispatcher
+    }
 }

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/di/AndroidAppContainer.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/di/AndroidAppContainer.kt
@@ -51,6 +51,6 @@ class AndroidAppContainer(
     )
 
     init {
-        autoSendDispatcher
+        activateEagerSingletons()
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/tubetoast/tether/di/AndroidAppContainer.kt
+++ b/composeApp/src/androidMain/kotlin/com/tubetoast/tether/di/AndroidAppContainer.kt
@@ -49,8 +49,4 @@ class AndroidAppContainer(
         defaultSaveLocation = application.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)?.absolutePath ?: "",
         saveLocationWritable = true,
     )
-
-    init {
-        activateEagerSingletons()
-    }
 }

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/di/AppleAppContainer.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/di/AppleAppContainer.kt
@@ -54,7 +54,7 @@ open class AppleAppContainer(
     )
 
     init {
-        autoSendDispatcher
+        activateEagerSingletons()
     }
 }
 

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/di/AppleAppContainer.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/di/AppleAppContainer.kt
@@ -52,6 +52,10 @@ open class AppleAppContainer(
         defaultSaveLocation = documentsDir(),
         saveLocationWritable = false,
     )
+
+    init {
+        autoSendDispatcher
+    }
 }
 
 @OptIn(ExperimentalForeignApi::class, kotlinx.cinterop.BetaInteropApi::class)

--- a/composeApp/src/appleMain/kotlin/com/tubetoast/tether/di/AppleAppContainer.kt
+++ b/composeApp/src/appleMain/kotlin/com/tubetoast/tether/di/AppleAppContainer.kt
@@ -52,10 +52,6 @@ open class AppleAppContainer(
         defaultSaveLocation = documentsDir(),
         saveLocationWritable = false,
     )
-
-    init {
-        activateEagerSingletons()
-    }
 }
 
 @OptIn(ExperimentalForeignApi::class, kotlinx.cinterop.BetaInteropApi::class)

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
@@ -12,7 +12,6 @@ import com.tubetoast.tether.preferences.FileTransferPreferences
 import com.tubetoast.tether.preferences.PeerPreferencesStore
 import com.tubetoast.tether.presentation.RootComponentFactory
 import com.tubetoast.tether.presentation.peer.PeersRepository
-import com.tubetoast.tether.presentation.transfer.PendingFilesRepository
 import com.tubetoast.tether.security.TrustedDeviceStore
 import com.tubetoast.tether.transfer.BatchSender
 import com.tubetoast.tether.transfer.ConnectionMonitor
@@ -20,6 +19,7 @@ import com.tubetoast.tether.transfer.NoOpConnectionMonitor
 import com.tubetoast.tether.transfer.PeerTransferEngine
 import com.tubetoast.tether.transfer.PeerTransferEngineRegistry
 import com.tubetoast.tether.transfer.PeerUnreachableException
+import com.tubetoast.tether.transfer.PendingFilesRepository
 import com.tubetoast.tether.transfer.ReconnectionTimeout
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
@@ -73,9 +73,10 @@ abstract class AppContainer {
     }
 
     /**
-     * Each concrete subclass MUST touch `init { autoSendDispatcher }` after its own property
-     * initializers to activate auto-send. Accessing the lazy val here wires the dispatcher
-     * to the already-initialised [peerPreferencesStore].
+     * Auto-send must be activated in the leaf container — the lazy is read once per process so
+     * the combine collector starts subscribing to peers and pending sources before the first
+     * share-sheet arrives. The base class cannot do this itself because the abstract collaborators
+     * are not yet assigned when its own `init` block runs.
      */
     open val autoSendDispatcher: AutoSendDispatcher by lazy {
         AutoSendDispatcher(

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
@@ -13,6 +13,7 @@ import com.tubetoast.tether.preferences.PeerPreferencesStore
 import com.tubetoast.tether.presentation.RootComponentFactory
 import com.tubetoast.tether.presentation.peer.PeersRepository
 import com.tubetoast.tether.security.TrustedDeviceStore
+import com.tubetoast.tether.transfer.AutoSendDispatcher
 import com.tubetoast.tether.transfer.BatchSender
 import com.tubetoast.tether.transfer.ConnectionMonitor
 import com.tubetoast.tether.transfer.NoOpConnectionMonitor
@@ -71,7 +72,18 @@ abstract class AppContainer {
         )
     }
 
+    open val autoSendDispatcher: AutoSendDispatcher by lazy {
+        AutoSendDispatcher(
+            peersRepository = peersRepository,
+            pendingFilesRepository = pendingFilesRepository,
+            peerPreferencesStore = peerPreferencesStore,
+            engineRegistry = peerTransferEngineRegistry,
+            scope = appScope,
+        ).also { it.start() }
+    }
+
     open val rootComponentFactory: RootComponentFactory by lazy {
+        autoSendDispatcher
         RootComponentFactory(
             peersRepository = peersRepository,
             peerTransferEngineRegistry = peerTransferEngineRegistry,

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
@@ -79,16 +79,7 @@ abstract class AppContainer {
             peerPreferencesStore = peerPreferencesStore,
             engineRegistry = peerTransferEngineRegistry,
             scope = appScope,
-        ).also { it.start() }
-    }
-
-    /**
-     * Activates eager singletons that survive Component destruction (auto-send dispatcher today,
-     * future ones added here). Each leaf container calls this from its own `init` block once all
-     * abstract collaborators have been assigned — the base cannot do this itself.
-     */
-    protected fun activateEagerSingletons() {
-        autoSendDispatcher
+        )
     }
 
     open val rootComponentFactory: RootComponentFactory by lazy {

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
@@ -8,10 +8,10 @@ import com.tubetoast.tether.network.DefaultTransferActivityTracker
 import com.tubetoast.tether.network.FileClient
 import com.tubetoast.tether.network.FileServer
 import com.tubetoast.tether.network.TransferActivityTracker
+import com.tubetoast.tether.peer.PeersRepository
 import com.tubetoast.tether.preferences.FileTransferPreferences
 import com.tubetoast.tether.preferences.PeerPreferencesStore
 import com.tubetoast.tether.presentation.RootComponentFactory
-import com.tubetoast.tether.presentation.peer.PeersRepository
 import com.tubetoast.tether.security.TrustedDeviceStore
 import com.tubetoast.tether.transfer.AutoSendDispatcher
 import com.tubetoast.tether.transfer.BatchSender

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
@@ -73,10 +73,8 @@ abstract class AppContainer {
     }
 
     /**
-     * Auto-send must be activated in the leaf container — the lazy is read once per process so
-     * the combine collector starts subscribing to peers and pending sources before the first
-     * share-sheet arrives. The base class cannot do this itself because the abstract collaborators
-     * are not yet assigned when its own `init` block runs.
+     * The base class cannot activate this itself because the abstract collaborators are not yet
+     * assigned when its own `init` block runs.
      */
     open val autoSendDispatcher: AutoSendDispatcher by lazy {
         AutoSendDispatcher(

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
@@ -72,10 +72,6 @@ abstract class AppContainer {
         )
     }
 
-    /**
-     * The base class cannot activate this itself because the abstract collaborators are not yet
-     * assigned when its own `init` block runs.
-     */
     open val autoSendDispatcher: AutoSendDispatcher by lazy {
         AutoSendDispatcher(
             peersRepository = peersRepository,
@@ -84,6 +80,15 @@ abstract class AppContainer {
             engineRegistry = peerTransferEngineRegistry,
             scope = appScope,
         ).also { it.start() }
+    }
+
+    /**
+     * Activates eager singletons that survive Component destruction (auto-send dispatcher today,
+     * future ones added here). Each leaf container calls this from its own `init` block once all
+     * abstract collaborators have been assigned — the base cannot do this itself.
+     */
+    protected fun activateEagerSingletons() {
+        autoSendDispatcher
     }
 
     open val rootComponentFactory: RootComponentFactory by lazy {

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
@@ -72,6 +72,11 @@ abstract class AppContainer {
         )
     }
 
+    /**
+     * Each concrete subclass MUST touch `init { autoSendDispatcher }` after its own property
+     * initializers to activate auto-send. Accessing the lazy val here wires the dispatcher
+     * to the already-initialised [peerPreferencesStore].
+     */
     open val autoSendDispatcher: AutoSendDispatcher by lazy {
         AutoSendDispatcher(
             peersRepository = peersRepository,
@@ -83,7 +88,6 @@ abstract class AppContainer {
     }
 
     open val rootComponentFactory: RootComponentFactory by lazy {
-        autoSendDispatcher
         RootComponentFactory(
             peersRepository = peersRepository,
             peerTransferEngineRegistry = peerTransferEngineRegistry,

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/peer/Peer.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/peer/Peer.kt
@@ -1,4 +1,4 @@
-package com.tubetoast.tether.presentation.peer
+package com.tubetoast.tether.peer
 
 import com.tubetoast.tether.protocol.Device
 import com.tubetoast.tether.transfer.PeerIdentity

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/peer/PeersRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/peer/PeersRepository.kt
@@ -1,4 +1,4 @@
-package com.tubetoast.tether.presentation.peer
+package com.tubetoast.tether.peer
 
 import com.tubetoast.tether.discovery.DeviceDiscovery
 import com.tubetoast.tether.transfer.toPeerIdentity

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/PeerListComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/PeerListComponent.kt
@@ -9,9 +9,9 @@ import com.arkivanov.decompose.value.update
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.coroutines.coroutineScope
 import com.arkivanov.essenty.lifecycle.resume
+import com.tubetoast.tether.peer.Peer
+import com.tubetoast.tether.peer.PeersRepository
 import com.tubetoast.tether.presentation.banners.BannersComponent
-import com.tubetoast.tether.presentation.peer.Peer
-import com.tubetoast.tether.presentation.peer.PeersRepository
 import com.tubetoast.tether.presentation.transfer.PeerTransferComponent
 import com.tubetoast.tether.transfer.PeerIdentity
 import kotlinx.coroutines.CoroutineScope

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/PeerListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/PeerListScreen.kt
@@ -27,8 +27,8 @@ import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.composables.core.SheetDetent
 import com.composables.core.rememberModalBottomSheetState
 import com.tubetoast.tether.foundation.IsMobileChooserPlatform
+import com.tubetoast.tether.peer.Peer
 import com.tubetoast.tether.presentation.banners.BannersSection
-import com.tubetoast.tether.presentation.peer.Peer
 import com.tubetoast.tether.presentation.peercard.PeerCard
 import com.tubetoast.tether.presentation.peercard.PeerCardCallbacks
 import com.tubetoast.tether.presentation.peercard.PeerCardContent

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/PeerListState.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/PeerListState.kt
@@ -1,6 +1,6 @@
 package com.tubetoast.tether.presentation
 
-import com.tubetoast.tether.presentation.peer.Peer
+import com.tubetoast.tether.peer.Peer
 import com.tubetoast.tether.presentation.transfer.PeerTransferComponent
 
 data class PeerRow(

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/RootComponentFactory.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/RootComponentFactory.kt
@@ -2,8 +2,8 @@ package com.tubetoast.tether.presentation
 
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.essenty.lifecycle.coroutines.withLifecycle
+import com.tubetoast.tether.peer.PeersRepository
 import com.tubetoast.tether.presentation.banners.BannersComponent
-import com.tubetoast.tether.presentation.peer.PeersRepository
 import com.tubetoast.tether.presentation.transfer.PeerTransferComponent
 import com.tubetoast.tether.transfer.PeerIdentity
 import com.tubetoast.tether.transfer.PeerTransferEngineRegistry

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/RootComponentFactory.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/RootComponentFactory.kt
@@ -5,9 +5,9 @@ import com.arkivanov.essenty.lifecycle.coroutines.withLifecycle
 import com.tubetoast.tether.presentation.banners.BannersComponent
 import com.tubetoast.tether.presentation.peer.PeersRepository
 import com.tubetoast.tether.presentation.transfer.PeerTransferComponent
-import com.tubetoast.tether.presentation.transfer.PendingFilesRepository
 import com.tubetoast.tether.transfer.PeerIdentity
 import com.tubetoast.tether.transfer.PeerTransferEngineRegistry
+import com.tubetoast.tether.transfer.PendingFilesRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/banners/BannersComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/banners/BannersComponent.kt
@@ -2,8 +2,8 @@ package com.tubetoast.tether.presentation.banners
 
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.essenty.lifecycle.coroutines.coroutineScope
-import com.tubetoast.tether.presentation.PendingFilesSummary
-import com.tubetoast.tether.presentation.transfer.PendingFilesRepository
+import com.tubetoast.tether.transfer.PendingFilesRepository
+import com.tubetoast.tether.transfer.PendingFilesSummary
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/banners/PendingOutboundBanner.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/banners/PendingOutboundBanner.kt
@@ -4,8 +4,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import com.tubetoast.tether.presentation.PendingFilesSummary
 import com.tubetoast.tether.transfer.ByteFormatting
+import com.tubetoast.tether.transfer.PendingFilesSummary
 import com.tubetoast.tether.ui.designsystem.Banner
 import com.tubetoast.tether.ui.designsystem.BannerSeverity
 import com.tubetoast.tether.ui.designsystem.Button

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardActive.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardActive.kt
@@ -36,8 +36,9 @@ internal fun PeerCardActiveOutbound(
     modifier: Modifier = Modifier,
 ) {
     val peerName = device.name
-    val progress = if (state.totalBytes != null && state.totalBytes > 0) {
-        (state.sentBytes.toFloat() / state.totalBytes.toFloat()).coerceIn(0f, 1f)
+    val sending = state as? PeerTransferState.ActiveOutbound.Sending
+    val progress = if (sending != null && sending.totalBytes != null && sending.totalBytes > 0) {
+        (sending.sentBytes.toFloat() / sending.totalBytes.toFloat()).coerceIn(0f, 1f)
     } else {
         0f
     }
@@ -46,14 +47,15 @@ internal fun PeerCardActiveOutbound(
         peerName = peerName,
         titlePrefix = null,
         progress = progress,
-        currentFile = state.currentFile,
-        sentBytes = state.sentBytes,
+        currentFile = sending?.currentFile.orEmpty(),
+        sentBytes = sending?.sentBytes ?: 0L,
         totalBytes = state.totalBytes,
-        bytesPerSec = state.bytesPerSec,
+        bytesPerSec = sending?.bytesPerSec,
         isInbound = false,
         trailingContent = {
-            if (state.skippedCount > 0) {
-                SkipCountBadge(count = state.skippedCount)
+            val skipped = sending?.skippedCount ?: 0
+            if (skipped > 0) {
+                SkipCountBadge(count = skipped)
             }
         },
         cancelDescription = "Cancel transfer to $peerName",

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardActive.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardActive.kt
@@ -187,6 +187,17 @@ private fun TransferProgressBar(
     ProgressBar(progress = progress, modifier = modifier)
 }
 
+@Preview(name = "PeerCardActiveOutbound — claimed")
+@Composable
+private fun PreviewActiveOutboundClaimed(@PreviewParameter(Themes::class) dark: Boolean) =
+    PreviewSurface(darkTheme = dark) {
+        PeerCardActiveOutbound(
+            state = TransferPreviewFixtures.activeOutboundClaimed,
+            device = TransferPreviewFixtures.device,
+            callbacks = previewCardCallbacks(),
+        )
+    }
+
 @Preview(name = "PeerCardActiveOutbound — normal")
 @Composable
 private fun PreviewActiveOutbound(@PreviewParameter(Themes::class) dark: Boolean) =

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponent.kt
@@ -10,6 +10,7 @@ import com.tubetoast.tether.presentation.peer.Peer
 import com.tubetoast.tether.transfer.FileSource
 import com.tubetoast.tether.transfer.PeerIdentity
 import com.tubetoast.tether.transfer.PeerTransferEngine
+import com.tubetoast.tether.transfer.PendingFilesRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponent.kt
@@ -6,7 +6,7 @@ import com.arkivanov.decompose.value.Value
 import com.arkivanov.decompose.value.update
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.destroy
-import com.tubetoast.tether.presentation.peer.Peer
+import com.tubetoast.tether.peer.Peer
 import com.tubetoast.tether.transfer.FileSource
 import com.tubetoast.tether.transfer.PeerIdentity
 import com.tubetoast.tether.transfer.PeerTransferEngine

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsCopy.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsCopy.kt
@@ -8,8 +8,10 @@ fun aggregateStripCopy(sent: Int, total: Int, failed: Int): String {
 }
 
 fun detailsSubtitleCopy(state: PeerTransferState, peerName: String): String = when (state) {
-    is PeerTransferState.ActiveOutbound ->
-        "Sending ${state.currentIndex + 1} of ${state.totalFiles}…"
+    is PeerTransferState.ActiveOutbound -> when (state) {
+        is PeerTransferState.ActiveOutbound.Sending -> "Sending ${state.currentIndex + 1} of ${state.totalFiles}…"
+        is PeerTransferState.ActiveOutbound.Claimed -> "Sending 1 of ${state.totalFiles}…"
+    }
     is PeerTransferState.ActiveInbound ->
         "Receiving ${state.currentIndex + 1} of ${state.totalFiles}…"
     is PeerTransferState.Sent ->

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcher.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcher.kt
@@ -1,0 +1,48 @@
+package com.tubetoast.tether.transfer
+
+import com.tubetoast.tether.preferences.PeerPreferencesStore
+import com.tubetoast.tether.presentation.peer.PeersRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
+
+/**
+ * Domain-layer trigger: when pending files arrive (share-sheet / drag-drop / CLI hand-off)
+ * and exactly one peer is online with per-peer auto-send ON, start the transfer immediately
+ * and clear pending. Lives next to `PeerTransferEngineRegistry` so any caller that has the
+ * registry — UI Components, CLI, future surfaces — gets auto-send for free.
+ */
+class AutoSendDispatcher(
+    private val peersRepository: PeersRepository,
+    private val pendingFilesRepository: PendingFilesRepository,
+    private val peerPreferencesStore: PeerPreferencesStore,
+    private val engineRegistry: PeerTransferEngineRegistry,
+    private val scope: CoroutineScope,
+) {
+    fun start() {
+        combine(peersRepository.peers, pendingFilesRepository.sources) { peers, sources ->
+            if (sources.isEmpty()) return@combine
+            val only = peers.filter { it.isOnline }.singleOrNull() ?: return@combine
+            val engine = engineRegistry.engineFor(only.id)
+            if (engine.state.value !is PeerTransferState.Idle) return@combine
+            val autoSend = peerPreferencesStore
+                .observeAutoSend(only.id)
+                .catch { emit(false) }
+                .first()
+            if (!autoSend) return@combine
+            // Re-validate after the suspending preference read — mDNS may have added a peer,
+            // sources may have been cleared, or the engine may have transitioned out of Idle.
+            val sourcesAfter = pendingFilesRepository.sources.value
+            if (sourcesAfter.isEmpty()) return@combine
+            val onlyAfter = peersRepository.peers.value
+                .filter { it.isOnline }
+                .singleOrNull() ?: return@combine
+            if (onlyAfter.id != only.id) return@combine
+            if (engine.state.value !is PeerTransferState.Idle) return@combine
+            engine.startOutbound(sourcesAfter)
+            pendingFilesRepository.clear()
+        }.launchIn(scope)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcher.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcher.kt
@@ -38,9 +38,7 @@ class AutoSendDispatcher(
             val onlineAfter = peersRepository.peers.value
                 .filter { it.isOnline }
                 .map { it.id }
-            val decision = AutoSendRouter.route(onlineAfter) { it == singleCandidate && autoSendEnabled }
-            val target = (decision as? RoutingDecision.AutoSend)?.peer ?: return@combine
-            if (target != singleCandidate) return@combine
+            if (onlineAfter.singleOrNull() != singleCandidate || !autoSendEnabled) return@combine
             if (engine.state.value !is PeerTransferState.Idle) return@combine
             engine.startOutbound(sourcesAfter)
             pendingFilesRepository.clear()

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcher.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcher.kt
@@ -24,22 +24,24 @@ class AutoSendDispatcher(
     fun start() {
         combine(peersRepository.peers, pendingFilesRepository.sources) { peers, sources ->
             if (sources.isEmpty()) return@combine
-            val only = peers.filter { it.isOnline }.singleOrNull() ?: return@combine
-            val engine = engineRegistry.engineFor(only.id)
+            val onlinePaired = peers.filter { it.isOnline }.map { it.id }
+            val singleCandidate = onlinePaired.singleOrNull() ?: return@combine
+            val engine = engineRegistry.engineFor(singleCandidate)
             if (engine.state.value !is PeerTransferState.Idle) return@combine
-            val autoSend = peerPreferencesStore
-                .observeAutoSend(only.id)
+            val autoSendEnabled = peerPreferencesStore
+                .observeAutoSend(singleCandidate)
                 .catch { emit(false) }
                 .first()
-            if (!autoSend) return@combine
             // Re-validate after the suspending preference read — mDNS may have added a peer,
             // sources may have been cleared, or the engine may have transitioned out of Idle.
             val sourcesAfter = pendingFilesRepository.sources.value
             if (sourcesAfter.isEmpty()) return@combine
-            val onlyAfter = peersRepository.peers.value
+            val onlineAfter = peersRepository.peers.value
                 .filter { it.isOnline }
-                .singleOrNull() ?: return@combine
-            if (onlyAfter.id != only.id) return@combine
+                .map { it.id }
+            val decision = AutoSendRouter.route(onlineAfter) { it == singleCandidate && autoSendEnabled }
+            val target = (decision as? RoutingDecision.AutoSend)?.peer ?: return@combine
+            if (target != singleCandidate) return@combine
             if (engine.state.value !is PeerTransferState.Idle) return@combine
             engine.startOutbound(sourcesAfter)
             pendingFilesRepository.clear()

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcher.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcher.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.launchIn
 /**
  * Domain-layer trigger: when pending files arrive (share-sheet / drag-drop / CLI hand-off)
  * and exactly one peer is online with per-peer auto-send ON, start the transfer immediately
- * and clear pending. Lives next to `PeerTransferEngineRegistry` so any caller that has the
+ * and clear pending. Lives in the transfer layer so any surface that already has the engine
  * registry — UI Components, CLI, future surfaces — gets auto-send for free.
  */
 class AutoSendDispatcher(

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcher.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcher.kt
@@ -26,19 +26,19 @@ class AutoSendDispatcher(
             if (sources.isEmpty()) return@combine
             val onlinePaired = peers.filter { it.isOnline }.map { it.id }
             val singleCandidate = onlinePaired.singleOrNull() ?: return@combine
-            val engine = engineRegistry.engineFor(singleCandidate)
-            if (engine.state.value !is PeerTransferState.Idle) return@combine
             val autoSendEnabled = peerPreferencesStore
                 .observeAutoSend(singleCandidate)
                 .catch { emit(false) }
                 .first()
+            if (!autoSendEnabled) return@combine
             // mDNS may have added a peer, sources may have been cleared, or the engine may have transitioned out of Idle.
             val sourcesAfter = pendingFilesRepository.sources.value
             if (sourcesAfter.isEmpty()) return@combine
             val onlineAfter = peersRepository.peers.value
                 .filter { it.isOnline }
                 .map { it.id }
-            if (onlineAfter.singleOrNull() != singleCandidate || !autoSendEnabled) return@combine
+            if (onlineAfter.singleOrNull() != singleCandidate) return@combine
+            val engine = engineRegistry.engineFor(singleCandidate)
             if (engine.state.value !is PeerTransferState.Idle) return@combine
             engine.startOutbound(sourcesAfter)
             pendingFilesRepository.clear()

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcher.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcher.kt
@@ -1,7 +1,7 @@
 package com.tubetoast.tether.transfer
 
+import com.tubetoast.tether.peer.PeersRepository
 import com.tubetoast.tether.preferences.PeerPreferencesStore
-import com.tubetoast.tether.presentation.peer.PeersRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcher.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcher.kt
@@ -32,8 +32,7 @@ class AutoSendDispatcher(
                 .observeAutoSend(singleCandidate)
                 .catch { emit(false) }
                 .first()
-            // Re-validate after the suspending preference read — mDNS may have added a peer,
-            // sources may have been cleared, or the engine may have transitioned out of Idle.
+            // mDNS may have added a peer, sources may have been cleared, or the engine may have transitioned out of Idle.
             val sourcesAfter = pendingFilesRepository.sources.value
             if (sourcesAfter.isEmpty()) return@combine
             val onlineAfter = peersRepository.peers.value

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngine.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.time.Duration
@@ -27,7 +26,7 @@ class PeerTransferEngine(
     private val inboundEvents: Flow<ReceiveEvent> = MutableSharedFlow(),
     private val reconnectionTimeout: Duration = ReconnectionTimeout.DEFAULT,
     private val scope: CoroutineScope,
-    private val peerPreferencesStore: PeerPreferencesStore? = null,
+    private val peerPreferencesStore: PeerPreferencesStore,
 ) {
     private val _state = MutableStateFlow<PeerTransferState>(PeerTransferState.Idle(peer))
     val state: StateFlow<PeerTransferState> = _state.asStateFlow()
@@ -136,12 +135,10 @@ class PeerTransferEngine(
         }
     }
 
-    fun observeAutoSend(): Flow<Boolean> =
-        peerPreferencesStore?.observeAutoSend(peer) ?: flowOf(false)
+    fun observeAutoSend(): Flow<Boolean> = peerPreferencesStore.observeAutoSend(peer)
 
     fun setAutoSend(enabled: Boolean) {
-        val store = peerPreferencesStore ?: return
-        scope.launch { store.setAutoSend(peer, enabled) }
+        scope.launch { peerPreferencesStore.setAutoSend(peer, enabled) }
     }
 
     private fun launchBatch(sources: List<FileSource>) {

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngine.kt
@@ -50,15 +50,10 @@ class PeerTransferEngine(
             //              clears PendingFilesRepository on this path, dropping the share-sheet payload.
             return
         }
-        val claim = PeerTransferState.ActiveOutbound(
+        val claim = PeerTransferState.ActiveOutbound.Claimed(
             peer = peer,
-            currentFile = sources.firstOrNull()?.name.orEmpty(),
-            currentIndex = 0,
             totalFiles = sources.size,
-            sentBytes = 0L,
             totalBytes = sources.sumOf { it.sizeBytes ?: 0L },
-            bytesPerSec = null,
-            skippedCount = 0,
             perFile = sources.map { PerFileStatus.Queued(it.name, it.sizeBytes) },
         )
         if (!_state.compareAndSet(current, claim)) return
@@ -111,7 +106,7 @@ class PeerTransferEngine(
             is PerFileStatus.Queued -> {
                 cancelledFileNames.update { it + name }
                 _state.update { s ->
-                    val active = s as? PeerTransferState.ActiveOutbound ?: return@update s
+                    val active = s as? PeerTransferState.ActiveOutbound.Sending ?: return@update s
                     val rowIndex = active.perFile.indexOfFirst { it.name == name }.takeIf { it >= 0 } ?: return@update s
                     val updated = active.perFile.toMutableList()
                     updated[rowIndex] = PerFileStatus.Failed(
@@ -169,7 +164,7 @@ class PeerTransferEngine(
     }
 
     private fun mapProgress(progress: BatchProgress): PeerTransferState = when (progress) {
-        is BatchProgress.Sending -> PeerTransferState.ActiveOutbound(
+        is BatchProgress.Sending -> PeerTransferState.ActiveOutbound.Sending(
             peer = progress.peer,
             currentFile = progress.currentFile,
             currentIndex = progress.currentIndex,

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngine.kt
@@ -45,14 +45,23 @@ class PeerTransferEngine(
 
     fun startOutbound(sources: List<FileSource>) {
         val current = _state.value
-        if (current is PeerTransferState.ActiveOutbound ||
-            current is PeerTransferState.ActiveInbound ||
-            current is PeerTransferState.Reconnecting
-        ) {
+        if (current !is PeerTransferState.Idle) {
             // TODO(#327): surface "transfer already in flight" to the user; the caller still
             //              clears PendingFilesRepository on this path, dropping the share-sheet payload.
             return
         }
+        val claim = PeerTransferState.ActiveOutbound(
+            peer = peer,
+            currentFile = sources.firstOrNull()?.name.orEmpty(),
+            currentIndex = 0,
+            totalFiles = sources.size,
+            sentBytes = 0L,
+            totalBytes = sources.sumOf { it.sizeBytes ?: 0L },
+            bytesPerSec = null,
+            skippedCount = 0,
+            perFile = sources.map { PerFileStatus.Queued(it.name, it.sizeBytes) },
+        )
+        if (!_state.compareAndSet(current, claim)) return
         originalSources = sources
         cancelledFileNames.update { emptySet() }
         launchBatch(sources)

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngine.kt
@@ -33,7 +33,7 @@ class PeerTransferEngine(
 
     private var activeJob: Job? = null
     private var currentSender: BatchSender? = null
-    private var originalSources: List<FileSource> = emptyList()
+    private val originalSources = MutableStateFlow<List<FileSource>>(emptyList())
     private val confirmedReceived = MutableStateFlow<Set<String>>(emptySet())
     private val cancelledFileNames = MutableStateFlow<Set<String>>(emptySet())
 
@@ -57,7 +57,7 @@ class PeerTransferEngine(
             perFile = sources.map { PerFileStatus.Queued(it.name, it.sizeBytes) },
         )
         if (!_state.compareAndSet(current, claim)) return
-        originalSources = sources
+        originalSources.value = sources
         cancelledFileNames.update { emptySet() }
         launchBatch(sources)
     }
@@ -65,6 +65,16 @@ class PeerTransferEngine(
     fun onCancel() {
         activeJob?.cancel()
         activeJob = null
+        _state.update { current ->
+            if (current is PeerTransferState.ActiveOutbound) {
+                val perFile = current.perFile
+                val sent = perFile.count { it is PerFileStatus.Done }
+                val remaining = perFile.filter { it !is PerFileStatus.Done }.map { it.name }
+                PeerTransferState.Cancelled(peer = peer, sent = sent, remaining = remaining, perFile = perFile)
+            } else {
+                current
+            }
+        }
     }
 
     fun onRetryOutbound() {
@@ -77,14 +87,14 @@ class PeerTransferEngine(
         }
         val failedNames = lastPerFile.filterIsInstance<PerFileStatus.Failed>().map { it.name }.toSet()
         val confirmed = confirmedReceived.value
-        val retryable = originalSources.filter { it.name in failedNames && it.name !in confirmed }
+        val retryable = originalSources.value.filter { it.name in failedNames && it.name !in confirmed }
         if (retryable.isEmpty()) return
         cancelledFileNames.update { emptySet() }
         launchBatch(retryable)
     }
 
     fun onRetryFile(name: String) {
-        val source = originalSources.firstOrNull { it.name == name } ?: return
+        val source = originalSources.value.firstOrNull { it.name == name } ?: return
         cancelledFileNames.update { it - name }
         val job = activeJob
         activeJob = scope.launch {
@@ -160,6 +170,16 @@ class PeerTransferEngine(
             }
         } finally {
             currentSender = null
+            _state.update { current ->
+                if (current is PeerTransferState.ActiveOutbound) {
+                    val perFile = current.perFile
+                    val sent = perFile.count { it is PerFileStatus.Done }
+                    val remaining = perFile.filter { it !is PerFileStatus.Done }.map { it.name }
+                    PeerTransferState.Cancelled(peer = peer, sent = sent, remaining = remaining, perFile = perFile)
+                } else {
+                    current
+                }
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngine.kt
@@ -66,14 +66,7 @@ class PeerTransferEngine(
         activeJob?.cancel()
         activeJob = null
         _state.update { current ->
-            if (current is PeerTransferState.ActiveOutbound) {
-                val perFile = current.perFile
-                val sent = perFile.count { it is PerFileStatus.Done }
-                val remaining = perFile.filter { it !is PerFileStatus.Done }.map { it.name }
-                PeerTransferState.Cancelled(peer = peer, sent = sent, remaining = remaining, perFile = perFile)
-            } else {
-                current
-            }
+            if (current is PeerTransferState.ActiveOutbound) cancelledFromActive(current) else current
         }
     }
 
@@ -171,16 +164,22 @@ class PeerTransferEngine(
         } finally {
             currentSender = null
             _state.update { current ->
-                if (current is PeerTransferState.ActiveOutbound) {
-                    val perFile = current.perFile
-                    val sent = perFile.count { it is PerFileStatus.Done }
-                    val remaining = perFile.filter { it !is PerFileStatus.Done }.map { it.name }
-                    PeerTransferState.Cancelled(peer = peer, sent = sent, remaining = remaining, perFile = perFile)
-                } else {
-                    current
-                }
+                if (current is PeerTransferState.ActiveOutbound) cancelledFromActive(current) else current
             }
         }
+    }
+
+    private fun cancelledFromActive(current: PeerTransferState.ActiveOutbound): PeerTransferState.Cancelled {
+        val perFile = current.perFile.map { entry ->
+            if (entry is PerFileStatus.Done) {
+                entry
+            } else {
+                PerFileStatus.Failed(entry.name, entry.size, FailureReason.TransferCancelled)
+            }
+        }
+        val sent = perFile.count { it is PerFileStatus.Done }
+        val remaining = perFile.filter { it !is PerFileStatus.Done }.map { it.name }
+        return PeerTransferState.Cancelled(peer = peer, sent = sent, remaining = remaining, perFile = perFile)
     }
 
     private fun mapProgress(progress: BatchProgress): PeerTransferState = when (progress) {

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferState.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferState.kt
@@ -13,8 +13,7 @@ sealed interface PeerTransferState {
         abstract val totalBytes: Long?
         abstract val perFile: List<PerFileStatus>
 
-        /** Engine atomically claimed via compareAndSet; the BatchSender has not produced its first
-         * progress heartbeat yet. No per-byte progress fields exist at this phase. */
+        /** Outbound transfer reserved by the engine; per-byte progress is not yet available. */
         data class Claimed(
             override val peer: PeerIdentity,
             override val totalFiles: Int,

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferState.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferState.kt
@@ -7,17 +7,33 @@ sealed interface PeerTransferState {
         override val peer: PeerIdentity,
     ) : PeerTransferState
 
-    data class ActiveOutbound(
-        override val peer: PeerIdentity,
-        val currentFile: String,
-        val currentIndex: Int,
-        val totalFiles: Int,
-        val sentBytes: Long,
-        val totalBytes: Long?,
-        val bytesPerSec: Long?,
-        val skippedCount: Int,
-        val perFile: List<PerFileStatus>,
-    ) : PeerTransferState
+    sealed class ActiveOutbound : PeerTransferState {
+        abstract override val peer: PeerIdentity
+        abstract val totalFiles: Int
+        abstract val totalBytes: Long?
+        abstract val perFile: List<PerFileStatus>
+
+        /** Engine atomically claimed via compareAndSet; the BatchSender has not produced its first
+         * progress heartbeat yet. No per-byte progress fields exist at this phase. */
+        data class Claimed(
+            override val peer: PeerIdentity,
+            override val totalFiles: Int,
+            override val totalBytes: Long?,
+            override val perFile: List<PerFileStatus>,
+        ) : ActiveOutbound()
+
+        data class Sending(
+            override val peer: PeerIdentity,
+            val currentFile: String,
+            val currentIndex: Int,
+            override val totalFiles: Int,
+            val sentBytes: Long,
+            override val totalBytes: Long?,
+            val bytesPerSec: Long?,
+            val skippedCount: Int,
+            override val perFile: List<PerFileStatus>,
+        ) : ActiveOutbound()
+    }
 
     data class ActiveInbound(
         override val peer: PeerIdentity,

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PendingFilesRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PendingFilesRepository.kt
@@ -1,7 +1,5 @@
-package com.tubetoast.tether.presentation.transfer
+package com.tubetoast.tether.transfer
 
-import com.tubetoast.tether.presentation.PendingFilesSummary
-import com.tubetoast.tether.transfer.FileSource
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PendingFilesSummary.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PendingFilesSummary.kt
@@ -1,4 +1,4 @@
-package com.tubetoast.tether.presentation
+package com.tubetoast.tether.transfer
 
 data class PendingFilesSummary(
     val fileCount: Int,

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/ui/preview/TransferPreviewFixtures.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/ui/preview/TransferPreviewFixtures.kt
@@ -16,6 +16,17 @@ object TransferPreviewFixtures {
     val idleCollapsed = PeerTransferState.Idle(peer)
     val idleExpanded = PeerTransferState.Idle(peer)
 
+    val activeOutboundClaimed = PeerTransferState.ActiveOutbound.Claimed(
+        peer = peer,
+        totalFiles = 3,
+        totalBytes = 31_457_280L,
+        perFile = listOf(
+            PerFileStatus.Queued("photo_001.jpg", 10_485_760L),
+            PerFileStatus.Queued("photo_002.jpg", 10_485_760L),
+            PerFileStatus.Queued("photo_003.jpg", 10_485_760L),
+        ),
+    )
+
     val activeOutbound = PeerTransferState.ActiveOutbound.Sending(
         peer = peer,
         currentFile = "vacation_photo_2024_summer_beach_holiday.jpg",

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/ui/preview/TransferPreviewFixtures.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/ui/preview/TransferPreviewFixtures.kt
@@ -16,7 +16,7 @@ object TransferPreviewFixtures {
     val idleCollapsed = PeerTransferState.Idle(peer)
     val idleExpanded = PeerTransferState.Idle(peer)
 
-    val activeOutbound = PeerTransferState.ActiveOutbound(
+    val activeOutbound = PeerTransferState.ActiveOutbound.Sending(
         peer = peer,
         currentFile = "vacation_photo_2024_summer_beach_holiday.jpg",
         currentIndex = 2,
@@ -46,7 +46,7 @@ object TransferPreviewFixtures {
         },
     )
 
-    val activeOutboundCalculating = PeerTransferState.ActiveOutbound(
+    val activeOutboundCalculating = PeerTransferState.ActiveOutbound.Sending(
         peer = peer,
         currentFile = "document.pdf",
         currentIndex = 0,

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/peer/FakePeersRepository.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/peer/FakePeersRepository.kt
@@ -1,4 +1,4 @@
-package com.tubetoast.tether.presentation.peer
+package com.tubetoast.tether.peer
 
 import com.tubetoast.tether.discovery.FakeDeviceDiscovery
 import kotlinx.coroutines.CoroutineScope

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/preferences/FakePeerPreferencesStore.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/preferences/FakePeerPreferencesStore.kt
@@ -1,0 +1,25 @@
+package com.tubetoast.tether.preferences
+
+import com.tubetoast.tether.transfer.PeerIdentity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+
+class FakePeerPreferencesStore : PeerPreferencesStore {
+    private val store = MutableStateFlow<Map<String, Boolean>>(emptyMap())
+
+    /** Replaces the stored value for [peer] and emits to active observers. */
+    fun setAutoSendSync(peer: PeerIdentity, enabled: Boolean) {
+        store.value = store.value + (peer.id to enabled)
+    }
+
+    override fun observeAutoSend(peer: PeerIdentity): Flow<Boolean> =
+        store.map { it[peer.id] ?: false }
+
+    override suspend fun setAutoSend(peer: PeerIdentity, enabled: Boolean) {
+        setAutoSendSync(peer, enabled)
+    }
+
+    override suspend fun autoSendEnabledFor(peer: PeerIdentity): Boolean =
+        store.value[peer.id] ?: false
+}

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/preferences/FakePeerPreferencesStore.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/preferences/FakePeerPreferencesStore.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.flow.map
 class FakePeerPreferencesStore : PeerPreferencesStore {
     private val store = MutableStateFlow<Map<String, Boolean>>(emptyMap())
 
-    /** Replaces the stored value for [peer] and emits to active observers. */
     fun setAutoSendSync(peer: PeerIdentity, enabled: Boolean) {
         store.value = store.value + (peer.id to enabled)
     }

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/PeerListComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/PeerListComponentTest.kt
@@ -9,11 +9,11 @@ import com.tubetoast.tether.presentation.peer.FakePeersRepository
 import com.tubetoast.tether.presentation.peer.Peer
 import com.tubetoast.tether.presentation.peer.PeersRepository
 import com.tubetoast.tether.presentation.transfer.PeerTransferComponent
-import com.tubetoast.tether.presentation.transfer.PendingFilesRepository
 import com.tubetoast.tether.protocol.Device
 import com.tubetoast.tether.transfer.FakeFileSource
 import com.tubetoast.tether.transfer.PeerTransferEngine
 import com.tubetoast.tether.transfer.PeerTransferState
+import com.tubetoast.tether.transfer.PendingFilesRepository
 import com.tubetoast.tether.transfer.fakeBatchSender
 import com.tubetoast.tether.transfer.toPeerIdentity
 import kotlinx.coroutines.CoroutineScope

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/PeerListComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/PeerListComponentTest.kt
@@ -4,6 +4,7 @@ import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
 import com.tubetoast.tether.discovery.FakeDeviceDiscovery
+import com.tubetoast.tether.preferences.FakePeerPreferencesStore
 import com.tubetoast.tether.presentation.banners.BannersComponent
 import com.tubetoast.tether.presentation.peer.FakePeersRepository
 import com.tubetoast.tether.presentation.peer.Peer
@@ -346,6 +347,7 @@ class PeerListComponentTest {
                     batchSenderFactory = fakeBatchSender(),
                     inboundEvents = MutableSharedFlow(),
                     scope = coroutineScope,
+                    peerPreferencesStore = FakePeerPreferencesStore(),
                 )
                 PeerTransferComponent(
                     componentContext = childCtx,
@@ -390,6 +392,7 @@ class PeerListComponentTest {
                     batchSenderFactory = fakeBatchSender(),
                     inboundEvents = MutableSharedFlow(),
                     scope = coroutineScope,
+                    peerPreferencesStore = FakePeerPreferencesStore(),
                 )
                 PeerTransferComponent(
                     componentContext = childCtx,

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/PeerListComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/PeerListComponentTest.kt
@@ -4,11 +4,11 @@ import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
 import com.tubetoast.tether.discovery.FakeDeviceDiscovery
+import com.tubetoast.tether.peer.FakePeersRepository
+import com.tubetoast.tether.peer.Peer
+import com.tubetoast.tether.peer.PeersRepository
 import com.tubetoast.tether.preferences.FakePeerPreferencesStore
 import com.tubetoast.tether.presentation.banners.BannersComponent
-import com.tubetoast.tether.presentation.peer.FakePeersRepository
-import com.tubetoast.tether.presentation.peer.Peer
-import com.tubetoast.tether.presentation.peer.PeersRepository
 import com.tubetoast.tether.presentation.transfer.PeerTransferComponent
 import com.tubetoast.tether.protocol.Device
 import com.tubetoast.tether.transfer.FakeFileSource

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/RootComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/RootComponentTest.kt
@@ -6,9 +6,9 @@ import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
 import com.arkivanov.essenty.statekeeper.StateKeeperDispatcher
 import com.tubetoast.tether.discovery.FakeDeviceDiscovery
+import com.tubetoast.tether.peer.PeersRepository
 import com.tubetoast.tether.preferences.FakePeerPreferencesStore
 import com.tubetoast.tether.presentation.banners.BannersComponent
-import com.tubetoast.tether.presentation.peer.PeersRepository
 import com.tubetoast.tether.presentation.transfer.PeerTransferComponent
 import com.tubetoast.tether.protocol.Device
 import com.tubetoast.tether.transfer.FakeFileSource

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/RootComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/RootComponentTest.kt
@@ -6,6 +6,7 @@ import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
 import com.arkivanov.essenty.statekeeper.StateKeeperDispatcher
 import com.tubetoast.tether.discovery.FakeDeviceDiscovery
+import com.tubetoast.tether.preferences.FakePeerPreferencesStore
 import com.tubetoast.tether.presentation.banners.BannersComponent
 import com.tubetoast.tether.presentation.peer.PeersRepository
 import com.tubetoast.tether.presentation.transfer.PeerTransferComponent
@@ -241,6 +242,7 @@ class RootComponentTest {
                             batchSenderFactory = fakeBatchSender(),
                             inboundEvents = MutableSharedFlow(),
                             scope = coroutineScope,
+                            peerPreferencesStore = FakePeerPreferencesStore(),
                         )
                         PeerTransferComponent(
                             componentContext = peerCtx,

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/RootComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/RootComponentTest.kt
@@ -9,11 +9,12 @@ import com.tubetoast.tether.discovery.FakeDeviceDiscovery
 import com.tubetoast.tether.presentation.banners.BannersComponent
 import com.tubetoast.tether.presentation.peer.PeersRepository
 import com.tubetoast.tether.presentation.transfer.PeerTransferComponent
-import com.tubetoast.tether.presentation.transfer.PendingFilesRepository
 import com.tubetoast.tether.protocol.Device
 import com.tubetoast.tether.transfer.FakeFileSource
 import com.tubetoast.tether.transfer.PeerTransferEngine
 import com.tubetoast.tether.transfer.PeerTransferState
+import com.tubetoast.tether.transfer.PendingFilesRepository
+import com.tubetoast.tether.transfer.PendingFilesSummary
 import com.tubetoast.tether.transfer.fakeBatchSender
 import com.tubetoast.tether.transfer.toPeerIdentity
 import kotlinx.coroutines.CoroutineScope

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/banners/BannersComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/banners/BannersComponentTest.kt
@@ -3,8 +3,8 @@ package com.tubetoast.tether.presentation.banners
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
-import com.tubetoast.tether.presentation.PendingFilesSummary
-import com.tubetoast.tether.presentation.transfer.PendingFilesRepository
+import com.tubetoast.tether.transfer.PendingFilesRepository
+import com.tubetoast.tether.transfer.PendingFilesSummary
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceTimeBy

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponentTest.kt
@@ -4,6 +4,7 @@ import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.lifecycle.Lifecycle
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
+import com.tubetoast.tether.preferences.FakePeerPreferencesStore
 import com.tubetoast.tether.presentation.peer.Peer
 import com.tubetoast.tether.protocol.Device
 import com.tubetoast.tether.transfer.FakeFileSource
@@ -61,6 +62,7 @@ class PeerTransferComponentTest {
             batchSenderFactory = fakeBatchSender(),
             inboundEvents = MutableSharedFlow(),
             scope = scope,
+            peerPreferencesStore = FakePeerPreferencesStore(),
         )
         val component = PeerTransferComponent(
             componentContext = context,
@@ -155,6 +157,7 @@ class PeerTransferComponentTest {
                     batchSenderFactory = fakeBatchSender(pauseChannel = pauseChannel),
                     inboundEvents = MutableSharedFlow(),
                     scope = engineScope,
+                    peerPreferencesStore = FakePeerPreferencesStore(),
                 )
             },
         )

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponentTest.kt
@@ -4,7 +4,6 @@ import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.lifecycle.Lifecycle
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
-import com.tubetoast.tether.presentation.PendingFilesSummary
 import com.tubetoast.tether.presentation.peer.Peer
 import com.tubetoast.tether.protocol.Device
 import com.tubetoast.tether.transfer.FakeFileSource
@@ -12,6 +11,8 @@ import com.tubetoast.tether.transfer.PeerIdentity
 import com.tubetoast.tether.transfer.PeerTransferEngine
 import com.tubetoast.tether.transfer.PeerTransferEngineRegistry
 import com.tubetoast.tether.transfer.PeerTransferState
+import com.tubetoast.tether.transfer.PendingFilesRepository
+import com.tubetoast.tether.transfer.PendingFilesSummary
 import com.tubetoast.tether.transfer.fakeBatchSender
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponentTest.kt
@@ -4,8 +4,8 @@ import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.lifecycle.Lifecycle
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
+import com.tubetoast.tether.peer.Peer
 import com.tubetoast.tether.preferences.FakePeerPreferencesStore
-import com.tubetoast.tether.presentation.peer.Peer
 import com.tubetoast.tether.protocol.Device
 import com.tubetoast.tether.transfer.FakeFileSource
 import com.tubetoast.tether.transfer.PeerIdentity

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsComponentTest.kt
@@ -3,8 +3,8 @@ package com.tubetoast.tether.presentation.transfer
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
+import com.tubetoast.tether.peer.Peer
 import com.tubetoast.tether.preferences.FakePeerPreferencesStore
-import com.tubetoast.tether.presentation.peer.Peer
 import com.tubetoast.tether.protocol.Device
 import com.tubetoast.tether.transfer.FailureReason
 import com.tubetoast.tether.transfer.FakeFileSource

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsComponentTest.kt
@@ -141,8 +141,7 @@ class TransferDetailsComponentTest {
         )
         runCurrent()
 
-        val stateOnB = peerComponent.state.value.transfer
-        assertIs<PeerTransferState.ActiveOutbound>(stateOnB)
+        val stateOnB = assertIs<PeerTransferState.ActiveOutbound.Sending>(peerComponent.state.value.transfer)
         assertEquals("b.txt", stateOnB.currentFile)
 
         details.onCancelFile("b.txt")
@@ -176,8 +175,7 @@ class TransferDetailsComponentTest {
         )
         runCurrent()
 
-        val activeState = peerComponent.state.value.transfer
-        assertIs<PeerTransferState.ActiveOutbound>(activeState)
+        val activeState = assertIs<PeerTransferState.ActiveOutbound.Sending>(peerComponent.state.value.transfer)
         assertEquals("file1.txt", activeState.currentFile)
 
         details.onCancelFile("file2.txt")

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsComponentTest.kt
@@ -3,6 +3,7 @@ package com.tubetoast.tether.presentation.transfer
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
+import com.tubetoast.tether.preferences.FakePeerPreferencesStore
 import com.tubetoast.tether.presentation.peer.Peer
 import com.tubetoast.tether.protocol.Device
 import com.tubetoast.tether.transfer.FailureReason
@@ -60,6 +61,7 @@ class TransferDetailsComponentTest {
             batchSenderFactory = fakeBatchSender(sendOneOverride = sendOneOverride, pauseChannel = pauseChannel),
             inboundEvents = MutableSharedFlow(),
             scope = scope,
+            peerPreferencesStore = FakePeerPreferencesStore(),
         )
         return PeerTransferComponent(
             componentContext = context,

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcherTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcherTest.kt
@@ -5,8 +5,10 @@ import com.tubetoast.tether.peer.Peer
 import com.tubetoast.tether.preferences.FakePeerPreferencesStore
 import com.tubetoast.tether.preferences.PeerPreferencesStore
 import com.tubetoast.tether.protocol.Device
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
@@ -109,22 +111,12 @@ class AutoSendDispatcherTest {
 
     @Test
     fun `auto-send bails when a second peer comes online during preference read`() = runTest {
-        val gate = kotlinx.coroutines.CompletableDeferred<Unit>()
+        val gate = CompletableDeferred<Unit>()
         val peersFlow = MutableStateFlow(listOf(peerA))
         val peersRepo = FakePeersRepository(peersFlow)
         val pendingRepo = PendingFilesRepository()
         val store = FakePeerPreferencesStore()
-
-        val gatedStore = object : PeerPreferencesStore {
-            override fun observeAutoSend(peer: PeerIdentity) = flow {
-                gate.await()
-                emit(true)
-            }
-
-            override suspend fun setAutoSend(peer: PeerIdentity, enabled: Boolean) = Unit
-
-            override suspend fun autoSendEnabledFor(peer: PeerIdentity) = true
-        }
+        val gatedStore = GatedPeerPreferencesStore(gate)
 
         val registry = buildRegistry(backgroundScope, store)
         buildDispatcher(peersRepo, pendingRepo, gatedStore, registry, backgroundScope).start()
@@ -143,21 +135,11 @@ class AutoSendDispatcherTest {
 
     @Test
     fun `auto-send bails when sources are cleared during preference read`() = runTest {
-        val gate = kotlinx.coroutines.CompletableDeferred<Unit>()
+        val gate = CompletableDeferred<Unit>()
         val peersRepo = FakePeersRepository(MutableStateFlow(listOf(peerA)))
         val pendingRepo = PendingFilesRepository()
         val store = FakePeerPreferencesStore()
-
-        val gatedStore = object : PeerPreferencesStore {
-            override fun observeAutoSend(peer: PeerIdentity) = flow {
-                gate.await()
-                emit(true)
-            }
-
-            override suspend fun setAutoSend(peer: PeerIdentity, enabled: Boolean) = Unit
-
-            override suspend fun autoSendEnabledFor(peer: PeerIdentity) = true
-        }
+        val gatedStore = GatedPeerPreferencesStore(gate)
 
         val registry = buildRegistry(backgroundScope, store)
         buildDispatcher(peersRepo, pendingRepo, gatedStore, registry, backgroundScope).start()
@@ -176,21 +158,11 @@ class AutoSendDispatcherTest {
 
     @Test
     fun `auto-send bails when engine is no longer Idle after preference read`() = runTest {
-        val gate = kotlinx.coroutines.CompletableDeferred<Unit>()
+        val gate = CompletableDeferred<Unit>()
         val peersRepo = FakePeersRepository(MutableStateFlow(listOf(peerA)))
         val pendingRepo = PendingFilesRepository()
         val store = FakePeerPreferencesStore()
-
-        val gatedStore = object : PeerPreferencesStore {
-            override fun observeAutoSend(peer: PeerIdentity) = flow {
-                gate.await()
-                emit(true)
-            }
-
-            override suspend fun setAutoSend(peer: PeerIdentity, enabled: Boolean) = Unit
-
-            override suspend fun autoSendEnabledFor(peer: PeerIdentity) = true
-        }
+        val gatedStore = GatedPeerPreferencesStore(gate)
 
         val registry = buildRegistry(backgroundScope, store)
         buildDispatcher(peersRepo, pendingRepo, gatedStore, registry, backgroundScope).start()
@@ -248,4 +220,18 @@ class AutoSendDispatcherTest {
         assertIs<PeerTransferState.Sent>(registry.engineFor(peerA.id).state.value)
         assertNull(pendingRepo.summary.value)
     }
+}
+
+private class GatedPeerPreferencesStore(
+    private val gate: CompletableDeferred<Unit>,
+    private val autoSendResult: Boolean = true,
+) : PeerPreferencesStore {
+    override fun observeAutoSend(peer: PeerIdentity): Flow<Boolean> = flow {
+        gate.await()
+        emit(autoSendResult)
+    }
+
+    override suspend fun setAutoSend(peer: PeerIdentity, enabled: Boolean) = Unit
+
+    override suspend fun autoSendEnabledFor(peer: PeerIdentity): Boolean = autoSendResult
 }

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcherTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcherTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.io.IOException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -222,7 +223,7 @@ class AutoSendDispatcherTest {
         val failOnceStore = object : PeerPreferencesStore {
             override fun observeAutoSend(peer: PeerIdentity) = flow<Boolean> {
                 callCount++
-                if (callCount == 1) throw java.io.IOException("DataStore unavailable")
+                if (callCount == 1) throw IOException("DataStore unavailable")
                 emit(true)
             }
 

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcherTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcherTest.kt
@@ -1,9 +1,9 @@
 package com.tubetoast.tether.transfer
 
+import com.tubetoast.tether.peer.FakePeersRepository
+import com.tubetoast.tether.peer.Peer
 import com.tubetoast.tether.preferences.FakePeerPreferencesStore
 import com.tubetoast.tether.preferences.PeerPreferencesStore
-import com.tubetoast.tether.presentation.peer.FakePeersRepository
-import com.tubetoast.tether.presentation.peer.Peer
 import com.tubetoast.tether.protocol.Device
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcherTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcherTest.kt
@@ -58,6 +58,23 @@ class AutoSendDispatcherTest {
     )
 
     @Test
+    fun `zero online peers do not trigger auto-send`() = runTest {
+        val store = FakePeerPreferencesStore()
+        store.setAutoSendSync(peerA.id, true)
+        val peersRepo = FakePeersRepository(MutableStateFlow(emptyList()))
+        val pendingRepo = PendingFilesRepository()
+        val registry = buildRegistry(backgroundScope, store)
+        buildDispatcher(peersRepo, pendingRepo, store, registry, backgroundScope).start()
+        runCurrent()
+
+        pendingRepo.setPending(PendingFilesSummary(1, 100L), listOf(FakeFileSource("a.txt", 100L)))
+        repeat(4) { runCurrent() }
+
+        assertIs<PeerTransferState.Idle>(registry.engineFor(peerA.id).state.value)
+        assertNotNull(pendingRepo.summary.value)
+    }
+
+    @Test
     fun `single online peer with auto-send ON triggers transfer on pending arrival`() = runTest {
         val store = FakePeerPreferencesStore()
         store.setAutoSendSync(peerA.id, true)

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcherTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcherTest.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -106,6 +107,35 @@ class AutoSendDispatcherTest {
         repeat(4) { runCurrent() }
 
         assertIs<PeerTransferState.Idle>(registry.engineFor(peerA.id).state.value)
+        assertNotNull(pendingRepo.summary.value)
+    }
+
+    @Test
+    fun `engine is not created when auto-send is OFF`() = runTest {
+        val store = FakePeerPreferencesStore()
+        val peersRepo = FakePeersRepository(MutableStateFlow(listOf(peerA)))
+        val pendingRepo = PendingFilesRepository()
+        var factoryCallCount = 0
+        val registry = PeerTransferEngineRegistry(
+            appScope = backgroundScope,
+            engineFactory = { peer, scope ->
+                factoryCallCount++
+                PeerTransferEngine(
+                    peer = peer,
+                    batchSenderFactory = fakeBatchSender(),
+                    inboundEvents = MutableSharedFlow(),
+                    scope = scope,
+                    peerPreferencesStore = store,
+                )
+            },
+        )
+        buildDispatcher(peersRepo, pendingRepo, store, registry, backgroundScope).start()
+        runCurrent()
+
+        pendingRepo.setPending(PendingFilesSummary(1, 100L), listOf(FakeFileSource("a.txt", 100L)))
+        repeat(4) { runCurrent() }
+
+        assertEquals(0, factoryCallCount)
         assertNotNull(pendingRepo.summary.value)
     }
 

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcherTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcherTest.kt
@@ -91,59 +91,6 @@ class AutoSendDispatcherTest {
     }
 
     @Test
-    fun `two online peers with auto-send ON for both do not trigger`() = runTest {
-        val store = FakePeerPreferencesStore()
-        store.setAutoSendSync(peerA.id, true)
-        store.setAutoSendSync(peerB.id, true)
-        val peersRepo = FakePeersRepository(MutableStateFlow(listOf(peerA, peerB)))
-        val pendingRepo = PendingFilesRepository()
-        val registry = buildRegistry(backgroundScope, store)
-        buildDispatcher(peersRepo, pendingRepo, store, registry, backgroundScope).start()
-        runCurrent()
-
-        pendingRepo.setPending(PendingFilesSummary(1, 100L), listOf(FakeFileSource("a.txt", 100L)))
-        repeat(4) { runCurrent() }
-
-        assertIs<PeerTransferState.Idle>(registry.engineFor(peerA.id).state.value)
-        assertIs<PeerTransferState.Idle>(registry.engineFor(peerB.id).state.value)
-        assertNotNull(pendingRepo.summary.value)
-    }
-
-    @Test
-    fun `two online peers with auto-send ON only for one do not trigger`() = runTest {
-        val store = FakePeerPreferencesStore()
-        store.setAutoSendSync(peerA.id, true)
-        val peersRepo = FakePeersRepository(MutableStateFlow(listOf(peerA, peerB)))
-        val pendingRepo = PendingFilesRepository()
-        val registry = buildRegistry(backgroundScope, store)
-        buildDispatcher(peersRepo, pendingRepo, store, registry, backgroundScope).start()
-        runCurrent()
-
-        pendingRepo.setPending(PendingFilesSummary(1, 100L), listOf(FakeFileSource("a.txt", 100L)))
-        repeat(4) { runCurrent() }
-
-        assertIs<PeerTransferState.Idle>(registry.engineFor(peerA.id).state.value)
-        assertIs<PeerTransferState.Idle>(registry.engineFor(peerB.id).state.value)
-        assertNotNull(pendingRepo.summary.value)
-    }
-
-    @Test
-    fun `zero online peers do not trigger`() = runTest {
-        val store = FakePeerPreferencesStore()
-        store.setAutoSendSync(peerA.id, true)
-        val peersRepo = FakePeersRepository(MutableStateFlow(emptyList()))
-        val pendingRepo = PendingFilesRepository()
-        val registry = buildRegistry(backgroundScope, store)
-        buildDispatcher(peersRepo, pendingRepo, store, registry, backgroundScope).start()
-        runCurrent()
-
-        pendingRepo.setPending(PendingFilesSummary(1, 100L), listOf(FakeFileSource("a.txt", 100L)))
-        repeat(4) { runCurrent() }
-
-        assertNotNull(pendingRepo.summary.value)
-    }
-
-    @Test
     fun `auto-send bails when a second peer comes online during preference read`() = runTest {
         val gate = kotlinx.coroutines.CompletableDeferred<Unit>()
         val peersFlow = MutableStateFlow(listOf(peerA))

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcherTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcherTest.kt
@@ -208,11 +208,9 @@ class AutoSendDispatcherTest {
         pendingRepo.setPending(PendingFilesSummary(1, 100L), listOf(FakeFileSource("a.txt", 100L)))
         repeat(4) { runCurrent() }
 
-        // First emission: IOException caught → emit(false) → no trigger.
         assertIs<PeerTransferState.Idle>(registry.engineFor(peerA.id).state.value)
         assertNotNull(pendingRepo.summary.value)
 
-        // Second emission: store succeeds → transfer starts.
         pendingRepo.clear()
         pendingRepo.setPending(PendingFilesSummary(1, 100L), listOf(FakeFileSource("a.txt", 100L)))
         repeat(4) { runCurrent() }

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcherTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/AutoSendDispatcherTest.kt
@@ -1,0 +1,287 @@
+package com.tubetoast.tether.transfer
+
+import com.tubetoast.tether.preferences.FakePeerPreferencesStore
+import com.tubetoast.tether.preferences.PeerPreferencesStore
+import com.tubetoast.tether.presentation.peer.FakePeersRepository
+import com.tubetoast.tether.presentation.peer.Peer
+import com.tubetoast.tether.protocol.Device
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AutoSendDispatcherTest {
+    private val deviceA = Device(name = "PeerA", host = "10.0.0.1", port = 8080)
+    private val deviceB = Device(name = "PeerB", host = "10.0.0.2", port = 8080)
+
+    private val peerA = Peer(id = PeerIdentity("peer-a"), device = deviceA, isOnline = true)
+    private val peerB = Peer(id = PeerIdentity("peer-b"), device = deviceB, isOnline = true)
+
+    /**
+     * Builds a registry whose engine factory uses the given [scope] (test scheduler),
+     * bypassing the [PeerTransferEngineRegistry]'s own Dispatchers.Default engine scope.
+     */
+    private fun buildRegistry(scope: CoroutineScope, store: PeerPreferencesStore): PeerTransferEngineRegistry =
+        PeerTransferEngineRegistry(
+            appScope = scope,
+            engineFactory = { peer, _ ->
+                PeerTransferEngine(
+                    peer = peer,
+                    batchSenderFactory = fakeBatchSender(),
+                    inboundEvents = MutableSharedFlow(),
+                    scope = scope,
+                    peerPreferencesStore = store,
+                )
+            },
+        )
+
+    private fun buildDispatcher(
+        peersRepo: FakePeersRepository,
+        pendingRepo: PendingFilesRepository,
+        store: PeerPreferencesStore,
+        registry: PeerTransferEngineRegistry,
+        scope: CoroutineScope,
+    ) = AutoSendDispatcher(
+        peersRepository = peersRepo,
+        pendingFilesRepository = pendingRepo,
+        peerPreferencesStore = store,
+        engineRegistry = registry,
+        scope = scope,
+    )
+
+    @Test
+    fun `single online peer with auto-send ON triggers transfer on pending arrival`() = runTest {
+        val store = FakePeerPreferencesStore()
+        store.setAutoSendSync(peerA.id, true)
+        val peersRepo = FakePeersRepository(MutableStateFlow(listOf(peerA)))
+        val pendingRepo = PendingFilesRepository()
+        val registry = buildRegistry(backgroundScope, store)
+        buildDispatcher(peersRepo, pendingRepo, store, registry, backgroundScope).start()
+        runCurrent()
+
+        pendingRepo.setPending(PendingFilesSummary(1, 100L), listOf(FakeFileSource("a.txt", 100L)))
+        repeat(4) { runCurrent() }
+
+        assertIs<PeerTransferState.Sent>(registry.engineFor(peerA.id).state.value)
+        assertNull(pendingRepo.summary.value)
+    }
+
+    @Test
+    fun `single online peer with auto-send OFF does not trigger`() = runTest {
+        val store = FakePeerPreferencesStore()
+        val peersRepo = FakePeersRepository(MutableStateFlow(listOf(peerA)))
+        val pendingRepo = PendingFilesRepository()
+        val registry = buildRegistry(backgroundScope, store)
+        buildDispatcher(peersRepo, pendingRepo, store, registry, backgroundScope).start()
+        runCurrent()
+
+        pendingRepo.setPending(PendingFilesSummary(1, 100L), listOf(FakeFileSource("a.txt", 100L)))
+        repeat(4) { runCurrent() }
+
+        assertIs<PeerTransferState.Idle>(registry.engineFor(peerA.id).state.value)
+        assertNotNull(pendingRepo.summary.value)
+    }
+
+    @Test
+    fun `two online peers with auto-send ON for both do not trigger`() = runTest {
+        val store = FakePeerPreferencesStore()
+        store.setAutoSendSync(peerA.id, true)
+        store.setAutoSendSync(peerB.id, true)
+        val peersRepo = FakePeersRepository(MutableStateFlow(listOf(peerA, peerB)))
+        val pendingRepo = PendingFilesRepository()
+        val registry = buildRegistry(backgroundScope, store)
+        buildDispatcher(peersRepo, pendingRepo, store, registry, backgroundScope).start()
+        runCurrent()
+
+        pendingRepo.setPending(PendingFilesSummary(1, 100L), listOf(FakeFileSource("a.txt", 100L)))
+        repeat(4) { runCurrent() }
+
+        assertIs<PeerTransferState.Idle>(registry.engineFor(peerA.id).state.value)
+        assertIs<PeerTransferState.Idle>(registry.engineFor(peerB.id).state.value)
+        assertNotNull(pendingRepo.summary.value)
+    }
+
+    @Test
+    fun `two online peers with auto-send ON only for one do not trigger`() = runTest {
+        val store = FakePeerPreferencesStore()
+        store.setAutoSendSync(peerA.id, true)
+        val peersRepo = FakePeersRepository(MutableStateFlow(listOf(peerA, peerB)))
+        val pendingRepo = PendingFilesRepository()
+        val registry = buildRegistry(backgroundScope, store)
+        buildDispatcher(peersRepo, pendingRepo, store, registry, backgroundScope).start()
+        runCurrent()
+
+        pendingRepo.setPending(PendingFilesSummary(1, 100L), listOf(FakeFileSource("a.txt", 100L)))
+        repeat(4) { runCurrent() }
+
+        assertIs<PeerTransferState.Idle>(registry.engineFor(peerA.id).state.value)
+        assertIs<PeerTransferState.Idle>(registry.engineFor(peerB.id).state.value)
+        assertNotNull(pendingRepo.summary.value)
+    }
+
+    @Test
+    fun `zero online peers do not trigger`() = runTest {
+        val store = FakePeerPreferencesStore()
+        store.setAutoSendSync(peerA.id, true)
+        val peersRepo = FakePeersRepository(MutableStateFlow(emptyList()))
+        val pendingRepo = PendingFilesRepository()
+        val registry = buildRegistry(backgroundScope, store)
+        buildDispatcher(peersRepo, pendingRepo, store, registry, backgroundScope).start()
+        runCurrent()
+
+        pendingRepo.setPending(PendingFilesSummary(1, 100L), listOf(FakeFileSource("a.txt", 100L)))
+        repeat(4) { runCurrent() }
+
+        assertNotNull(pendingRepo.summary.value)
+    }
+
+    @Test
+    fun `auto-send bails when a second peer comes online during preference read`() = runTest {
+        val gate = kotlinx.coroutines.CompletableDeferred<Unit>()
+        val peersFlow = MutableStateFlow(listOf(peerA))
+        val peersRepo = FakePeersRepository(peersFlow)
+        val pendingRepo = PendingFilesRepository()
+        val store = FakePeerPreferencesStore()
+
+        val gatedStore = object : PeerPreferencesStore {
+            override fun observeAutoSend(peer: PeerIdentity) = flow {
+                gate.await()
+                emit(true)
+            }
+
+            override suspend fun setAutoSend(peer: PeerIdentity, enabled: Boolean) = Unit
+
+            override suspend fun autoSendEnabledFor(peer: PeerIdentity) = true
+        }
+
+        val registry = buildRegistry(backgroundScope, store)
+        buildDispatcher(peersRepo, pendingRepo, gatedStore, registry, backgroundScope).start()
+        runCurrent()
+
+        pendingRepo.setPending(PendingFilesSummary(1, 100L), listOf(FakeFileSource("a.txt", 100L)))
+        runCurrent()
+
+        peersFlow.value = listOf(peerA, peerB)
+        gate.complete(Unit)
+        repeat(4) { runCurrent() }
+
+        assertIs<PeerTransferState.Idle>(registry.engineFor(peerA.id).state.value)
+        assertNotNull(pendingRepo.summary.value)
+    }
+
+    @Test
+    fun `auto-send bails when sources are cleared during preference read`() = runTest {
+        val gate = kotlinx.coroutines.CompletableDeferred<Unit>()
+        val peersRepo = FakePeersRepository(MutableStateFlow(listOf(peerA)))
+        val pendingRepo = PendingFilesRepository()
+        val store = FakePeerPreferencesStore()
+
+        val gatedStore = object : PeerPreferencesStore {
+            override fun observeAutoSend(peer: PeerIdentity) = flow {
+                gate.await()
+                emit(true)
+            }
+
+            override suspend fun setAutoSend(peer: PeerIdentity, enabled: Boolean) = Unit
+
+            override suspend fun autoSendEnabledFor(peer: PeerIdentity) = true
+        }
+
+        val registry = buildRegistry(backgroundScope, store)
+        buildDispatcher(peersRepo, pendingRepo, gatedStore, registry, backgroundScope).start()
+        runCurrent()
+
+        pendingRepo.setPending(PendingFilesSummary(1, 100L), listOf(FakeFileSource("a.txt", 100L)))
+        runCurrent()
+
+        pendingRepo.clear()
+        gate.complete(Unit)
+        repeat(4) { runCurrent() }
+
+        assertIs<PeerTransferState.Idle>(registry.engineFor(peerA.id).state.value)
+        assertNull(pendingRepo.summary.value)
+    }
+
+    @Test
+    fun `auto-send bails when engine is no longer Idle after preference read`() = runTest {
+        val gate = kotlinx.coroutines.CompletableDeferred<Unit>()
+        val peersRepo = FakePeersRepository(MutableStateFlow(listOf(peerA)))
+        val pendingRepo = PendingFilesRepository()
+        val store = FakePeerPreferencesStore()
+
+        val gatedStore = object : PeerPreferencesStore {
+            override fun observeAutoSend(peer: PeerIdentity) = flow {
+                gate.await()
+                emit(true)
+            }
+
+            override suspend fun setAutoSend(peer: PeerIdentity, enabled: Boolean) = Unit
+
+            override suspend fun autoSendEnabledFor(peer: PeerIdentity) = true
+        }
+
+        val registry = buildRegistry(backgroundScope, store)
+        buildDispatcher(peersRepo, pendingRepo, gatedStore, registry, backgroundScope).start()
+        runCurrent()
+
+        val otherSources = listOf(FakeFileSource("other.txt", 50L))
+        pendingRepo.setPending(PendingFilesSummary(1, 100L), listOf(FakeFileSource("a.txt", 100L)))
+        runCurrent()
+
+        registry.engineFor(peerA.id).startOutbound(otherSources)
+        repeat(4) { runCurrent() }
+
+        gate.complete(Unit)
+        repeat(4) { runCurrent() }
+
+        // Engine already transitioned; auto-send must not start a second batch or clear pending.
+        assertNotNull(pendingRepo.summary.value)
+    }
+
+    @Test
+    fun `auto-send pipeline recovers after preference read IOException`() = runTest {
+        var callCount = 0
+        val peersRepo = FakePeersRepository(MutableStateFlow(listOf(peerA)))
+        val pendingRepo = PendingFilesRepository()
+        val store = FakePeerPreferencesStore()
+
+        val failOnceStore = object : PeerPreferencesStore {
+            override fun observeAutoSend(peer: PeerIdentity) = flow<Boolean> {
+                callCount++
+                if (callCount == 1) throw java.io.IOException("DataStore unavailable")
+                emit(true)
+            }
+
+            override suspend fun setAutoSend(peer: PeerIdentity, enabled: Boolean) = Unit
+
+            override suspend fun autoSendEnabledFor(peer: PeerIdentity) = true
+        }
+
+        val registry = buildRegistry(backgroundScope, store)
+        buildDispatcher(peersRepo, pendingRepo, failOnceStore, registry, backgroundScope).start()
+        runCurrent()
+
+        pendingRepo.setPending(PendingFilesSummary(1, 100L), listOf(FakeFileSource("a.txt", 100L)))
+        repeat(4) { runCurrent() }
+
+        // First emission: IOException caught → emit(false) → no trigger.
+        assertIs<PeerTransferState.Idle>(registry.engineFor(peerA.id).state.value)
+        assertNotNull(pendingRepo.summary.value)
+
+        // Second emission: store succeeds → transfer starts.
+        pendingRepo.clear()
+        pendingRepo.setPending(PendingFilesSummary(1, 100L), listOf(FakeFileSource("a.txt", 100L)))
+        repeat(4) { runCurrent() }
+
+        assertIs<PeerTransferState.Sent>(registry.engineFor(peerA.id).state.value)
+        assertNull(pendingRepo.summary.value)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineRegistryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineRegistryTest.kt
@@ -1,5 +1,6 @@
 package com.tubetoast.tether.transfer
 
+import com.tubetoast.tether.preferences.FakePeerPreferencesStore
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -32,6 +33,7 @@ class PeerTransferEngineRegistryTest {
                     batchSenderFactory = fakeBatchSender(),
                     inboundEvents = MutableSharedFlow(),
                     scope = engineScope,
+                    peerPreferencesStore = FakePeerPreferencesStore(),
                 )
             },
         )
@@ -79,6 +81,7 @@ class PeerTransferEngineRegistryTest {
                     batchSenderFactory = fakeBatchSender(),
                     inboundEvents = MutableSharedFlow(),
                     scope = engineScope,
+                    peerPreferencesStore = FakePeerPreferencesStore(),
                 )
             },
         )

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineTest.kt
@@ -61,6 +61,20 @@ class PeerTransferEngineTest {
     }
 
     @Test
+    fun `cancel during Claimed phase transitions to Cancelled`() = runTest {
+        val pauseChannel = Channel<Unit>(0)
+        val engine = buildEngine(pauseChannel = pauseChannel, scope = backgroundScope)
+
+        engine.startOutbound(listOf(FakeFileSource("a.txt", 100L), FakeFileSource("b.txt", 100L)))
+        assertIs<PeerTransferState.ActiveOutbound.Claimed>(engine.state.value)
+
+        engine.onCancel()
+        runCurrent()
+
+        assertIs<PeerTransferState.Cancelled>(engine.state.value)
+    }
+
+    @Test
     fun `inbound Started Progress FileCompleted BatchCompleted produces Received`() = runTest {
         val events = MutableSharedFlow<ReceiveEvent>(extraBufferCapacity = 16)
         val engine = buildEngine(events = events, scope = backgroundScope)

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineTest.kt
@@ -340,6 +340,31 @@ class PeerTransferEngineTest {
     }
 
     @Test
+    fun `concurrent startOutbound calls produce one launchBatch`() = runTest {
+        var factoryInvocations = 0
+        val engine = PeerTransferEngine(
+            peer = peer,
+            batchSenderFactory = {
+                factoryInvocations++
+                fakeBatchSender()()
+            },
+            inboundEvents = MutableSharedFlow(),
+            scope = backgroundScope,
+            peerPreferencesStore = FakePeerPreferencesStore(),
+        )
+
+        val sourcesA = listOf(FakeFileSource("a.txt", 100L))
+        val sourcesB = listOf(FakeFileSource("b.txt", 200L))
+        engine.startOutbound(sourcesA)
+        engine.startOutbound(sourcesB)
+        runCurrent()
+
+        assertEquals(1, factoryInvocations)
+        val state = engine.state.value as PeerTransferState.Sent
+        assertEquals("a.txt", state.perFile.first().name)
+    }
+
+    @Test
     fun `onDismiss from Sent returns to Idle`() = runTest {
         val engine = buildEngine(scope = backgroundScope)
 

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineTest.kt
@@ -75,6 +75,36 @@ class PeerTransferEngineTest {
     }
 
     @Test
+    fun `cancel during Claimed phase produces retryable Cancelled`() = runTest {
+        var factoryInvocations = 0
+        val engine = PeerTransferEngine(
+            peer = peer,
+            batchSenderFactory = {
+                factoryInvocations++
+                fakeBatchSender()()
+            },
+            inboundEvents = MutableSharedFlow(),
+            scope = backgroundScope,
+            peerPreferencesStore = FakePeerPreferencesStore(),
+        )
+
+        engine.startOutbound(listOf(FakeFileSource("a.txt", 100L), FakeFileSource("b.txt", 100L)))
+        assertIs<PeerTransferState.ActiveOutbound.Claimed>(engine.state.value)
+
+        engine.onCancel()
+        runCurrent()
+
+        assertIs<PeerTransferState.Cancelled>(engine.state.value)
+        assertEquals(1, factoryInvocations)
+
+        engine.onRetryOutbound()
+        runCurrent()
+
+        assertEquals(2, factoryInvocations)
+        assertIs<PeerTransferState.Sent>(engine.state.value)
+    }
+
+    @Test
     fun `inbound Started Progress FileCompleted BatchCompleted produces Received`() = runTest {
         val events = MutableSharedFlow<ReceiveEvent>(extraBufferCapacity = 16)
         val engine = buildEngine(events = events, scope = backgroundScope)

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineTest.kt
@@ -1,5 +1,6 @@
 package com.tubetoast.tether.transfer
 
+import com.tubetoast.tether.preferences.FakePeerPreferencesStore
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -24,6 +25,7 @@ class PeerTransferEngineTest {
         batchSenderFactory = fakeBatchSender(sendOneOverride = sendOneOverride, pauseChannel = pauseChannel),
         inboundEvents = events,
         scope = scope,
+        peerPreferencesStore = FakePeerPreferencesStore(),
     )
 
     @Test

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineTest.kt
@@ -35,13 +35,13 @@ class PeerTransferEngineTest {
 
         engine.startOutbound(listOf(FakeFileSource("a.txt", 100L)))
         runCurrent()
-        assertIs<PeerTransferState.ActiveOutbound>(engine.state.value)
-        val firstFile = (engine.state.value as PeerTransferState.ActiveOutbound).currentFile
+        val firstState = assertIs<PeerTransferState.ActiveOutbound.Sending>(engine.state.value)
+        val firstFile = firstState.currentFile
 
         engine.startOutbound(listOf(FakeFileSource("b.txt", 200L)))
         runCurrent()
 
-        val state = engine.state.value as PeerTransferState.ActiveOutbound
+        val state = assertIs<PeerTransferState.ActiveOutbound.Sending>(engine.state.value)
         assertEquals(firstFile, state.currentFile)
     }
 

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineTest.kt
@@ -95,12 +95,13 @@ class PeerTransferEngineTest {
         runCurrent()
 
         assertIs<PeerTransferState.Cancelled>(engine.state.value)
-        assertEquals(1, factoryInvocations)
+        // First launch was cancelled before its body executed — factory never called.
+        assertEquals(0, factoryInvocations)
 
         engine.onRetryOutbound()
         runCurrent()
 
-        assertEquals(2, factoryInvocations)
+        assertEquals(1, factoryInvocations)
         assertIs<PeerTransferState.Sent>(engine.state.value)
     }
 

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/MainUi.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/MainUi.kt
@@ -25,6 +25,7 @@ fun main() = runBlocking {
     )
     container.nameStore.init()
     val handle = container.startBackendOrFail()
+    container.autoSendDispatcher.start()
     registerShutdownHook(handle)
 
     val lifecycle = LifecycleRegistry()

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/di/DesktopAppContainer.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/di/DesktopAppContainer.kt
@@ -38,8 +38,4 @@ class DesktopAppContainer(
         defaultSaveLocation = File(System.getProperty("user.home"), "Downloads").absolutePath,
         saveLocationWritable = true,
     )
-
-    init {
-        activateEagerSingletons()
-    }
 }

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/di/DesktopAppContainer.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/di/DesktopAppContainer.kt
@@ -40,6 +40,6 @@ class DesktopAppContainer(
     )
 
     init {
-        autoSendDispatcher
+        activateEagerSingletons()
     }
 }

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/di/DesktopAppContainer.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/di/DesktopAppContainer.kt
@@ -38,4 +38,8 @@ class DesktopAppContainer(
         defaultSaveLocation = File(System.getProperty("user.home"), "Downloads").absolutePath,
         saveLocationWritable = true,
     )
+
+    init {
+        autoSendDispatcher
+    }
 }

--- a/composeApp/src/iosMain/kotlin/com/tubetoast/tether/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/com/tubetoast/tether/MainViewController.kt
@@ -45,6 +45,7 @@ fun MainViewController() = run {
                 val port = container.fileServer.start()
                 container.mdnsDiscovery.start(name, port = port)
                 container.nameRepublisher.start(scope)
+                container.autoSendDispatcher.start()
             }
             onDispose {
                 container.nameRepublisher.stop()

--- a/docs/engineering/dependency-injection.md
+++ b/docs/engineering/dependency-injection.md
@@ -123,6 +123,10 @@ The composition root is the only place that knows lifecycles. Everywhere else, y
 
 The logging façade ([`KydraLog`](logging.md)) is the documented exception: a process-global cross-cutting infra singleton initialised once per platform entry point, accessed directly (`KydraLog.withTag(...)`) without passing through the graph. Rationale and trade-offs in [`adr/adr-logging-kydra.md`](adr/adr-logging-kydra.md).
 
+**`AppContainer` composes; entry points start.** A singleton that owns a long-lived collector or background subscription is constructed lazily in `AppContainer` like any other graph node, but its `start()` is invoked from each platform's entry point (Android `Application.onCreate`, Desktop `main`, iOS `MainViewController`, future CLI `main`) alongside `fileServer.start()` / `mdnsDiscovery.start()`. The base container cannot do this from its own `init` block — abstract collaborators are not yet assigned when `AppContainer.<init>` runs. Adding the `start()` line to a new entry point is the explicit, compile-noisy way to opt in; a forgotten line surfaces as silent inactivity, not a crash.
+
+**Domain-layer orchestrators live in the relevant domain package.** When a singleton coordinates domain primitives (e.g. `AutoSendDispatcher` reading `peersRepository.peers` + `pendingFilesRepository.sources` + `peerPreferencesStore` and driving `PeerTransferEngineRegistry`) it goes into the matching domain package (`com.tubetoast.tether.transfer`, etc.), not into `presentation`. CLI and UI then share the same orchestrator through `AppContainer` without each surface re-implementing the rule.
+
 ### 4. Don't instantiate dependencies inside composables
 
 ❌

--- a/docs/interview-prep-checklist.md
+++ b/docs/interview-prep-checklist.md
@@ -16,7 +16,7 @@
 - [ ] `copy` — поверхностная копия, что с этим делать
 - [ ] `value class` (`@JvmInline`) — боксинг/анбоксинг, когда vs `data class`
 - [ ] `data object` (Kotlin 1.9+) — чем отличается от `object` и `data class`
-- [ ] `sealed class` vs `sealed interface` — когда что, exhaustive `when`
+- [x] `sealed class` vs `sealed interface` — когда что, exhaustive `when`
 - [ ] `object` — singleton, companion object, thread-safety, порядок инициализации
 - [ ] `inner class` vs вложенный класс — захват ссылки, утечки памяти
 - [ ] Делегирование через `by` — `lazy`, `observable`, `vetoable`, кастомные делегаты


### PR DESCRIPTION
**What / why.** Реализует AC #5, перенесённый из #191: при поступлении pending файлов (share-sheet / drag-drop / CLI hand-off) и единственном онлайн-peer с включенным auto-send, передача стартует немедленно без тапа по карточке. Логика живёт в домен-слое (`AutoSendDispatcher` в `com.tubetoast.tether.transfer/`), поэтому будущий CLI (#328) получает её через `AppContainer` без дублирования.

**👀 Sanity-check.**
- Atomic-claim в `PeerTransferEngine.startOutbound` (`_state.compareAndSet(Idle, syntheticActiveOutbound)` перед `launchBatch`) — закрывает гонку двух одновременных callers (dispatcher + `onCardClick`). Покрыто `concurrent startOutbound calls produce one launchBatch`.
- Eager-init через `protected fun activateEagerSingletons()` на `AppContainer`. Каждый leaf-контейнер (Android / Desktop / Apple) зовёт его из своего `init` — нельзя сделать это в базе из-за порядка инициализации абстрактных свойств в Kotlin. Если появится новый платформенный контейнер, он должен повторить тот же вызов; компилятор это не ловит (документировано в KDoc).
- `AutoSendRouter` + `RoutingDecision` (предсуществующие на main) после инлайнинга решения внутрь `AutoSendDispatcher` больше не вызываются из прод-кода — только из своих тестов. Удалять не стал в рамках этого PR (не входит в scope #309); follow-up: «удалить осиротевший `AutoSendRouter` или найти ему второго потребителя».
- H5 из адверсариала: если карточка осталась в Sent после предыдущей auto-send и пришёл новый share, второй share НЕ авто-отправится — диспетчер увидит engine не-Idle и вернётся. Pending файлы остаются в репозитории; manual-banner показывается. По спецификации auto-send это намеренный fallback на manual; полноценный flow «Sent → dismiss → re-auto-send» вне scope #309 (отслеживается через #327).
- Три pre-existing residual-вопроса (auto-send TOCTOU, `clear()` racing future `setPending`, отсутствие `withTimeoutOrNull` на pref read) — таймингово-зависимые, в продакшене сейчас недостижимы; помечены как known-bounded.
- Smoke skipped: только presentation+domain wiring, network / mDNS / native код не трогали. Проверено `:composeApp:allTests` (десктоп + iOS arm64 + iOS sim arm64 compile) — зелёное.

Closes #309