### PR TITLE
#319: extract PeerTransferEngine + retain via PeerTransferEngineRegistry

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
@@ -17,7 +17,10 @@ import com.tubetoast.tether.security.TrustedDeviceStore
 import com.tubetoast.tether.transfer.BatchSender
 import com.tubetoast.tether.transfer.ConnectionMonitor
 import com.tubetoast.tether.transfer.NoOpConnectionMonitor
+import com.tubetoast.tether.transfer.PeerTransferEngine
+import com.tubetoast.tether.transfer.PeerTransferEngineRegistry
 import com.tubetoast.tether.transfer.PeerUnreachableException
+import com.tubetoast.tether.transfer.ReconnectionTimeout
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -52,12 +55,27 @@ abstract class AppContainer {
         }
     }
 
+    open val peerTransferEngineRegistry: PeerTransferEngineRegistry by lazy {
+        PeerTransferEngineRegistry(
+            appScope = appScope,
+            engineFactory = { peer, engineScope ->
+                PeerTransferEngine(
+                    peer = peer,
+                    batchSenderFactory = batchSenderFactory,
+                    // TODO(#195): wire real ReceiveEvent source when Receiver UI lands
+                    reconnectionTimeout = ReconnectionTimeout.DEFAULT,
+                    scope = engineScope,
+                    peerPreferencesStore = peerPreferencesStore,
+                )
+            },
+        )
+    }
+
     open val rootComponentFactory: RootComponentFactory by lazy {
         RootComponentFactory(
             peersRepository = peersRepository,
-            batchSenderFactory = batchSenderFactory,
+            peerTransferEngineRegistry = peerTransferEngineRegistry,
             pendingFilesRepository = pendingFilesRepository,
-            peerPreferencesStore = peerPreferencesStore,
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/PeerListComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/PeerListComponent.kt
@@ -35,11 +35,6 @@ class PeerListComponent(
                 val previous = _state.value.rows.associateBy { it.peer.id }
                 val newIds = peers.map { it.id }.toSet()
 
-                // Destroy components for peers no longer in the emit. Trade-off: an active
-                // transfer for a peer that drops from mDNS mid-flight is aborted when its
-                // lifecycle is destroyed. Until #319 (transfer state machine in domain repo)
-                // there is no safety net; foundation is cleaner this way and the regression
-                // is observable in behaviour, not in silent drift.
                 previous.values
                     .filter { it.peer.id !in newIds }
                     .forEach { it.transferComponent.destroyContext() }

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/PeerListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/PeerListScreen.kt
@@ -33,7 +33,7 @@ import com.tubetoast.tether.presentation.peercard.PeerCard
 import com.tubetoast.tether.presentation.peercard.PeerCardCallbacks
 import com.tubetoast.tether.presentation.peercard.PeerCardContent
 import com.tubetoast.tether.presentation.sheets.MobilePickerChooserSheet
-import com.tubetoast.tether.presentation.transfer.PeerTransferState
+import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.transfer.toPeerIdentity
 import com.tubetoast.tether.ui.designsystem.BodyText
 import com.tubetoast.tether.ui.designsystem.BrandMark

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/PeerListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/PeerListScreen.kt
@@ -33,6 +33,7 @@ import com.tubetoast.tether.presentation.peercard.PeerCard
 import com.tubetoast.tether.presentation.peercard.PeerCardCallbacks
 import com.tubetoast.tether.presentation.peercard.PeerCardContent
 import com.tubetoast.tether.presentation.sheets.MobilePickerChooserSheet
+import com.tubetoast.tether.presentation.transfer.PeerCardState
 import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.transfer.toPeerIdentity
 import com.tubetoast.tether.ui.designsystem.BodyText
@@ -95,7 +96,9 @@ private fun PeerListContent(
                 items(rows, key = { it.peer.device.id }) { row ->
                     val peerComponent = row.transferComponent
                     val transferState by peerComponent.state.subscribeAsState()
-                    val tapAction: () -> Unit = if (transferState is PeerTransferState.Idle && showMobileChooser) {
+                    val tapAction: () -> Unit = if (transferState.transfer is PeerTransferState.Idle &&
+                        showMobileChooser
+                    ) {
                         {
                             triggerClick = peerComponent::onCardClick
                             sheetState.targetDetent = SheetDetent.FullyExpanded
@@ -141,7 +144,7 @@ private fun PeerListContent(
 
 private data class PeerCardPreviewSpec(
     val peer: Peer,
-    val transferState: PeerTransferState,
+    val transferState: PeerCardState,
 )
 
 @Preview(name = "PeerList — discovering empty")
@@ -160,7 +163,7 @@ private fun PreviewSingleDevice(@PreviewParameter(Themes::class) dark: Boolean) 
             specs = listOf(
                 PeerCardPreviewSpec(
                     peer = Peer(id = device.toPeerIdentity(), device = device),
-                    transferState = TransferPreviewFixtures.idleCollapsed,
+                    transferState = PeerCardState(TransferPreviewFixtures.idleCollapsed, expanded = false),
                 ),
             ),
         )
@@ -174,11 +177,14 @@ private fun PreviewMultipleDevices(@PreviewParameter(Themes::class) dark: Boolea
             specs = PreviewFixtures.multipleDevices.mapIndexed { index, device ->
                 PeerCardPreviewSpec(
                     peer = Peer(id = device.toPeerIdentity(), device = device, isOnline = index != 2),
-                    transferState = when (index) {
-                        0 -> TransferPreviewFixtures.activeOutbound
-                        1 -> TransferPreviewFixtures.idleCollapsed
-                        else -> TransferPreviewFixtures.sentFull
-                    },
+                    transferState = PeerCardState(
+                        transfer = when (index) {
+                            0 -> TransferPreviewFixtures.activeOutbound
+                            1 -> TransferPreviewFixtures.idleCollapsed
+                            else -> TransferPreviewFixtures.sentFull
+                        },
+                        expanded = false,
+                    ),
                 )
             },
         )
@@ -193,7 +199,7 @@ private fun PreviewPendingState(@PreviewParameter(Themes::class) dark: Boolean) 
             specs = listOf(
                 PeerCardPreviewSpec(
                     peer = Peer(id = device.toPeerIdentity(), device = device),
-                    transferState = TransferPreviewFixtures.idleCollapsed,
+                    transferState = PeerCardState(TransferPreviewFixtures.idleCollapsed, expanded = false),
                 ),
             ),
         )

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/PeerListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/PeerListScreen.kt
@@ -144,7 +144,7 @@ private fun PeerListContent(
 
 private data class PeerCardPreviewSpec(
     val peer: Peer,
-    val transferState: PeerCardState,
+    val peerCardState: PeerCardState,
 )
 
 @Preview(name = "PeerList — discovering empty")
@@ -163,7 +163,7 @@ private fun PreviewSingleDevice(@PreviewParameter(Themes::class) dark: Boolean) 
             specs = listOf(
                 PeerCardPreviewSpec(
                     peer = Peer(id = device.toPeerIdentity(), device = device),
-                    transferState = PeerCardState(TransferPreviewFixtures.idleCollapsed, expanded = false),
+                    peerCardState = PeerCardState(TransferPreviewFixtures.idleCollapsed, expanded = false),
                 ),
             ),
         )
@@ -177,7 +177,7 @@ private fun PreviewMultipleDevices(@PreviewParameter(Themes::class) dark: Boolea
             specs = PreviewFixtures.multipleDevices.mapIndexed { index, device ->
                 PeerCardPreviewSpec(
                     peer = Peer(id = device.toPeerIdentity(), device = device, isOnline = index != 2),
-                    transferState = PeerCardState(
+                    peerCardState = PeerCardState(
                         transfer = when (index) {
                             0 -> TransferPreviewFixtures.activeOutbound
                             1 -> TransferPreviewFixtures.idleCollapsed
@@ -199,7 +199,7 @@ private fun PreviewPendingState(@PreviewParameter(Themes::class) dark: Boolean) 
             specs = listOf(
                 PeerCardPreviewSpec(
                     peer = Peer(id = device.toPeerIdentity(), device = device),
-                    transferState = PeerCardState(TransferPreviewFixtures.idleCollapsed, expanded = false),
+                    peerCardState = PeerCardState(TransferPreviewFixtures.idleCollapsed, expanded = false),
                 ),
             ),
         )
@@ -227,7 +227,7 @@ private fun PeerListContentPreview(specs: List<PeerCardPreviewSpec>) {
             LazyColumn(modifier = Modifier.fillMaxSize()) {
                 items(specs, key = { it.peer.device.id }) { spec ->
                     PeerCardContent(
-                        state = spec.transferState,
+                        state = spec.peerCardState,
                         isOnline = spec.peer.isOnline,
                         device = spec.peer.device,
                         callbacks = previewCallbacks(),
@@ -246,7 +246,7 @@ private fun previewCallbacks() = PeerCardCallbacks(
     onToggleAutoSend = {},
     onCancel = {},
     onDismiss = {},
-    onRetry = {},
+    onRetryOutbound = {},
     onShowDetails = {},
     onOpenFiles = {},
     onClick = null,

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/RootComponentFactory.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/RootComponentFactory.kt
@@ -2,23 +2,19 @@ package com.tubetoast.tether.presentation
 
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.essenty.lifecycle.coroutines.withLifecycle
-import com.tubetoast.tether.preferences.PeerPreferencesStore
 import com.tubetoast.tether.presentation.banners.BannersComponent
 import com.tubetoast.tether.presentation.peer.PeersRepository
 import com.tubetoast.tether.presentation.transfer.PeerTransferComponent
 import com.tubetoast.tether.presentation.transfer.PendingFilesRepository
-import com.tubetoast.tether.transfer.BatchSender
 import com.tubetoast.tether.transfer.PeerIdentity
-import com.tubetoast.tether.transfer.PeerTransferEngine
-import com.tubetoast.tether.transfer.ReconnectionTimeout
+import com.tubetoast.tether.transfer.PeerTransferEngineRegistry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 
 class RootComponentFactory(
     private val peersRepository: PeersRepository,
-    private val batchSenderFactory: () -> BatchSender,
+    private val peerTransferEngineRegistry: PeerTransferEngineRegistry,
     private val pendingFilesRepository: PendingFilesRepository,
-    private val peerPreferencesStore: PeerPreferencesStore? = null,
     private val onPickerPick: (PeerIdentity) -> Unit = {},
 ) {
     fun create(componentContext: ComponentContext): RootComponent =
@@ -29,21 +25,15 @@ class RootComponentFactory(
                     componentContext = ctx,
                     peersRepository = peersRepository,
                     peerTransferComponentFactory = { childCtx, lifecycle, peer ->
-                        val scope = CoroutineScope(Dispatchers.Main.immediate).withLifecycle(lifecycle)
-                        val engine = PeerTransferEngine(
-                            peer = peer.id,
-                            batchSenderFactory = batchSenderFactory,
-                            reconnectionTimeout = ReconnectionTimeout.DEFAULT,
-                            scope = scope,
-                            peerPreferencesStore = peerPreferencesStore,
-                        )
+                        val engine = peerTransferEngineRegistry.engineFor(peer.id)
+                        val componentScope = CoroutineScope(Dispatchers.Main.immediate).withLifecycle(lifecycle)
                         PeerTransferComponent(
                             componentContext = childCtx,
                             peer = peer,
                             lifecycleRegistry = lifecycle,
                             engine = engine,
+                            scope = componentScope,
                             onShowDetails = onShowDetails,
-                            scope = scope,
                             pendingFilesRepository = pendingFilesRepository,
                             onOpenPicker = { onPickerPick(peer.id) },
                         )

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/RootComponentFactory.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/RootComponentFactory.kt
@@ -9,6 +9,7 @@ import com.tubetoast.tether.presentation.transfer.PeerTransferComponent
 import com.tubetoast.tether.presentation.transfer.PendingFilesRepository
 import com.tubetoast.tether.transfer.BatchSender
 import com.tubetoast.tether.transfer.PeerIdentity
+import com.tubetoast.tether.transfer.PeerTransferEngine
 import com.tubetoast.tether.transfer.ReconnectionTimeout
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -28,16 +29,22 @@ class RootComponentFactory(
                     componentContext = ctx,
                     peersRepository = peersRepository,
                     peerTransferComponentFactory = { childCtx, lifecycle, peer ->
+                        val scope = CoroutineScope(Dispatchers.Main).withLifecycle(lifecycle)
+                        val engine = PeerTransferEngine(
+                            peer = peer.id,
+                            batchSenderFactory = batchSenderFactory,
+                            reconnectionTimeout = ReconnectionTimeout.DEFAULT,
+                            scope = scope,
+                            peerPreferencesStore = peerPreferencesStore,
+                        )
                         PeerTransferComponent(
                             componentContext = childCtx,
                             peer = peer,
                             lifecycleRegistry = lifecycle,
-                            batchSenderFactory = batchSenderFactory,
+                            engine = engine,
                             onShowDetails = onShowDetails,
-                            reconnectionTimeout = ReconnectionTimeout.DEFAULT,
-                            scope = CoroutineScope(Dispatchers.Main).withLifecycle(lifecycle),
+                            scope = scope,
                             pendingFilesRepository = pendingFilesRepository,
-                            peerPreferencesStore = peerPreferencesStore,
                             onOpenPicker = { onPickerPick(peer.id) },
                         )
                     },

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/RootComponentFactory.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/RootComponentFactory.kt
@@ -29,7 +29,7 @@ class RootComponentFactory(
                     componentContext = ctx,
                     peersRepository = peersRepository,
                     peerTransferComponentFactory = { childCtx, lifecycle, peer ->
-                        val scope = CoroutineScope(Dispatchers.Main).withLifecycle(lifecycle)
+                        val scope = CoroutineScope(Dispatchers.Main.immediate).withLifecycle(lifecycle)
                         val engine = PeerTransferEngine(
                             peer = peer.id,
                             batchSenderFactory = batchSenderFactory,

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/TransferDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/TransferDetailsScreen.kt
@@ -21,11 +21,11 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
-import com.tubetoast.tether.presentation.transfer.PeerTransferState
 import com.tubetoast.tether.presentation.transfer.PerFileRow
 import com.tubetoast.tether.presentation.transfer.TransferDetailsComponent
 import com.tubetoast.tether.presentation.transfer.aggregateStripCopy
 import com.tubetoast.tether.presentation.transfer.detailsSubtitleCopy
+import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.transfer.PerFileStatus
 import com.tubetoast.tether.ui.designsystem.BodyText
 import com.tubetoast.tether.ui.designsystem.Button

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/TransferDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/TransferDetailsScreen.kt
@@ -39,9 +39,9 @@ import com.tubetoast.tether.ui.theme.TetherTheme
 
 @Composable
 fun TransferDetailsScreen(component: TransferDetailsComponent) {
-    val state by component.state.subscribeAsState()
+    val cardState by component.state.subscribeAsState()
     TransferDetailsContent(
-        state = state,
+        state = cardState.transfer,
         onBack = component::onBack,
         onCancelTransfer = component::onCancelTransfer,
         onCancelFile = component::onCancelFile,

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCard.kt
@@ -22,7 +22,7 @@ fun PeerCard(
         onToggleAutoSend = component::setAutoSend,
         onCancel = component::onCancel,
         onDismiss = component::onDismiss,
-        onRetry = component::onRetry,
+        onRetryOutbound = component::onRetryOutbound,
         onShowDetails = component::onShowDetails,
         onOpenFiles = {
             // TODO(#192): Android — Intent.ACTION_VIEW to FileProvider URI for received folder

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCard.kt
@@ -6,8 +6,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.tubetoast.tether.presentation.transfer.PeerTransferComponent
-import com.tubetoast.tether.presentation.transfer.PeerTransferState
 import com.tubetoast.tether.protocol.Device
+import com.tubetoast.tether.transfer.PeerTransferState
 
 @Composable
 fun PeerCard(

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCard.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
+import com.tubetoast.tether.presentation.transfer.PeerCardState
 import com.tubetoast.tether.presentation.transfer.PeerTransferComponent
 import com.tubetoast.tether.protocol.Device
 import com.tubetoast.tether.transfer.PeerTransferState
@@ -42,16 +43,17 @@ fun PeerCard(
 
 @Composable
 internal fun PeerCardContent(
-    state: PeerTransferState,
+    state: PeerCardState,
     isOnline: Boolean,
     device: Device,
     callbacks: PeerCardCallbacks,
     modifier: Modifier = Modifier,
     isAutoSendEnabled: Boolean = false,
 ) {
-    when (state) {
+    when (val transfer = state.transfer) {
         is PeerTransferState.Idle -> PeerCardIdle(
-            state = state,
+            state = transfer,
+            expanded = state.expanded,
             device = device,
             isOnline = isOnline,
             isAutoSendEnabled = isAutoSendEnabled,
@@ -59,42 +61,42 @@ internal fun PeerCardContent(
             modifier = modifier,
         )
         is PeerTransferState.ActiveOutbound -> PeerCardActiveOutbound(
-            state = state,
+            state = transfer,
             device = device,
             callbacks = callbacks,
             modifier = modifier,
         )
         is PeerTransferState.ActiveInbound -> PeerCardActiveInbound(
-            state = state,
+            state = transfer,
             device = device,
             callbacks = callbacks,
             modifier = modifier,
         )
         is PeerTransferState.Reconnecting -> PeerCardReconnecting(
-            state = state,
+            state = transfer,
             device = device,
             modifier = modifier,
         )
         is PeerTransferState.Sent -> PeerCardSent(
-            state = state,
+            state = transfer,
             device = device,
             callbacks = callbacks,
             modifier = modifier,
         )
         is PeerTransferState.Received -> PeerCardReceived(
-            state = state,
+            state = transfer,
             device = device,
             callbacks = callbacks,
             modifier = modifier,
         )
         is PeerTransferState.Cancelled -> PeerCardCancelled(
-            state = state,
+            state = transfer,
             device = device,
             callbacks = callbacks,
             modifier = modifier,
         )
         is PeerTransferState.Error -> PeerCardError(
-            state = state,
+            state = transfer,
             device = device,
             isOnline = isOnline,
             callbacks = callbacks,

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardActive.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardActive.kt
@@ -234,7 +234,7 @@ private fun previewCardCallbacks() = PeerCardCallbacks(
     onToggleAutoSend = {},
     onCancel = {},
     onDismiss = {},
-    onRetry = {},
+    onRetryOutbound = {},
     onShowDetails = {},
     onOpenFiles = {},
 )

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardActive.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardActive.kt
@@ -16,8 +16,8 @@ import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import com.tubetoast.tether.presentation.transfer.PeerTransferState
 import com.tubetoast.tether.protocol.Device
+import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.ui.designsystem.Button
 import com.tubetoast.tether.ui.designsystem.ProgressBar
 import com.tubetoast.tether.ui.designsystem.TitleText

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardCallbacks.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardCallbacks.kt
@@ -5,7 +5,7 @@ data class PeerCardCallbacks(
     val onToggleAutoSend: (Boolean) -> Unit,
     val onCancel: () -> Unit,
     val onDismiss: () -> Unit,
-    val onRetry: () -> Unit,
+    val onRetryOutbound: () -> Unit,
     val onShowDetails: () -> Unit,
     val onOpenFiles: () -> Unit,
     /** Called when the card body is tapped while pending files exist. Null means the tap is a no-op. */

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardCopy.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardCopy.kt
@@ -1,7 +1,7 @@
 package com.tubetoast.tether.presentation.peercard
 
-import com.tubetoast.tether.presentation.transfer.PeerTransferState
 import com.tubetoast.tether.transfer.PartialOutcome
+import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.transfer.TransferErrorReason
 
 fun sentCardCopy(state: PeerTransferState.Sent): String {

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardIdle.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardIdle.kt
@@ -26,6 +26,7 @@ import com.tubetoast.tether.ui.theme.TetherTheme
 @Composable
 internal fun PeerCardIdle(
     state: PeerTransferState.Idle,
+    expanded: Boolean,
     device: Device,
     isOnline: Boolean,
     isAutoSendEnabled: Boolean,
@@ -57,13 +58,13 @@ internal fun PeerCardIdle(
                 )
             }
             ChevronToggleIcon(
-                expanded = state.expanded,
+                expanded = expanded,
                 onClick = callbacks.onToggleExpand,
-                contentDescription = if (state.expanded) "Collapse $peerName settings" else "Expand $peerName settings",
+                contentDescription = if (expanded) "Collapse $peerName settings" else "Expand $peerName settings",
             )
         }
 
-        if (state.expanded) {
+        if (expanded) {
             AutoSendToggle(
                 enabled = isAutoSendEnabled,
                 onToggle = callbacks.onToggleAutoSend,
@@ -83,6 +84,7 @@ private fun PreviewIdleCollapsedOnline(@PreviewParameter(Themes::class) dark: Bo
     PreviewSurface(darkTheme = dark) {
         PeerCardIdle(
             state = TransferPreviewFixtures.idleCollapsed,
+            expanded = false,
             device = TransferPreviewFixtures.device,
             isOnline = true,
             isAutoSendEnabled = false,
@@ -96,6 +98,7 @@ private fun PreviewIdleCollapsedOffline(@PreviewParameter(Themes::class) dark: B
     PreviewSurface(darkTheme = dark) {
         PeerCardIdle(
             state = TransferPreviewFixtures.idleCollapsed,
+            expanded = false,
             device = TransferPreviewFixtures.device,
             isOnline = false,
             isAutoSendEnabled = false,
@@ -109,6 +112,7 @@ private fun PreviewIdleExpandedAutoSendOff(@PreviewParameter(Themes::class) dark
     PreviewSurface(darkTheme = dark) {
         PeerCardIdle(
             state = TransferPreviewFixtures.idleExpanded,
+            expanded = true,
             device = TransferPreviewFixtures.device,
             isOnline = true,
             isAutoSendEnabled = false,
@@ -122,6 +126,7 @@ private fun PreviewIdleExpandedAutoSendOn(@PreviewParameter(Themes::class) dark:
     PreviewSurface(darkTheme = dark) {
         PeerCardIdle(
             state = TransferPreviewFixtures.idleExpanded,
+            expanded = true,
             device = TransferPreviewFixtures.device,
             isOnline = true,
             isAutoSendEnabled = true,

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardIdle.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardIdle.kt
@@ -12,8 +12,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import com.tubetoast.tether.presentation.transfer.PeerTransferState
 import com.tubetoast.tether.protocol.Device
+import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.ui.designsystem.BodyText
 import com.tubetoast.tether.ui.designsystem.ChevronToggleIcon
 import com.tubetoast.tether.ui.designsystem.TitleText

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardIdle.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardIdle.kt
@@ -139,7 +139,7 @@ private fun previewCallbacks() = PeerCardCallbacks(
     onToggleAutoSend = {},
     onCancel = {},
     onDismiss = {},
-    onRetry = {},
+    onRetryOutbound = {},
     onShowDetails = {},
     onOpenFiles = {},
 )

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardReconnecting.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardReconnecting.kt
@@ -11,8 +11,8 @@ import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import com.tubetoast.tether.presentation.transfer.PeerTransferState
 import com.tubetoast.tether.protocol.Device
+import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.ui.designsystem.BodyText
 import com.tubetoast.tether.ui.designsystem.TitleText
 import com.tubetoast.tether.ui.preview.PreviewSurface

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardTerminal.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardTerminal.kt
@@ -13,8 +13,8 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import com.tubetoast.tether.presentation.transfer.PeerTransferState
 import com.tubetoast.tether.protocol.Device
+import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.transfer.TransferErrorReason
 import com.tubetoast.tether.ui.designsystem.BodyText
 import com.tubetoast.tether.ui.designsystem.Button

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardTerminal.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardTerminal.kt
@@ -176,7 +176,7 @@ internal fun PeerCardError(
             if (state.reason != TransferErrorReason.ReceiverSuspended) {
                 Button(
                     label = "Retry",
-                    onClick = callbacks.onRetry,
+                    onClick = callbacks.onRetryOutbound,
                     contentDescription = retryDesc,
                     enabled = retryEnabled,
                 )
@@ -230,7 +230,7 @@ private fun previewCallbacks() = PeerCardCallbacks(
     onToggleAutoSend = {},
     onCancel = {},
     onDismiss = {},
-    onRetry = {},
+    onRetryOutbound = {},
     onShowDetails = {},
     onOpenFiles = {},
 )

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/Direction.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/Direction.kt
@@ -1,3 +1,0 @@
-package com.tubetoast.tether.presentation.transfer
-
-enum class Direction { Outbound, Inbound }

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/PeerCardState.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/PeerCardState.kt
@@ -4,6 +4,6 @@ import com.tubetoast.tether.transfer.PeerTransferState
 
 data class PeerCardState(
     val transfer: PeerTransferState,
-    /** Only meaningful when [transfer] is [PeerTransferState.Idle]. */
+    /** Has no effect when the card is not idle. */
     val expanded: Boolean,
 )

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/PeerCardState.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/PeerCardState.kt
@@ -1,0 +1,9 @@
+package com.tubetoast.tether.presentation.transfer
+
+import com.tubetoast.tether.transfer.PeerTransferState
+
+data class PeerCardState(
+    val transfer: PeerTransferState,
+    /** Only meaningful when [transfer] is [PeerTransferState.Idle]. */
+    val expanded: Boolean,
+)

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponent.kt
@@ -12,6 +12,7 @@ import com.tubetoast.tether.transfer.PeerIdentity
 import com.tubetoast.tether.transfer.PeerTransferEngine
 import com.tubetoast.tether.transfer.PeerTransferState
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -38,7 +39,7 @@ class PeerTransferComponent(
     init {
         engine.state
             .onEach { s -> mutableState.update { s } }
-            .launchIn(scope)
+            .launchIn(CoroutineScope(scope.coroutineContext + Dispatchers.Main.immediate))
     }
 
     fun startOutbound(sources: List<FileSource>) = engine.startOutbound(sources)

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponent.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 
 class PeerTransferComponent(
@@ -39,8 +38,7 @@ class PeerTransferComponent(
     val state: Value<PeerCardState> = mutableState
 
     init {
-        combine(engine.state, expanded) { transfer, exp -> PeerCardState(transfer, exp) }
-            .onEach { s -> mutableState.update { s } }
+        combine(engine.state, expanded) { transfer, exp -> mutableState.update { PeerCardState(transfer, exp) } }
             .launchIn(scope)
     }
 
@@ -58,7 +56,7 @@ class PeerTransferComponent(
 
     fun onCancel() = engine.onCancel()
 
-    fun onRetry() = engine.onRetry()
+    fun onRetryOutbound() = engine.onRetryOutbound()
 
     fun onRetryFile(name: String) = engine.onRetryFile(name)
 

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponent.kt
@@ -6,41 +6,24 @@ import com.arkivanov.decompose.value.Value
 import com.arkivanov.decompose.value.update
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.destroy
-import com.tubetoast.tether.preferences.PeerPreferencesStore
 import com.tubetoast.tether.presentation.peer.Peer
-import com.tubetoast.tether.transfer.BatchOutcome
-import com.tubetoast.tether.transfer.BatchProgress
-import com.tubetoast.tether.transfer.BatchSender
-import com.tubetoast.tether.transfer.FailureReason
 import com.tubetoast.tether.transfer.FileSource
-import com.tubetoast.tether.transfer.PartialOutcome
 import com.tubetoast.tether.transfer.PeerIdentity
-import com.tubetoast.tether.transfer.PerFileStatus
-import com.tubetoast.tether.transfer.ReceiveEvent
-import com.tubetoast.tether.transfer.ReconnectionTimeout
-import com.tubetoast.tether.transfer.TransferErrorReason
+import com.tubetoast.tether.transfer.PeerTransferEngine
+import com.tubetoast.tether.transfer.PeerTransferState
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
-import kotlin.time.Duration
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 class PeerTransferComponent(
     componentContext: ComponentContext,
     val peer: Peer,
     private val lifecycleRegistry: LifecycleRegistry,
-    private val batchSenderFactory: () -> BatchSender,
-    // TODO(#195): wire real ReceiveEvent source when Receiver UI lands
-    private val inboundEvents: Flow<ReceiveEvent> = MutableSharedFlow(),
+    private val engine: PeerTransferEngine,
     onShowDetails: (PeerIdentity) -> Unit,
-    private val reconnectionTimeout: Duration = ReconnectionTimeout.DEFAULT,
     private val scope: CoroutineScope,
     private val pendingFilesRepository: PendingFilesRepository? = null,
-    private val peerPreferencesStore: PeerPreferencesStore? = null,
     // TODO(#192/#193/#194): platform actuals wire real file picker here
     private val onOpenPicker: () -> Unit = {},
 ) : ComponentContext by componentContext {
@@ -49,326 +32,42 @@ class PeerTransferComponent(
     }
 
     private val showDetailsCallback = onShowDetails
-    private val mutableState = MutableValue<PeerTransferState>(PeerTransferState.Idle(peer.id))
+    private val mutableState = MutableValue<PeerTransferState>(engine.state.value)
     val state: Value<PeerTransferState> = mutableState
-    private var activeJob: Job? = null
-    private var currentSender: BatchSender? = null
-    private var originalSources: List<FileSource> = emptyList()
-    private val confirmedReceived = MutableStateFlow<Set<String>>(emptySet())
-    private val cancelledFileNames = MutableStateFlow<Set<String>>(emptySet())
 
     init {
-        scope.launch {
-            inboundEvents.collect { ev -> handleInbound(ev) }
-        }
+        engine.state
+            .onEach { s -> mutableState.update { s } }
+            .launchIn(scope)
     }
 
-    fun startOutbound(sources: List<FileSource>) {
-        val current = mutableState.value
-        if (current is PeerTransferState.ActiveOutbound ||
-            current is PeerTransferState.ActiveInbound ||
-            current is PeerTransferState.Reconnecting
-        ) {
-            return
-        }
-        originalSources = sources
-        cancelledFileNames.value = emptySet()
-        launchBatch(sources)
-    }
+    fun startOutbound(sources: List<FileSource>) = engine.startOutbound(sources)
 
     fun onCardClick() {
         val sources = pendingFilesRepository?.sources?.value.orEmpty()
         if (sources.isNotEmpty()) {
-            startOutbound(sources)
+            engine.startOutbound(sources)
             pendingFilesRepository?.clear()
         } else {
             onOpenPicker()
         }
     }
 
-    fun observeAutoSend(): Flow<Boolean> =
-        peerPreferencesStore?.observeAutoSend(peer.id) ?: flowOf(false)
+    fun onCancel() = engine.onCancel()
 
-    fun setAutoSend(enabled: Boolean) {
-        val store = peerPreferencesStore ?: return
-        scope.launch { store.setAutoSend(peer.id, enabled) }
-    }
+    fun onRetry() = engine.onRetry()
 
-    fun onCancel() {
-        activeJob?.cancel()
-        activeJob = null
-    }
+    fun onRetryFile(name: String) = engine.onRetryFile(name)
 
-    fun onRetry() {
-        val current = mutableState.value
-        val lastPerFile = when (current) {
-            is PeerTransferState.Sent -> current.perFile
-            is PeerTransferState.Error -> current.perFile
-            is PeerTransferState.Cancelled -> current.perFile
-            else -> return
-        }
-        val failedNames = lastPerFile.filterIsInstance<PerFileStatus.Failed>().map { it.name }.toSet()
-        val confirmed = confirmedReceived.value
-        val retryable = originalSources.filter { it.name in failedNames && it.name !in confirmed }
-        if (retryable.isEmpty()) return
-        cancelledFileNames.value = emptySet()
-        launchBatch(retryable)
-    }
+    fun onCancelFile(name: String) = engine.onCancelFile(name)
 
-    fun onRetryFile(name: String) {
-        val source = originalSources.firstOrNull { it.name == name } ?: return
-        cancelledFileNames.update { it - name }
-        val job = activeJob
-        activeJob = scope.launch {
-            job?.cancel()
-            job?.join()
-            launchBatchIn(listOf(source))
-        }
-    }
+    fun onDismiss() = engine.onDismiss()
 
-    fun onCancelFile(name: String) {
-        val current = mutableState.value as? PeerTransferState.ActiveOutbound ?: return
-        val idx = current.perFile.indexOfFirst { it.name == name }
-        if (idx < 0) return
-        when (val status = current.perFile[idx]) {
-            is PerFileStatus.InProgress -> {
-                val sender = currentSender
-                if (sender != null) scope.launch { sender.cancelCurrent(name) }
-            }
-            is PerFileStatus.Queued -> {
-                cancelledFileNames.update { it + name }
-                mutableState.update { s ->
-                    val active = s as? PeerTransferState.ActiveOutbound ?: return@update s
-                    val rowIdx = active.perFile.indexOfFirst { it.name == name }.takeIf { it >= 0 } ?: return@update s
-                    val updated = active.perFile.toMutableList()
-                    updated[rowIdx] = PerFileStatus.Failed(
-                        status.name,
-                        status.size,
-                        FailureReason.CancelledByUser,
-                        cancelledByUser = true,
-                    )
-                    active.copy(
-                        perFile = updated,
-                        skippedCount = updated.count { it is PerFileStatus.Failed },
-                    )
-                }
-            }
-            else -> Unit
-        }
-    }
+    fun toggleExpanded() = engine.toggleExpanded()
 
-    fun onDismiss() {
-        mutableState.update { s ->
-            if (s is PeerTransferState.Sent ||
-                s is PeerTransferState.Received ||
-                s is PeerTransferState.Cancelled ||
-                s is PeerTransferState.Error
-            ) {
-                PeerTransferState.Idle(peer.id)
-            } else {
-                s
-            }
-        }
-    }
+    fun observeAutoSend(): Flow<Boolean> = engine.observeAutoSend()
 
-    fun toggleExpanded() {
-        mutableState.update { s ->
-            (s as? PeerTransferState.Idle)?.copy(expanded = !s.expanded) ?: s
-        }
-    }
+    fun setAutoSend(enabled: Boolean) = engine.setAutoSend(enabled)
 
     fun onShowDetails() = showDetailsCallback(peer.id)
-
-    private fun launchBatch(sources: List<FileSource>) {
-        activeJob = scope.launch {
-            launchBatchIn(sources)
-        }
-    }
-
-    private suspend fun launchBatchIn(sources: List<FileSource>) {
-        val sender = batchSenderFactory()
-        currentSender = sender
-        try {
-            sender.run(sources, peer.id, { src -> src.name in cancelledFileNames.value }) { progress ->
-                mutableState.value = mapProgress(progress)
-            }
-        } finally {
-            currentSender = null
-        }
-    }
-
-    private fun mapProgress(progress: BatchProgress): PeerTransferState = when (progress) {
-        is BatchProgress.Sending -> PeerTransferState.ActiveOutbound(
-            peer = progress.peer,
-            currentFile = progress.currentFile,
-            currentIndex = progress.currentIndex,
-            totalFiles = progress.totalFiles,
-            sentBytes = progress.sentBytes,
-            totalBytes = progress.totalBytes,
-            bytesPerSec = progress.bytesPerSec,
-            skippedCount = progress.skippedCount,
-            perFile = progress.perFile,
-        )
-        is BatchProgress.Reconnecting -> PeerTransferState.Reconnecting(
-            peer = progress.peer,
-            direction = Direction.Outbound,
-            remainingSeconds = progress.remainingSeconds,
-            snapshotBeforeDrop = mapProgress(progress.snapshotBeforeDrop),
-        )
-        is BatchProgress.Completed -> mapCompleted(progress)
-    }
-
-    private fun mapCompleted(progress: BatchProgress.Completed): PeerTransferState {
-        val peer = progress.peer
-        val perFile = progress.perFile
-        return when (val outcome = progress.outcome) {
-            is BatchOutcome.AllSent -> PeerTransferState.Sent(
-                peer = peer,
-                sent = perFile.count { it is PerFileStatus.Done },
-                total = perFile.size,
-                perFile = perFile,
-                partialReason = null,
-            )
-            is BatchOutcome.PartialSent -> {
-                val failedEntries = perFile.filterIsInstance<PerFileStatus.Failed>()
-                val doneCount = perFile.count { it is PerFileStatus.Done }
-                PeerTransferState.Sent(
-                    peer = peer,
-                    sent = doneCount,
-                    total = perFile.size,
-                    perFile = perFile,
-                    partialReason = failedEntries.dominantPartialReason(),
-                )
-            }
-            is BatchOutcome.Cancelled -> PeerTransferState.Cancelled(
-                peer = peer,
-                sent = outcome.sent,
-                remaining = outcome.remaining,
-                perFile = perFile,
-            )
-            is BatchOutcome.Failed -> PeerTransferState.Error(
-                peer = peer,
-                reason = outcome.reason,
-                sent = outcome.sent,
-                perFile = perFile,
-            )
-        }
-    }
-
-    private fun handleInbound(ev: ReceiveEvent) {
-        when (ev) {
-            is ReceiveEvent.Started -> {
-                val perFile: List<PerFileStatus> = List(ev.totalFiles) { i ->
-                    if (i == 0) PerFileStatus.Queued(ev.currentFile, null) else PerFileStatus.Queued("", null)
-                }
-                mutableState.value = PeerTransferState.ActiveInbound(
-                    peer = peer.id,
-                    currentFile = ev.currentFile,
-                    currentIndex = 0,
-                    totalFiles = ev.totalFiles,
-                    receivedBytes = 0L,
-                    totalBytes = null,
-                    bytesPerSec = null,
-                    perFile = perFile,
-                )
-            }
-            is ReceiveEvent.Progress -> {
-                mutableState.update { s ->
-                    val active = s as? PeerTransferState.ActiveInbound ?: return@update s
-                    val idx = active.perFile.indexOfFirst { it.name == ev.name }.takeIf { it >= 0 }
-                        ?: active.perFile.indexOfFirst { it.name.isEmpty() }.takeIf { it >= 0 }
-                        ?: active.currentIndex
-                    val updated = active.perFile.toMutableList()
-                    updated[idx] = PerFileStatus.InProgress(ev.name, ev.totalBytes, ev.receivedBytes)
-                    active.copy(
-                        currentFile = ev.name,
-                        receivedBytes = ev.receivedBytes,
-                        totalBytes = ev.totalBytes,
-                        perFile = updated,
-                    )
-                }
-            }
-            is ReceiveEvent.FileCompleted -> {
-                confirmedReceived.update { it + ev.name }
-                mutableState.update { s ->
-                    val active = s as? PeerTransferState.ActiveInbound ?: return@update s
-                    val idx = active.perFile.indexOfFirst { it.name == ev.name }.takeIf { it >= 0 }
-                        ?: active.currentIndex
-                    val updated = active.perFile.toMutableList()
-                    updated[idx] = PerFileStatus.Done(ev.name, active.perFile[idx].size)
-                    active.copy(
-                        currentIndex = (idx + 1).coerceAtMost(active.totalFiles - 1),
-                        perFile = updated,
-                    )
-                }
-            }
-            is ReceiveEvent.BatchCompleted -> {
-                mutableState.update { s ->
-                    val perFile = (s as? PeerTransferState.ActiveInbound)?.perFile ?: emptyList()
-                    val partialReason = if (ev.received < ev.total) {
-                        val failedEntries = perFile.filterIsInstance<PerFileStatus.Failed>()
-                        val cancelledCount = failedEntries.count { it.reason is FailureReason.CancelledByUser }
-                        if (cancelledCount > 0 && cancelledCount == failedEntries.size) {
-                            PartialOutcome.ReceiverCancelled
-                        } else {
-                            PartialOutcome.ConnectionLost
-                        }
-                    } else {
-                        null
-                    }
-                    PeerTransferState.Received(
-                        peer = peer.id,
-                        received = ev.received,
-                        total = ev.total,
-                        perFile = perFile,
-                        partialReason = partialReason,
-                    )
-                }
-            }
-            is ReceiveEvent.Failed -> {
-                mutableState.update { s ->
-                    val active = s as? PeerTransferState.ActiveInbound ?: return@update s
-                    val idx = active.perFile.indexOfFirst { it.name == ev.file }.takeIf { it >= 0 }
-                        ?: active.currentIndex
-                    val updated = active.perFile.toMutableList()
-                    updated[idx] = PerFileStatus.Failed(ev.file, active.perFile[idx].size, ev.reason)
-                    active.copy(perFile = updated)
-                }
-            }
-            is ReceiveEvent.ConnectionLost -> {
-                mutableState.update { snapshot ->
-                    PeerTransferState.Reconnecting(
-                        peer = peer.id,
-                        direction = Direction.Inbound,
-                        remainingSeconds = reconnectionTimeout.inWholeSeconds.toInt(),
-                        snapshotBeforeDrop = snapshot,
-                    )
-                }
-            }
-            ReceiveEvent.ReceiverSuspended -> {
-                mutableState.update { s ->
-                    val perFile = (s as? PeerTransferState.ActiveInbound)?.perFile ?: emptyList()
-                    val doneCount = perFile.count { it is PerFileStatus.Done }
-                    PeerTransferState.Error(
-                        peer = peer.id,
-                        reason = TransferErrorReason.ReceiverSuspended,
-                        sent = doneCount,
-                        perFile = perFile,
-                    )
-                }
-            }
-        }
-    }
-}
-
-private fun List<PerFileStatus.Failed>.dominantPartialReason(): PartialOutcome {
-    val unreadableCount = count { it.reason is FailureReason.Unreadable }
-    val cancelledByUserCount = count { it.cancelledByUser }
-    return when {
-        unreadableCount == size -> PartialOutcome.FilesUnreadable(unreadableCount)
-        cancelledByUserCount == size -> PartialOutcome.SenderCancelled
-        all { it.reason is FailureReason.PeerUnreachable } -> PartialOutcome.PeerUnreachable
-        all { it.reason is FailureReason.ReceiverWriteFailed } -> PartialOutcome.ReceiverWriteFailed
-        else -> PartialOutcome.ConnectionLost
-    }
 }

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponent.kt
@@ -10,11 +10,13 @@ import com.tubetoast.tether.presentation.peer.Peer
 import com.tubetoast.tether.transfer.FileSource
 import com.tubetoast.tether.transfer.PeerIdentity
 import com.tubetoast.tether.transfer.PeerTransferEngine
-import com.tubetoast.tether.transfer.PeerTransferState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
 
 class PeerTransferComponent(
     componentContext: ComponentContext,
@@ -32,11 +34,12 @@ class PeerTransferComponent(
     }
 
     private val showDetailsCallback = onShowDetails
-    private val mutableState = MutableValue<PeerTransferState>(engine.state.value)
-    val state: Value<PeerTransferState> = mutableState
+    private val expanded = MutableStateFlow(false)
+    private val mutableState = MutableValue(PeerCardState(engine.state.value, expanded.value))
+    val state: Value<PeerCardState> = mutableState
 
     init {
-        engine.state
+        combine(engine.state, expanded) { transfer, exp -> PeerCardState(transfer, exp) }
             .onEach { s -> mutableState.update { s } }
             .launchIn(scope)
     }
@@ -63,7 +66,7 @@ class PeerTransferComponent(
 
     fun onDismiss() = engine.onDismiss()
 
-    fun toggleExpanded() = engine.toggleExpanded()
+    fun toggleExpanded() = expanded.update { !it }
 
     fun observeAutoSend(): Flow<Boolean> = engine.observeAutoSend()
 

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponent.kt
@@ -12,7 +12,6 @@ import com.tubetoast.tether.transfer.PeerIdentity
 import com.tubetoast.tether.transfer.PeerTransferEngine
 import com.tubetoast.tether.transfer.PeerTransferState
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -39,7 +38,7 @@ class PeerTransferComponent(
     init {
         engine.state
             .onEach { s -> mutableState.update { s } }
-            .launchIn(CoroutineScope(scope.coroutineContext + Dispatchers.Main.immediate))
+            .launchIn(scope)
     }
 
     fun startOutbound(sources: List<FileSource>) = engine.startOutbound(sources)

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsComponent.kt
@@ -16,7 +16,7 @@ class TransferDetailsComponent(
 
     fun onCancelTransfer() = peerComponent.onCancel()
 
-    fun onRetryAll() = peerComponent.onRetry()
+    fun onRetryAll() = peerComponent.onRetryOutbound()
 
     fun onBack() = onBack.invoke()
 }

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsComponent.kt
@@ -2,14 +2,13 @@ package com.tubetoast.tether.presentation.transfer
 
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.value.Value
-import com.tubetoast.tether.transfer.PeerTransferState
 
 class TransferDetailsComponent(
     componentContext: ComponentContext,
     private val peerComponent: PeerTransferComponent,
     private val onBack: () -> Unit,
 ) : ComponentContext by componentContext {
-    val state: Value<PeerTransferState> get() = peerComponent.state
+    val state: Value<PeerCardState> get() = peerComponent.state
 
     fun onRetryFile(name: String) = peerComponent.onRetryFile(name)
 

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsComponent.kt
@@ -2,6 +2,7 @@ package com.tubetoast.tether.presentation.transfer
 
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.value.Value
+import com.tubetoast.tether.transfer.PeerTransferState
 
 class TransferDetailsComponent(
     componentContext: ComponentContext,

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsCopy.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsCopy.kt
@@ -1,5 +1,7 @@
 package com.tubetoast.tether.presentation.transfer
 
+import com.tubetoast.tether.transfer.PeerTransferState
+
 fun aggregateStripCopy(sent: Int, total: Int, failed: Int): String {
     val base = "$sent of $total sent"
     return if (failed > 0) "$base · $failed failed" else base

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/BatchSender.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/BatchSender.kt
@@ -28,6 +28,12 @@ class PeerUnreachableException(
     cause: Throwable? = null,
 ) : RuntimeException(cause)
 
+/**
+ * Drives a single outbound batch to one peer: walks the source list, invokes `sendOne` per
+ * file, emits `BatchProgress` updates, returns the final `BatchOutcome`. Owns wire-level
+ * concerns within that one batch — per-file cancel, drop-and-reconnect within the
+ * reconnection timeout, progress throttling. One instance per batch attempt.
+ */
 class BatchSender(
     private val sendOne: suspend (FileSource, onProgress: (Long, Long?) -> Unit) -> Unit,
     private val connectionMonitor: ConnectionMonitor,

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/Direction.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/Direction.kt
@@ -1,0 +1,3 @@
+package com.tubetoast.tether.transfer
+
+enum class Direction { Outbound, Inbound }

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngine.kt
@@ -50,8 +50,8 @@ class PeerTransferEngine(
             current is PeerTransferState.ActiveInbound ||
             current is PeerTransferState.Reconnecting
         ) {
-            // TODO: surface "transfer already in flight" to the user instead of silently no-oping —
-            //       onCardClick currently clears PendingFilesRepository regardless, losing the share-sheet payload.
+            // TODO(#327): surface "transfer already in flight" to the user; the caller still
+            //              clears PendingFilesRepository on this path, dropping the share-sheet payload.
             return
         }
         originalSources = sources

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngine.kt
@@ -46,7 +46,7 @@ class PeerTransferEngine(
             return
         }
         originalSources = sources
-        cancelledFileNames.value = emptySet()
+        cancelledFileNames.update { emptySet() }
         launchBatch(sources)
     }
 
@@ -67,7 +67,7 @@ class PeerTransferEngine(
         val confirmed = confirmedReceived.value
         val retryable = originalSources.filter { it.name in failedNames && it.name !in confirmed }
         if (retryable.isEmpty()) return
-        cancelledFileNames.value = emptySet()
+        cancelledFileNames.update { emptySet() }
         launchBatch(retryable)
     }
 
@@ -152,7 +152,7 @@ class PeerTransferEngine(
         currentSender = sender
         try {
             sender.run(sources, peer, { src -> src.name in cancelledFileNames.value }) { progress ->
-                _state.value = mapProgress(progress)
+                _state.update { mapProgress(progress) }
             }
         } finally {
             currentSender = null
@@ -223,16 +223,18 @@ class PeerTransferEngine(
                 val perFile: List<PerFileStatus> = List(ev.totalFiles) { i ->
                     if (i == 0) PerFileStatus.Queued(ev.currentFile, null) else PerFileStatus.Queued("", null)
                 }
-                _state.value = PeerTransferState.ActiveInbound(
-                    peer = peer,
-                    currentFile = ev.currentFile,
-                    currentIndex = 0,
-                    totalFiles = ev.totalFiles,
-                    receivedBytes = 0L,
-                    totalBytes = null,
-                    bytesPerSec = null,
-                    perFile = perFile,
-                )
+                _state.update {
+                    PeerTransferState.ActiveInbound(
+                        peer = peer,
+                        currentFile = ev.currentFile,
+                        currentIndex = 0,
+                        totalFiles = ev.totalFiles,
+                        receivedBytes = 0L,
+                        totalBytes = null,
+                        bytesPerSec = null,
+                        perFile = perFile,
+                    )
+                }
             }
             is ReceiveEvent.Progress -> {
                 _state.update { s ->

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngine.kt
@@ -127,12 +127,6 @@ class PeerTransferEngine(
         }
     }
 
-    fun toggleExpanded() {
-        _state.update { s ->
-            (s as? PeerTransferState.Idle)?.copy(expanded = !s.expanded) ?: s
-        }
-    }
-
     fun observeAutoSend(): Flow<Boolean> =
         peerPreferencesStore?.observeAutoSend(peer) ?: flowOf(false)
 

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngine.kt
@@ -13,6 +13,13 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.time.Duration
 
+/**
+ * Per-peer transfer state holder for the peer's session. Owns the live `PeerTransferState`
+ * across multiple outbound batches (each driven through a freshly constructed `BatchSender`)
+ * and inbound `ReceiveEvent`s. Holds cross-batch memory a single batch cannot — receipts the
+ * peer has confirmed (filtered out on retry) and queued cancellations (consumed by the next
+ * batch's skip predicate).
+ */
 class PeerTransferEngine(
     private val peer: PeerIdentity,
     private val batchSenderFactory: () -> BatchSender,

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngine.kt
@@ -40,7 +40,7 @@ class PeerTransferEngine(
 
     init {
         scope.launch {
-            inboundEvents.collect { ev -> handleInbound(ev) }
+            inboundEvents.collect { event -> handleInbound(event) }
         }
     }
 
@@ -50,6 +50,8 @@ class PeerTransferEngine(
             current is PeerTransferState.ActiveInbound ||
             current is PeerTransferState.Reconnecting
         ) {
+            // TODO: surface "transfer already in flight" to the user instead of silently no-oping —
+            //       onCardClick currently clears PendingFilesRepository regardless, losing the share-sheet payload.
             return
         }
         originalSources = sources
@@ -62,7 +64,7 @@ class PeerTransferEngine(
         activeJob = null
     }
 
-    fun onRetry() {
+    fun onRetryOutbound() {
         val current = _state.value
         val lastPerFile = when (current) {
             is PeerTransferState.Sent -> current.perFile
@@ -91,9 +93,9 @@ class PeerTransferEngine(
 
     fun onCancelFile(name: String) {
         val current = _state.value as? PeerTransferState.ActiveOutbound ?: return
-        val idx = current.perFile.indexOfFirst { it.name == name }
-        if (idx < 0) return
-        when (val status = current.perFile[idx]) {
+        val index = current.perFile.indexOfFirst { it.name == name }
+        if (index < 0) return
+        when (val status = current.perFile[index]) {
             is PerFileStatus.InProgress -> {
                 val sender = currentSender
                 if (sender != null) scope.launch { sender.cancelCurrent(name) }
@@ -102,9 +104,9 @@ class PeerTransferEngine(
                 cancelledFileNames.update { it + name }
                 _state.update { s ->
                     val active = s as? PeerTransferState.ActiveOutbound ?: return@update s
-                    val rowIdx = active.perFile.indexOfFirst { it.name == name }.takeIf { it >= 0 } ?: return@update s
+                    val rowIndex = active.perFile.indexOfFirst { it.name == name }.takeIf { it >= 0 } ?: return@update s
                     val updated = active.perFile.toMutableList()
-                    updated[rowIdx] = PerFileStatus.Failed(
+                    updated[rowIndex] = PerFileStatus.Failed(
                         status.name,
                         status.size,
                         FailureReason.CancelledByUser,
@@ -152,7 +154,7 @@ class PeerTransferEngine(
         val sender = batchSenderFactory()
         currentSender = sender
         try {
-            sender.run(sources, peer, { src -> src.name in cancelledFileNames.value }) { progress ->
+            sender.run(sources, peer, { source -> source.name in cancelledFileNames.value }) { progress ->
                 _state.update { mapProgress(progress) }
             }
         } finally {
@@ -218,18 +220,18 @@ class PeerTransferEngine(
         }
     }
 
-    private fun handleInbound(ev: ReceiveEvent) {
-        when (ev) {
+    private fun handleInbound(event: ReceiveEvent) {
+        when (event) {
             is ReceiveEvent.Started -> {
-                val perFile: List<PerFileStatus> = List(ev.totalFiles) { i ->
-                    if (i == 0) PerFileStatus.Queued(ev.currentFile, null) else PerFileStatus.Queued("", null)
+                val perFile: List<PerFileStatus> = List(event.totalFiles) { i ->
+                    if (i == 0) PerFileStatus.Queued(event.currentFile, null) else PerFileStatus.Queued("", null)
                 }
                 _state.update {
                     PeerTransferState.ActiveInbound(
                         peer = peer,
-                        currentFile = ev.currentFile,
+                        currentFile = event.currentFile,
                         currentIndex = 0,
-                        totalFiles = ev.totalFiles,
+                        totalFiles = event.totalFiles,
                         receivedBytes = 0L,
                         totalBytes = null,
                         bytesPerSec = null,
@@ -240,29 +242,29 @@ class PeerTransferEngine(
             is ReceiveEvent.Progress -> {
                 _state.update { s ->
                     val active = s as? PeerTransferState.ActiveInbound ?: return@update s
-                    val idx = active.perFile.indexOfFirst { it.name == ev.name }.takeIf { it >= 0 }
+                    val index = active.perFile.indexOfFirst { it.name == event.name }.takeIf { it >= 0 }
                         ?: active.perFile.indexOfFirst { it.name.isEmpty() }.takeIf { it >= 0 }
                         ?: active.currentIndex
                     val updated = active.perFile.toMutableList()
-                    updated[idx] = PerFileStatus.InProgress(ev.name, ev.totalBytes, ev.receivedBytes)
+                    updated[index] = PerFileStatus.InProgress(event.name, event.totalBytes, event.receivedBytes)
                     active.copy(
-                        currentFile = ev.name,
-                        receivedBytes = ev.receivedBytes,
-                        totalBytes = ev.totalBytes,
+                        currentFile = event.name,
+                        receivedBytes = event.receivedBytes,
+                        totalBytes = event.totalBytes,
                         perFile = updated,
                     )
                 }
             }
             is ReceiveEvent.FileCompleted -> {
-                confirmedReceived.update { it + ev.name }
+                confirmedReceived.update { it + event.name }
                 _state.update { s ->
                     val active = s as? PeerTransferState.ActiveInbound ?: return@update s
-                    val idx = active.perFile.indexOfFirst { it.name == ev.name }.takeIf { it >= 0 }
+                    val index = active.perFile.indexOfFirst { it.name == event.name }.takeIf { it >= 0 }
                         ?: active.currentIndex
                     val updated = active.perFile.toMutableList()
-                    updated[idx] = PerFileStatus.Done(ev.name, active.perFile[idx].size)
+                    updated[index] = PerFileStatus.Done(event.name, active.perFile[index].size)
                     active.copy(
-                        currentIndex = (idx + 1).coerceAtMost(active.totalFiles - 1),
+                        currentIndex = (index + 1).coerceAtMost(active.totalFiles - 1),
                         perFile = updated,
                     )
                 }
@@ -270,7 +272,7 @@ class PeerTransferEngine(
             is ReceiveEvent.BatchCompleted -> {
                 _state.update { s ->
                     val perFile = (s as? PeerTransferState.ActiveInbound)?.perFile ?: emptyList()
-                    val partialReason = if (ev.received < ev.total) {
+                    val partialReason = if (event.received < event.total) {
                         val failedEntries = perFile.filterIsInstance<PerFileStatus.Failed>()
                         val cancelledCount = failedEntries.count { it.reason is FailureReason.CancelledByUser }
                         if (cancelledCount > 0 && cancelledCount == failedEntries.size) {
@@ -283,8 +285,8 @@ class PeerTransferEngine(
                     }
                     PeerTransferState.Received(
                         peer = peer,
-                        received = ev.received,
-                        total = ev.total,
+                        received = event.received,
+                        total = event.total,
                         perFile = perFile,
                         partialReason = partialReason,
                     )
@@ -293,10 +295,10 @@ class PeerTransferEngine(
             is ReceiveEvent.Failed -> {
                 _state.update { s ->
                     val active = s as? PeerTransferState.ActiveInbound ?: return@update s
-                    val idx = active.perFile.indexOfFirst { it.name == ev.file }.takeIf { it >= 0 }
+                    val index = active.perFile.indexOfFirst { it.name == event.file }.takeIf { it >= 0 }
                         ?: active.currentIndex
                     val updated = active.perFile.toMutableList()
-                    updated[idx] = PerFileStatus.Failed(ev.file, active.perFile[idx].size, ev.reason)
+                    updated[index] = PerFileStatus.Failed(event.file, active.perFile[index].size, event.reason)
                     active.copy(perFile = updated)
                 }
             }

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngine.kt
@@ -1,0 +1,336 @@
+package com.tubetoast.tether.transfer
+
+import com.tubetoast.tether.preferences.PeerPreferencesStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlin.time.Duration
+
+class PeerTransferEngine(
+    private val peer: PeerIdentity,
+    private val batchSenderFactory: () -> BatchSender,
+    // TODO(#195): wire real ReceiveEvent source when Receiver UI lands
+    private val inboundEvents: Flow<ReceiveEvent> = MutableSharedFlow(),
+    private val reconnectionTimeout: Duration = ReconnectionTimeout.DEFAULT,
+    private val scope: CoroutineScope,
+    private val peerPreferencesStore: PeerPreferencesStore? = null,
+) {
+    private val _state = MutableStateFlow<PeerTransferState>(PeerTransferState.Idle(peer))
+    val state: StateFlow<PeerTransferState> = _state.asStateFlow()
+
+    private var activeJob: Job? = null
+    private var currentSender: BatchSender? = null
+    private var originalSources: List<FileSource> = emptyList()
+    private val confirmedReceived = MutableStateFlow<Set<String>>(emptySet())
+    private val cancelledFileNames = MutableStateFlow<Set<String>>(emptySet())
+
+    init {
+        scope.launch {
+            inboundEvents.collect { ev -> handleInbound(ev) }
+        }
+    }
+
+    fun startOutbound(sources: List<FileSource>) {
+        val current = _state.value
+        if (current is PeerTransferState.ActiveOutbound ||
+            current is PeerTransferState.ActiveInbound ||
+            current is PeerTransferState.Reconnecting
+        ) {
+            return
+        }
+        originalSources = sources
+        cancelledFileNames.value = emptySet()
+        launchBatch(sources)
+    }
+
+    fun onCancel() {
+        activeJob?.cancel()
+        activeJob = null
+    }
+
+    fun onRetry() {
+        val current = _state.value
+        val lastPerFile = when (current) {
+            is PeerTransferState.Sent -> current.perFile
+            is PeerTransferState.Error -> current.perFile
+            is PeerTransferState.Cancelled -> current.perFile
+            else -> return
+        }
+        val failedNames = lastPerFile.filterIsInstance<PerFileStatus.Failed>().map { it.name }.toSet()
+        val confirmed = confirmedReceived.value
+        val retryable = originalSources.filter { it.name in failedNames && it.name !in confirmed }
+        if (retryable.isEmpty()) return
+        cancelledFileNames.value = emptySet()
+        launchBatch(retryable)
+    }
+
+    fun onRetryFile(name: String) {
+        val source = originalSources.firstOrNull { it.name == name } ?: return
+        cancelledFileNames.update { it - name }
+        val job = activeJob
+        activeJob = scope.launch {
+            job?.cancel()
+            job?.join()
+            launchBatchIn(listOf(source))
+        }
+    }
+
+    fun onCancelFile(name: String) {
+        val current = _state.value as? PeerTransferState.ActiveOutbound ?: return
+        val idx = current.perFile.indexOfFirst { it.name == name }
+        if (idx < 0) return
+        when (val status = current.perFile[idx]) {
+            is PerFileStatus.InProgress -> {
+                val sender = currentSender
+                if (sender != null) scope.launch { sender.cancelCurrent(name) }
+            }
+            is PerFileStatus.Queued -> {
+                cancelledFileNames.update { it + name }
+                _state.update { s ->
+                    val active = s as? PeerTransferState.ActiveOutbound ?: return@update s
+                    val rowIdx = active.perFile.indexOfFirst { it.name == name }.takeIf { it >= 0 } ?: return@update s
+                    val updated = active.perFile.toMutableList()
+                    updated[rowIdx] = PerFileStatus.Failed(
+                        status.name,
+                        status.size,
+                        FailureReason.CancelledByUser,
+                        cancelledByUser = true,
+                    )
+                    active.copy(
+                        perFile = updated,
+                        skippedCount = updated.count { it is PerFileStatus.Failed },
+                    )
+                }
+            }
+            else -> Unit
+        }
+    }
+
+    fun onDismiss() {
+        _state.update { s ->
+            if (s is PeerTransferState.Sent ||
+                s is PeerTransferState.Received ||
+                s is PeerTransferState.Cancelled ||
+                s is PeerTransferState.Error
+            ) {
+                PeerTransferState.Idle(peer)
+            } else {
+                s
+            }
+        }
+    }
+
+    fun toggleExpanded() {
+        _state.update { s ->
+            (s as? PeerTransferState.Idle)?.copy(expanded = !s.expanded) ?: s
+        }
+    }
+
+    fun observeAutoSend(): Flow<Boolean> =
+        peerPreferencesStore?.observeAutoSend(peer) ?: flowOf(false)
+
+    fun setAutoSend(enabled: Boolean) {
+        val store = peerPreferencesStore ?: return
+        scope.launch { store.setAutoSend(peer, enabled) }
+    }
+
+    private fun launchBatch(sources: List<FileSource>) {
+        activeJob = scope.launch {
+            launchBatchIn(sources)
+        }
+    }
+
+    private suspend fun launchBatchIn(sources: List<FileSource>) {
+        val sender = batchSenderFactory()
+        currentSender = sender
+        try {
+            sender.run(sources, peer, { src -> src.name in cancelledFileNames.value }) { progress ->
+                _state.value = mapProgress(progress)
+            }
+        } finally {
+            currentSender = null
+        }
+    }
+
+    private fun mapProgress(progress: BatchProgress): PeerTransferState = when (progress) {
+        is BatchProgress.Sending -> PeerTransferState.ActiveOutbound(
+            peer = progress.peer,
+            currentFile = progress.currentFile,
+            currentIndex = progress.currentIndex,
+            totalFiles = progress.totalFiles,
+            sentBytes = progress.sentBytes,
+            totalBytes = progress.totalBytes,
+            bytesPerSec = progress.bytesPerSec,
+            skippedCount = progress.skippedCount,
+            perFile = progress.perFile,
+        )
+        is BatchProgress.Reconnecting -> PeerTransferState.Reconnecting(
+            peer = progress.peer,
+            direction = Direction.Outbound,
+            remainingSeconds = progress.remainingSeconds,
+            snapshotBeforeDrop = mapProgress(progress.snapshotBeforeDrop),
+        )
+        is BatchProgress.Completed -> mapCompleted(progress)
+    }
+
+    private fun mapCompleted(progress: BatchProgress.Completed): PeerTransferState {
+        val peer = progress.peer
+        val perFile = progress.perFile
+        return when (val outcome = progress.outcome) {
+            is BatchOutcome.AllSent -> PeerTransferState.Sent(
+                peer = peer,
+                sent = perFile.count { it is PerFileStatus.Done },
+                total = perFile.size,
+                perFile = perFile,
+                partialReason = null,
+            )
+            is BatchOutcome.PartialSent -> {
+                val failedEntries = perFile.filterIsInstance<PerFileStatus.Failed>()
+                val doneCount = perFile.count { it is PerFileStatus.Done }
+                PeerTransferState.Sent(
+                    peer = peer,
+                    sent = doneCount,
+                    total = perFile.size,
+                    perFile = perFile,
+                    partialReason = failedEntries.dominantPartialReason(),
+                )
+            }
+            is BatchOutcome.Cancelled -> PeerTransferState.Cancelled(
+                peer = peer,
+                sent = outcome.sent,
+                remaining = outcome.remaining,
+                perFile = perFile,
+            )
+            is BatchOutcome.Failed -> PeerTransferState.Error(
+                peer = peer,
+                reason = outcome.reason,
+                sent = outcome.sent,
+                perFile = perFile,
+            )
+        }
+    }
+
+    private fun handleInbound(ev: ReceiveEvent) {
+        when (ev) {
+            is ReceiveEvent.Started -> {
+                val perFile: List<PerFileStatus> = List(ev.totalFiles) { i ->
+                    if (i == 0) PerFileStatus.Queued(ev.currentFile, null) else PerFileStatus.Queued("", null)
+                }
+                _state.value = PeerTransferState.ActiveInbound(
+                    peer = peer,
+                    currentFile = ev.currentFile,
+                    currentIndex = 0,
+                    totalFiles = ev.totalFiles,
+                    receivedBytes = 0L,
+                    totalBytes = null,
+                    bytesPerSec = null,
+                    perFile = perFile,
+                )
+            }
+            is ReceiveEvent.Progress -> {
+                _state.update { s ->
+                    val active = s as? PeerTransferState.ActiveInbound ?: return@update s
+                    val idx = active.perFile.indexOfFirst { it.name == ev.name }.takeIf { it >= 0 }
+                        ?: active.perFile.indexOfFirst { it.name.isEmpty() }.takeIf { it >= 0 }
+                        ?: active.currentIndex
+                    val updated = active.perFile.toMutableList()
+                    updated[idx] = PerFileStatus.InProgress(ev.name, ev.totalBytes, ev.receivedBytes)
+                    active.copy(
+                        currentFile = ev.name,
+                        receivedBytes = ev.receivedBytes,
+                        totalBytes = ev.totalBytes,
+                        perFile = updated,
+                    )
+                }
+            }
+            is ReceiveEvent.FileCompleted -> {
+                confirmedReceived.update { it + ev.name }
+                _state.update { s ->
+                    val active = s as? PeerTransferState.ActiveInbound ?: return@update s
+                    val idx = active.perFile.indexOfFirst { it.name == ev.name }.takeIf { it >= 0 }
+                        ?: active.currentIndex
+                    val updated = active.perFile.toMutableList()
+                    updated[idx] = PerFileStatus.Done(ev.name, active.perFile[idx].size)
+                    active.copy(
+                        currentIndex = (idx + 1).coerceAtMost(active.totalFiles - 1),
+                        perFile = updated,
+                    )
+                }
+            }
+            is ReceiveEvent.BatchCompleted -> {
+                _state.update { s ->
+                    val perFile = (s as? PeerTransferState.ActiveInbound)?.perFile ?: emptyList()
+                    val partialReason = if (ev.received < ev.total) {
+                        val failedEntries = perFile.filterIsInstance<PerFileStatus.Failed>()
+                        val cancelledCount = failedEntries.count { it.reason is FailureReason.CancelledByUser }
+                        if (cancelledCount > 0 && cancelledCount == failedEntries.size) {
+                            PartialOutcome.ReceiverCancelled
+                        } else {
+                            PartialOutcome.ConnectionLost
+                        }
+                    } else {
+                        null
+                    }
+                    PeerTransferState.Received(
+                        peer = peer,
+                        received = ev.received,
+                        total = ev.total,
+                        perFile = perFile,
+                        partialReason = partialReason,
+                    )
+                }
+            }
+            is ReceiveEvent.Failed -> {
+                _state.update { s ->
+                    val active = s as? PeerTransferState.ActiveInbound ?: return@update s
+                    val idx = active.perFile.indexOfFirst { it.name == ev.file }.takeIf { it >= 0 }
+                        ?: active.currentIndex
+                    val updated = active.perFile.toMutableList()
+                    updated[idx] = PerFileStatus.Failed(ev.file, active.perFile[idx].size, ev.reason)
+                    active.copy(perFile = updated)
+                }
+            }
+            is ReceiveEvent.ConnectionLost -> {
+                _state.update { snapshot ->
+                    PeerTransferState.Reconnecting(
+                        peer = peer,
+                        direction = Direction.Inbound,
+                        remainingSeconds = reconnectionTimeout.inWholeSeconds.toInt(),
+                        snapshotBeforeDrop = snapshot,
+                    )
+                }
+            }
+            ReceiveEvent.ReceiverSuspended -> {
+                _state.update { s ->
+                    val perFile = (s as? PeerTransferState.ActiveInbound)?.perFile ?: emptyList()
+                    val doneCount = perFile.count { it is PerFileStatus.Done }
+                    PeerTransferState.Error(
+                        peer = peer,
+                        reason = TransferErrorReason.ReceiverSuspended,
+                        sent = doneCount,
+                        perFile = perFile,
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun List<PerFileStatus.Failed>.dominantPartialReason(): PartialOutcome {
+    val unreadableCount = count { it.reason is FailureReason.Unreadable }
+    val cancelledByUserCount = count { it.cancelledByUser }
+    return when {
+        unreadableCount == size -> PartialOutcome.FilesUnreadable(unreadableCount)
+        cancelledByUserCount == size -> PartialOutcome.SenderCancelled
+        all { it.reason is FailureReason.PeerUnreachable } -> PartialOutcome.PeerUnreachable
+        all { it.reason is FailureReason.ReceiverWriteFailed } -> PartialOutcome.ReceiverWriteFailed
+        else -> PartialOutcome.ConnectionLost
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineRegistry.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineRegistry.kt
@@ -8,9 +8,9 @@ import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 /**
- * Per-process registry of per-peer `PeerTransferEngine` instances. Engines survive Component
- * destruction (mDNS drops, screen navigation) and are evicted only on explicit `evict` (un-pair)
- * or process death.
+ * Engines survive Component destruction (mDNS drops, screen navigation) and are evicted only
+ * on explicit `evict` or process death. No caller wires `evict` yet — engines for permanently
+ * gone peers stay until process death.
  */
 @OptIn(ExperimentalAtomicApi::class)
 class PeerTransferEngineRegistry(
@@ -37,7 +37,7 @@ class PeerTransferEngineRegistry(
         }
     }
 
-    fun evict(peer: PeerIdentity) {
+    internal fun evict(peer: PeerIdentity) {
         while (true) {
             val current = entries.load()
             if (peer !in current) return

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineRegistry.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineRegistry.kt
@@ -1,0 +1,56 @@
+package com.tubetoast.tether.transfer
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+
+/**
+ * Per-process registry of per-peer `PeerTransferEngine` instances. Engines survive Component
+ * destruction (mDNS drops, screen navigation) and are evicted only on explicit `evict` (un-pair)
+ * or process death.
+ */
+@OptIn(ExperimentalAtomicApi::class)
+class PeerTransferEngineRegistry(
+    private val appScope: CoroutineScope,
+    private val engineFactory: (PeerIdentity, CoroutineScope) -> PeerTransferEngine,
+) {
+    private data class Entry(
+        val engine: PeerTransferEngine,
+        val scope: CoroutineScope,
+    )
+
+    private val entries = AtomicReference(emptyMap<PeerIdentity, Entry>())
+
+    fun engineFor(peer: PeerIdentity): PeerTransferEngine {
+        while (true) {
+            val current = entries.load()
+            val existing = current[peer]
+            if (existing != null) return existing.engine
+            val engineScope = CoroutineScope(SupervisorJob(appScope.coroutineContext[Job]) + Dispatchers.Default)
+            val newEntry = Entry(engineFactory(peer, engineScope), engineScope)
+            val next = current + (peer to newEntry)
+            if (entries.compareAndSet(current, next)) return newEntry.engine
+            engineScope.coroutineContext[Job]?.cancel()
+        }
+    }
+
+    fun evict(peer: PeerIdentity) {
+        while (true) {
+            val current = entries.load()
+            if (peer !in current) return
+            val evicted = current[peer]
+            val next = current - peer
+            if (entries.compareAndSet(current, next)) {
+                evicted
+                    ?.scope
+                    ?.coroutineContext
+                    ?.get(Job)
+                    ?.cancel()
+                return
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineRegistry.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineRegistry.kt
@@ -8,9 +8,9 @@ import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 /**
- * Engines survive Component destruction (mDNS drops, screen navigation) and are evicted only
- * on explicit `evict` or process death. No caller wires `evict` yet — engines for permanently
- * gone peers stay until process death.
+ * Engines survive Component destruction (mDNS drops, screen navigation). The only triggers
+ * for engine death are an explicit eviction call by the caller and process death; an engine
+ * for a permanently gone peer that nobody evicts lives until process death.
  */
 @OptIn(ExperimentalAtomicApi::class)
 class PeerTransferEngineRegistry(

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineRegistry.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineRegistry.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
@@ -33,7 +34,7 @@ class PeerTransferEngineRegistry(
             val newEntry = Entry(engineFactory(peer, engineScope), engineScope)
             val next = current + (peer to newEntry)
             if (entries.compareAndSet(current, next)) return newEntry.engine
-            engineScope.coroutineContext[Job]?.cancel()
+            engineScope.cancel()
         }
     }
 
@@ -44,11 +45,7 @@ class PeerTransferEngineRegistry(
             val evicted = current[peer]
             val next = current - peer
             if (entries.compareAndSet(current, next)) {
-                evicted
-                    ?.scope
-                    ?.coroutineContext
-                    ?.get(Job)
-                    ?.cancel()
+                evicted?.scope?.cancel()
                 return
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferState.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferState.kt
@@ -1,9 +1,4 @@
-package com.tubetoast.tether.presentation.transfer
-
-import com.tubetoast.tether.transfer.PartialOutcome
-import com.tubetoast.tether.transfer.PeerIdentity
-import com.tubetoast.tether.transfer.PerFileStatus
-import com.tubetoast.tether.transfer.TransferErrorReason
+package com.tubetoast.tether.transfer
 
 sealed interface PeerTransferState {
     val peer: PeerIdentity

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferState.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferState.kt
@@ -5,7 +5,6 @@ sealed interface PeerTransferState {
 
     data class Idle(
         override val peer: PeerIdentity,
-        val expanded: Boolean = false,
     ) : PeerTransferState
 
     data class ActiveOutbound(

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/ui/preview/TransferPreviewFixtures.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/ui/preview/TransferPreviewFixtures.kt
@@ -1,11 +1,11 @@
 package com.tubetoast.tether.ui.preview
 
-import com.tubetoast.tether.presentation.transfer.Direction
-import com.tubetoast.tether.presentation.transfer.PeerTransferState
 import com.tubetoast.tether.protocol.Device
+import com.tubetoast.tether.transfer.Direction
 import com.tubetoast.tether.transfer.FailureReason
 import com.tubetoast.tether.transfer.PartialOutcome
 import com.tubetoast.tether.transfer.PeerIdentity
+import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.transfer.PerFileStatus
 import com.tubetoast.tether.transfer.TransferErrorReason
 

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/ui/preview/TransferPreviewFixtures.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/ui/preview/TransferPreviewFixtures.kt
@@ -13,8 +13,8 @@ object TransferPreviewFixtures {
     val peer = PeerIdentity("Alice")
     val device: Device = PreviewFixtures.singleDevice.first()
 
-    val idleCollapsed = PeerTransferState.Idle(peer, expanded = false)
-    val idleExpanded = PeerTransferState.Idle(peer, expanded = true)
+    val idleCollapsed = PeerTransferState.Idle(peer)
+    val idleExpanded = PeerTransferState.Idle(peer)
 
     val activeOutbound = PeerTransferState.ActiveOutbound(
         peer = peer,

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/PeerListComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/PeerListComponentTest.kt
@@ -17,17 +17,11 @@ import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.transfer.fakeBatchSender
 import com.tubetoast.tether.transfer.toPeerIdentity
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -37,16 +31,6 @@ import kotlin.test.assertNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PeerListComponentTest {
-    @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(UnconfinedTestDispatcher())
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
     private val deviceA = Device(name = "DeviceA", host = "192.168.1.1", port = 8080)
     private val deviceB = Device(name = "DeviceB", host = "192.168.1.2", port = 8080)
 

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/PeerListComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/PeerListComponentTest.kt
@@ -17,11 +17,17 @@ import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.transfer.fakeBatchSender
 import com.tubetoast.tether.transfer.toPeerIdentity
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -31,6 +37,16 @@ import kotlin.test.assertNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PeerListComponentTest {
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
     private val deviceA = Device(name = "DeviceA", host = "192.168.1.1", port = 8080)
     private val deviceB = Device(name = "DeviceB", host = "192.168.1.2", port = 8080)
 

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/PeerListComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/PeerListComponentTest.kt
@@ -17,11 +17,17 @@ import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.transfer.fakeBatchSender
 import com.tubetoast.tether.transfer.toPeerIdentity
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -31,6 +37,16 @@ import kotlin.test.assertNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PeerListComponentTest {
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
     private val deviceA = Device(name = "DeviceA", host = "192.168.1.1", port = 8080)
     private val deviceB = Device(name = "DeviceB", host = "192.168.1.2", port = 8080)
 
@@ -195,7 +211,7 @@ class PeerListComponentTest {
         assertIs<PeerTransferState.Idle>(
             component.state.value.rows
                 .first()
-                .transferComponent.state.value,
+                .transferComponent.state.value.transfer,
         )
 
         val peerComponent = component.peerTransferComponent(deviceA.toPeerIdentity())
@@ -206,7 +222,7 @@ class PeerListComponentTest {
         assertIs<PeerTransferState.Sent>(
             component.state.value.rows
                 .first()
-                .transferComponent.state.value,
+                .transferComponent.state.value.transfer,
         )
     }
 

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/PeerListComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/PeerListComponentTest.kt
@@ -9,10 +9,11 @@ import com.tubetoast.tether.presentation.peer.FakePeersRepository
 import com.tubetoast.tether.presentation.peer.Peer
 import com.tubetoast.tether.presentation.peer.PeersRepository
 import com.tubetoast.tether.presentation.transfer.PeerTransferComponent
-import com.tubetoast.tether.presentation.transfer.PeerTransferState
 import com.tubetoast.tether.presentation.transfer.PendingFilesRepository
 import com.tubetoast.tether.protocol.Device
 import com.tubetoast.tether.transfer.FakeFileSource
+import com.tubetoast.tether.transfer.PeerTransferEngine
+import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.transfer.fakeBatchSender
 import com.tubetoast.tether.transfer.toPeerIdentity
 import kotlinx.coroutines.CoroutineScope
@@ -324,12 +325,17 @@ class PeerListComponentTest {
                         childLifecycle.onDestroy()
                     }
                 }
+                val engine = PeerTransferEngine(
+                    peer = peer.id,
+                    batchSenderFactory = fakeBatchSender(),
+                    inboundEvents = MutableSharedFlow(),
+                    scope = coroutineScope,
+                )
                 PeerTransferComponent(
                     componentContext = childCtx,
                     peer = peer,
                     lifecycleRegistry = wrappedLifecycle,
-                    batchSenderFactory = fakeBatchSender(),
-                    inboundEvents = MutableSharedFlow(),
+                    engine = engine,
                     onShowDetails = {},
                     scope = coroutineScope,
                 )
@@ -363,12 +369,17 @@ class PeerListComponentTest {
                         childLifecycle.onDestroy()
                     }
                 }
+                val engine = PeerTransferEngine(
+                    peer = peer.id,
+                    batchSenderFactory = fakeBatchSender(),
+                    inboundEvents = MutableSharedFlow(),
+                    scope = coroutineScope,
+                )
                 PeerTransferComponent(
                     componentContext = childCtx,
                     peer = peer,
                     lifecycleRegistry = wrappedLifecycle,
-                    batchSenderFactory = fakeBatchSender(),
-                    inboundEvents = MutableSharedFlow(),
+                    engine = engine,
                     onShowDetails = {},
                     scope = coroutineScope,
                 )

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/RootComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/RootComponentTest.kt
@@ -17,12 +17,18 @@ import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.transfer.fakeBatchSender
 import com.tubetoast.tether.transfer.toPeerIdentity
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import kotlinx.serialization.builtins.serializer
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -33,6 +39,16 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class RootComponentTest {
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
     private val deviceA = Device(name = "DeviceA", host = "192.168.1.1", port = 8080)
     private val peer = deviceA.toPeerIdentity()
 
@@ -118,7 +134,7 @@ class RootComponentTest {
         peerComponent.onCardClick()
         runCurrent()
 
-        assertIs<PeerTransferState.Sent>(peerComponent.state.value)
+        assertIs<PeerTransferState.Sent>(peerComponent.state.value.transfer)
         assertNull(repo.summary.value)
     }
 

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/RootComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/RootComponentTest.kt
@@ -17,18 +17,12 @@ import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.transfer.fakeBatchSender
 import com.tubetoast.tether.transfer.toPeerIdentity
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import kotlinx.serialization.builtins.serializer
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -39,16 +33,6 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class RootComponentTest {
-    @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(UnconfinedTestDispatcher())
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
     private val deviceA = Device(name = "DeviceA", host = "192.168.1.1", port = 8080)
     private val peer = deviceA.toPeerIdentity()
 

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/RootComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/RootComponentTest.kt
@@ -17,12 +17,18 @@ import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.transfer.fakeBatchSender
 import com.tubetoast.tether.transfer.toPeerIdentity
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import kotlinx.serialization.builtins.serializer
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -33,6 +39,16 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class RootComponentTest {
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
     private val deviceA = Device(name = "DeviceA", host = "192.168.1.1", port = 8080)
     private val peer = deviceA.toPeerIdentity()
 

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/RootComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/RootComponentTest.kt
@@ -9,10 +9,11 @@ import com.tubetoast.tether.discovery.FakeDeviceDiscovery
 import com.tubetoast.tether.presentation.banners.BannersComponent
 import com.tubetoast.tether.presentation.peer.PeersRepository
 import com.tubetoast.tether.presentation.transfer.PeerTransferComponent
-import com.tubetoast.tether.presentation.transfer.PeerTransferState
 import com.tubetoast.tether.presentation.transfer.PendingFilesRepository
 import com.tubetoast.tether.protocol.Device
 import com.tubetoast.tether.transfer.FakeFileSource
+import com.tubetoast.tether.transfer.PeerTransferEngine
+import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.transfer.fakeBatchSender
 import com.tubetoast.tether.transfer.toPeerIdentity
 import kotlinx.coroutines.CoroutineScope
@@ -218,12 +219,17 @@ class RootComponentTest {
                     componentContext = childCtx,
                     peersRepository = peersRepository,
                     peerTransferComponentFactory = { peerCtx, peerLifecycle, peerModel ->
+                        val engine = PeerTransferEngine(
+                            peer = peerModel.id,
+                            batchSenderFactory = fakeBatchSender(),
+                            inboundEvents = MutableSharedFlow(),
+                            scope = coroutineScope,
+                        )
                         PeerTransferComponent(
                             componentContext = peerCtx,
                             peer = peerModel,
                             lifecycleRegistry = peerLifecycle,
-                            batchSenderFactory = fakeBatchSender(),
-                            inboundEvents = MutableSharedFlow(),
+                            engine = engine,
                             onShowDetails = onShowDetails,
                             scope = coroutineScope,
                             pendingFilesRepository = pendingFilesRepository,

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardCopyTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/peercard/PeerCardCopyTest.kt
@@ -1,8 +1,8 @@
 package com.tubetoast.tether.presentation.peercard
 
-import com.tubetoast.tether.presentation.transfer.PeerTransferState
 import com.tubetoast.tether.transfer.PartialOutcome
 import com.tubetoast.tether.transfer.PeerIdentity
+import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.transfer.TransferErrorReason
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -188,7 +188,7 @@ class PeerCardCopyTest {
     fun reconnectingCopy() {
         val state = PeerTransferState.Reconnecting(
             peer = peer,
-            direction = com.tubetoast.tether.presentation.transfer.Direction.Outbound,
+            direction = com.tubetoast.tether.transfer.Direction.Outbound,
             remainingSeconds = 12,
             snapshotBeforeDrop = PeerTransferState.Idle(peer),
         )

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponentTest.kt
@@ -7,25 +7,17 @@ import com.tubetoast.tether.presentation.PendingFilesSummary
 import com.tubetoast.tether.presentation.peer.Peer
 import com.tubetoast.tether.protocol.Device
 import com.tubetoast.tether.transfer.BatchSender
-import com.tubetoast.tether.transfer.FailureReason
 import com.tubetoast.tether.transfer.FakeConnectionMonitor
 import com.tubetoast.tether.transfer.FakeFileSource
-import com.tubetoast.tether.transfer.FileSource
-import com.tubetoast.tether.transfer.PartialOutcome
 import com.tubetoast.tether.transfer.PeerIdentity
-import com.tubetoast.tether.transfer.PeerUnreachableException
-import com.tubetoast.tether.transfer.PerFileStatus
-import com.tubetoast.tether.transfer.ReceiveEvent
-import com.tubetoast.tether.transfer.ReceiverWriteFailedException
-import com.tubetoast.tether.transfer.TransferErrorReason
+import com.tubetoast.tether.transfer.PeerTransferEngine
+import com.tubetoast.tether.transfer.PeerTransferState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -39,10 +31,6 @@ class PeerTransferComponentTest {
     )
 
     private fun buildComponent(
-        events: MutableSharedFlow<ReceiveEvent> = MutableSharedFlow(extraBufferCapacity = 16),
-        monitor: FakeConnectionMonitor = FakeConnectionMonitor(),
-        pauseChannel: Channel<Unit>? = null,
-        sendOneOverride: (suspend (FileSource, (Long, Long?) -> Unit) -> Unit)? = null,
         pendingFilesRepository: PendingFilesRepository? = null,
         onOpenPicker: () -> Unit = {},
         scope: kotlinx.coroutines.CoroutineScope,
@@ -50,22 +38,24 @@ class PeerTransferComponentTest {
         val lifecycle = LifecycleRegistry()
         lifecycle.resume()
         val context = DefaultComponentContext(lifecycle)
-        return PeerTransferComponent(
-            componentContext = context,
-            peer = peer,
-            lifecycleRegistry = lifecycle,
+        val engine = PeerTransferEngine(
+            peer = peer.id,
             batchSenderFactory = {
                 BatchSender(
-                    sendOne = sendOneOverride ?: { src, onProgress ->
-                        pauseChannel?.receive()
-                        onProgress(src.sizeBytes ?: 0L, src.sizeBytes)
-                    },
-                    connectionMonitor = monitor,
+                    sendOne = { src, onProgress -> onProgress(src.sizeBytes ?: 0L, src.sizeBytes) },
+                    connectionMonitor = FakeConnectionMonitor(),
                     progressThrottle = 100.milliseconds,
                     dispatcher = Dispatchers.Unconfined,
                 )
             },
-            inboundEvents = events,
+            inboundEvents = MutableSharedFlow(),
+            scope = scope,
+        )
+        return PeerTransferComponent(
+            componentContext = context,
+            peer = peer,
+            lifecycleRegistry = lifecycle,
+            engine = engine,
             onShowDetails = {},
             scope = scope,
             pendingFilesRepository = pendingFilesRepository,
@@ -74,314 +64,15 @@ class PeerTransferComponentTest {
     }
 
     @Test
-    fun `startOutbound while Active is no-op`() = runTest {
-        val pauseChannel = Channel<Unit>(0)
-        val component = buildComponent(pauseChannel = pauseChannel, scope = backgroundScope)
+    fun `state Value mirrors engine StateFlow`() = runTest {
+        val component = buildComponent(scope = backgroundScope)
+
+        assertIs<PeerTransferState.Idle>(component.state.value)
 
         component.startOutbound(listOf(FakeFileSource("a.txt", 100L)))
         runCurrent()
-        assertIs<PeerTransferState.ActiveOutbound>(component.state.value)
-        val firstFile = (component.state.value as PeerTransferState.ActiveOutbound).currentFile
 
-        component.startOutbound(listOf(FakeFileSource("b.txt", 200L)))
-        runCurrent()
-
-        val state = component.state.value as PeerTransferState.ActiveOutbound
-        assertEquals(firstFile, state.currentFile)
-    }
-
-    @Test
-    fun `onCancel transitions state to Cancelled`() = runTest {
-        val pauseChannel = Channel<Unit>(0)
-        val component = buildComponent(pauseChannel = pauseChannel, scope = backgroundScope)
-
-        component.startOutbound(listOf(FakeFileSource("a.txt", 100L), FakeFileSource("b.txt", 100L)))
-        runCurrent()
-        assertIs<PeerTransferState.ActiveOutbound>(component.state.value)
-
-        component.onCancel()
-        runCurrent()
-
-        assertIs<PeerTransferState.Cancelled>(component.state.value)
-    }
-
-    @Test
-    fun `inbound Started Progress FileCompleted BatchCompleted produces Received`() = runTest {
-        val events = MutableSharedFlow<ReceiveEvent>(extraBufferCapacity = 16)
-        val component = buildComponent(events = events, scope = backgroundScope)
-        runCurrent()
-
-        events.emit(ReceiveEvent.Started("file.txt", 1))
-        runCurrent()
-        assertIs<PeerTransferState.ActiveInbound>(component.state.value)
-
-        events.emit(ReceiveEvent.Progress("file.txt", 50L, 100L))
-        runCurrent()
-        assertIs<PeerTransferState.ActiveInbound>(component.state.value)
-
-        events.emit(ReceiveEvent.FileCompleted("file.txt"))
-        runCurrent()
-        assertIs<PeerTransferState.ActiveInbound>(component.state.value)
-
-        events.emit(ReceiveEvent.BatchCompleted(received = 1, total = 1))
-        runCurrent()
-
-        val state = component.state.value
-        assertIs<PeerTransferState.Received>(state)
-        assertEquals(1, state.received)
-        assertEquals(1, state.total)
-    }
-
-    @Test
-    fun `ReceiverSuspended event produces Error ReceiverSuspended`() = runTest {
-        val events = MutableSharedFlow<ReceiveEvent>(extraBufferCapacity = 16)
-        val component = buildComponent(events = events, scope = backgroundScope)
-        runCurrent()
-
-        events.emit(ReceiveEvent.Started("file.txt", 1))
-        runCurrent()
-        events.emit(ReceiveEvent.ReceiverSuspended)
-        runCurrent()
-
-        val state = component.state.value
-        assertIs<PeerTransferState.Error>(state)
-        assertEquals(TransferErrorReason.ReceiverSuspended, state.reason)
-    }
-
-    @Test
-    fun `onRetry after ReceiverSuspended does not restart transfer`() = runTest {
-        val events = MutableSharedFlow<ReceiveEvent>(extraBufferCapacity = 16)
-        val component = buildComponent(events = events, scope = backgroundScope)
-        runCurrent()
-
-        events.emit(ReceiveEvent.Started("file.txt", 1))
-        runCurrent()
-        events.emit(ReceiveEvent.ReceiverSuspended)
-        runCurrent()
-
-        val errorState = component.state.value
-        assertIs<PeerTransferState.Error>(errorState)
-
-        component.onRetry()
-        runCurrent()
-
-        assertIs<PeerTransferState.Error>(
-            component.state.value,
-            "State must remain Error when no retryable sources exist",
-        )
-    }
-
-    @Test
-    fun `BatchCompleted with failed CancelledByUser files produces ReceiverCancelled partial reason`() = runTest {
-        val events = MutableSharedFlow<ReceiveEvent>(extraBufferCapacity = 16)
-        val component = buildComponent(events = events, scope = backgroundScope)
-        runCurrent()
-
-        events.emit(ReceiveEvent.Started("file.txt", 2))
-        runCurrent()
-        events.emit(ReceiveEvent.Failed("skipped.txt", FailureReason.CancelledByUser))
-        runCurrent()
-        events.emit(ReceiveEvent.BatchCompleted(received = 1, total = 2))
-        runCurrent()
-
-        val state = component.state.value
-        assertIs<PeerTransferState.Received>(state)
-        assertIs<PartialOutcome.ReceiverCancelled>(state.partialReason)
-    }
-
-    @Test
-    fun `BatchCompleted with partial receive and no cancellations produces ConnectionLost partial reason`() = runTest {
-        val events = MutableSharedFlow<ReceiveEvent>(extraBufferCapacity = 16)
-        val component = buildComponent(events = events, scope = backgroundScope)
-        runCurrent()
-
-        events.emit(ReceiveEvent.Started("file.txt", 2))
-        runCurrent()
-        events.emit(ReceiveEvent.BatchCompleted(received = 1, total = 2))
-        runCurrent()
-
-        val state = component.state.value
-        assertIs<PeerTransferState.Received>(state)
-        assertIs<PartialOutcome.ConnectionLost>(state.partialReason)
-    }
-
-    @Test
-    fun `onRetry sends only failed files and skips already succeeded ones`() = runTest {
-        val sendCalls = mutableMapOf("a.txt" to 0, "b.txt" to 0, "c.txt" to 0)
-        val component = buildComponent(
-            scope = backgroundScope,
-            sendOneOverride = { src, onProgress ->
-                sendCalls[src.name] = (sendCalls[src.name] ?: 0) + 1
-                if (src.name == "b.txt" && sendCalls["b.txt"] == 1) {
-                    throw ReceiverWriteFailedException(507)
-                }
-                onProgress(src.sizeBytes ?: 0L, src.sizeBytes)
-            },
-        )
-
-        component.startOutbound(
-            listOf(FakeFileSource("a.txt", 100L), FakeFileSource("b.txt", 100L), FakeFileSource("c.txt", 100L)),
-        )
-        runCurrent()
-
-        val afterFirst = component.state.value
-        assertIs<PeerTransferState.Sent>(afterFirst)
-        assertEquals(2, afterFirst.sent)
-        assertEquals(3, afterFirst.total)
-
-        component.onRetry()
-        runCurrent()
-
-        assertEquals(1, sendCalls["a.txt"])
-        assertEquals(2, sendCalls["b.txt"])
-        assertEquals(1, sendCalls["c.txt"])
-
-        val finalState = component.state.value
-        assertIs<PeerTransferState.Sent>(finalState)
-        assertNull(finalState.partialReason)
-    }
-
-    @Test
-    fun `inbound ReceiveEvent Failed sets perFile entry to Failed`() = runTest {
-        val events = MutableSharedFlow<ReceiveEvent>(extraBufferCapacity = 16)
-        val component = buildComponent(events = events, scope = backgroundScope)
-        runCurrent()
-
-        events.emit(ReceiveEvent.Started("x.txt", 1))
-        runCurrent()
-        events.emit(ReceiveEvent.Progress("x.txt", 50L, 100L))
-        runCurrent()
-        events.emit(ReceiveEvent.Failed("x.txt", FailureReason.ReceiverWriteFailed(null)))
-        runCurrent()
-
-        val state = component.state.value
-        assertIs<PeerTransferState.ActiveInbound>(state)
-        val xStatus = state.perFile.first { it.name == "x.txt" }
-        assertIs<PerFileStatus.Failed>(xStatus)
-        assertIs<FailureReason.ReceiverWriteFailed>(xStatus.reason)
-    }
-
-    @Test
-    fun `inbound ConnectionLost transitions to Reconnecting Inbound`() = runTest {
-        val events = MutableSharedFlow<ReceiveEvent>(extraBufferCapacity = 16)
-        val component = buildComponent(events = events, scope = backgroundScope)
-        runCurrent()
-
-        events.emit(ReceiveEvent.Started("file.txt", 1))
-        runCurrent()
-        events.emit(ReceiveEvent.Progress("file.txt", 50L, 100L))
-        runCurrent()
-        events.emit(ReceiveEvent.ConnectionLost(receivedSoFar = 0))
-        runCurrent()
-
-        val state = component.state.value
-        assertIs<PeerTransferState.Reconnecting>(state)
-        assertEquals(Direction.Inbound, state.direction)
-    }
-
-    @Test
-    fun `inbound BatchCompleted with received less than total sets partialReason`() = runTest {
-        val events = MutableSharedFlow<ReceiveEvent>(extraBufferCapacity = 16)
-        val component = buildComponent(events = events, scope = backgroundScope)
-        runCurrent()
-
-        events.emit(ReceiveEvent.Started("file.txt", 3))
-        runCurrent()
-        events.emit(ReceiveEvent.BatchCompleted(received = 2, total = 3))
-        runCurrent()
-
-        val state = component.state.value
-        assertIs<PeerTransferState.Received>(state)
-        assertEquals(2, state.received)
-        assertEquals(3, state.total)
-        assertIs<PartialOutcome>(state.partialReason)
-    }
-
-    @Test
-    fun `onRetryFile resends only the named file`() = runTest {
-        val sendCalls = mutableMapOf("a.txt" to 0, "b.txt" to 0, "c.txt" to 0)
-        val component = buildComponent(
-            scope = backgroundScope,
-            sendOneOverride = { src, onProgress ->
-                sendCalls[src.name] = (sendCalls[src.name] ?: 0) + 1
-                if (src.name == "b.txt" && sendCalls["b.txt"] == 1) {
-                    throw ReceiverWriteFailedException(507)
-                }
-                onProgress(src.sizeBytes ?: 0L, src.sizeBytes)
-            },
-        )
-
-        component.startOutbound(
-            listOf(FakeFileSource("a.txt", 100L), FakeFileSource("b.txt", 100L), FakeFileSource("c.txt", 100L)),
-        )
-        runCurrent()
         assertIs<PeerTransferState.Sent>(component.state.value)
-
-        component.onRetryFile("b.txt")
-        runCurrent()
-
-        assertEquals(1, sendCalls["a.txt"])
-        assertEquals(2, sendCalls["b.txt"])
-        assertEquals(1, sendCalls["c.txt"])
-    }
-
-    @Test
-    fun `partial success with all PeerUnreachable failures produces PartialOutcome PeerUnreachable`() = runTest {
-        val component = buildComponent(
-            scope = backgroundScope,
-            sendOneOverride = { src, onProgress ->
-                if (src.name == "b.txt") throw PeerUnreachableException()
-                onProgress(src.sizeBytes ?: 0L, src.sizeBytes)
-            },
-        )
-
-        component.startOutbound(listOf(FakeFileSource("a.txt", 100L), FakeFileSource("b.txt", 100L)))
-        runCurrent()
-
-        val state = component.state.value
-        assertIs<PeerTransferState.Sent>(state)
-        assertEquals(PartialOutcome.PeerUnreachable, state.partialReason)
-    }
-
-    @Test
-    fun `partial success with all ReceiverWriteFailed produces ReceiverWriteFailed partial`() = runTest {
-        val component = buildComponent(
-            scope = backgroundScope,
-            sendOneOverride = { src, onProgress ->
-                if (src.name == "b.txt") throw ReceiverWriteFailedException(507)
-                onProgress(src.sizeBytes ?: 0L, src.sizeBytes)
-            },
-        )
-
-        component.startOutbound(listOf(FakeFileSource("a.txt", 100L), FakeFileSource("b.txt", 100L)))
-        runCurrent()
-
-        val state = component.state.value
-        assertIs<PeerTransferState.Sent>(state)
-        assertEquals(PartialOutcome.ReceiverWriteFailed, state.partialReason)
-    }
-
-    @Test
-    fun `partial success with heterogeneous failures produces PartialOutcome ConnectionLost`() = runTest {
-        val component = buildComponent(
-            scope = backgroundScope,
-            sendOneOverride = { src, onProgress ->
-                when (src.name) {
-                    "b.txt" -> throw PeerUnreachableException()
-                    "c.txt" -> throw ReceiverWriteFailedException(507)
-                    else -> onProgress(src.sizeBytes ?: 0L, src.sizeBytes)
-                }
-            },
-        )
-
-        component.startOutbound(
-            listOf(FakeFileSource("a.txt", 100L), FakeFileSource("b.txt", 100L), FakeFileSource("c.txt", 100L)),
-        )
-        runCurrent()
-
-        val state = component.state.value
-        assertIs<PeerTransferState.Sent>(state)
-        assertEquals(PartialOutcome.ConnectionLost, state.partialReason)
     }
 
     @Test
@@ -413,5 +104,11 @@ class PeerTransferComponentTest {
         component.onCardClick()
 
         assertTrue(pickerInvoked)
+    }
+
+    @Test
+    fun `destroyContext does not throw`() = runTest {
+        val component = buildComponent(scope = backgroundScope)
+        component.destroyContext()
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponentTest.kt
@@ -16,13 +16,8 @@ import com.tubetoast.tether.transfer.PeerTransferState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -32,16 +27,6 @@ import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PeerTransferComponentTest {
-    @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(UnconfinedTestDispatcher())
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
     private val peer = Peer(
         id = PeerIdentity("test-peer"),
         device = Device(name = "TestDevice", host = "127.0.0.1", port = 8080),

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponentTest.kt
@@ -10,10 +10,12 @@ import com.tubetoast.tether.protocol.Device
 import com.tubetoast.tether.transfer.FakeFileSource
 import com.tubetoast.tether.transfer.PeerIdentity
 import com.tubetoast.tether.transfer.PeerTransferEngine
+import com.tubetoast.tether.transfer.PeerTransferEngineRegistry
 import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.transfer.fakeBatchSender
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -139,5 +141,52 @@ class PeerTransferComponentTest {
         val (component, lifecycle) = buildComponent(scope = backgroundScope)
         component.destroyContext()
         assertEquals(Lifecycle.State.DESTROYED, lifecycle.state)
+    }
+
+    @Test
+    fun `engine survives destroyContext and re-attaches on new component`() = runTest {
+        val pauseChannel = Channel<Unit>(0)
+        val registry = PeerTransferEngineRegistry(
+            appScope = backgroundScope,
+            engineFactory = { id, engineScope ->
+                PeerTransferEngine(
+                    peer = id,
+                    batchSenderFactory = fakeBatchSender(pauseChannel = pauseChannel),
+                    inboundEvents = MutableSharedFlow(),
+                    scope = engineScope,
+                )
+            },
+        )
+
+        val lifecycleA = LifecycleRegistry()
+        lifecycleA.resume()
+        val componentA = PeerTransferComponent(
+            componentContext = DefaultComponentContext(lifecycleA),
+            peer = peer,
+            lifecycleRegistry = lifecycleA,
+            engine = registry.engineFor(peer.id),
+            onShowDetails = {},
+            scope = backgroundScope,
+        )
+
+        componentA.startOutbound(listOf(FakeFileSource("file.txt", 100L)))
+        runCurrent()
+        assertIs<PeerTransferState.ActiveOutbound>(componentA.state.value.transfer)
+
+        componentA.destroyContext()
+
+        val lifecycleB = LifecycleRegistry()
+        lifecycleB.resume()
+        val componentB = PeerTransferComponent(
+            componentContext = DefaultComponentContext(lifecycleB),
+            peer = peer,
+            lifecycleRegistry = lifecycleB,
+            engine = registry.engineFor(peer.id),
+            onShowDetails = {},
+            scope = backgroundScope,
+        )
+        runCurrent()
+
+        assertIs<PeerTransferState.ActiveOutbound>(componentB.state.value.transfer)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponentTest.kt
@@ -7,13 +7,11 @@ import com.arkivanov.essenty.lifecycle.resume
 import com.tubetoast.tether.presentation.PendingFilesSummary
 import com.tubetoast.tether.presentation.peer.Peer
 import com.tubetoast.tether.protocol.Device
-import com.tubetoast.tether.transfer.BatchSender
-import com.tubetoast.tether.transfer.FakeConnectionMonitor
 import com.tubetoast.tether.transfer.FakeFileSource
 import com.tubetoast.tether.transfer.PeerIdentity
 import com.tubetoast.tether.transfer.PeerTransferEngine
 import com.tubetoast.tether.transfer.PeerTransferState
-import kotlinx.coroutines.Dispatchers
+import com.tubetoast.tether.transfer.fakeBatchSender
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runCurrent
@@ -23,7 +21,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PeerTransferComponentTest {
@@ -42,14 +39,7 @@ class PeerTransferComponentTest {
         val context = DefaultComponentContext(lifecycle)
         val engine = PeerTransferEngine(
             peer = peer.id,
-            batchSenderFactory = {
-                BatchSender(
-                    sendOne = { src, onProgress -> onProgress(src.sizeBytes ?: 0L, src.sizeBytes) },
-                    connectionMonitor = FakeConnectionMonitor(),
-                    progressThrottle = 100.milliseconds,
-                    dispatcher = Dispatchers.Unconfined,
-                )
-            },
+            batchSenderFactory = fakeBatchSender(),
             inboundEvents = MutableSharedFlow(),
             scope = scope,
         )

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponentTest.kt
@@ -12,10 +12,16 @@ import com.tubetoast.tether.transfer.PeerIdentity
 import com.tubetoast.tether.transfer.PeerTransferEngine
 import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.transfer.fakeBatchSender
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -24,6 +30,16 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PeerTransferComponentTest {
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
     private val peer = Peer(
         id = PeerIdentity("test-peer"),
         device = Device(name = "TestDevice", host = "127.0.0.1", port = 8080),
@@ -60,12 +76,31 @@ class PeerTransferComponentTest {
     fun `state Value mirrors engine StateFlow`() = runTest {
         val (component) = buildComponent(scope = backgroundScope)
 
-        assertIs<PeerTransferState.Idle>(component.state.value)
+        assertIs<PeerTransferState.Idle>(component.state.value.transfer)
 
         component.startOutbound(listOf(FakeFileSource("a.txt", 100L)))
         runCurrent()
 
-        assertIs<PeerTransferState.Sent>(component.state.value)
+        assertIs<PeerTransferState.Sent>(component.state.value.transfer)
+    }
+
+    @Test
+    fun `toggleExpanded flips expanded and preserves transfer state`() = runTest {
+        val (component) = buildComponent(scope = backgroundScope)
+
+        assertIs<PeerTransferState.Idle>(component.state.value.transfer)
+        assertEquals(false, component.state.value.expanded)
+
+        component.toggleExpanded()
+        runCurrent()
+
+        assertTrue(component.state.value.expanded)
+        assertIs<PeerTransferState.Idle>(component.state.value.transfer)
+
+        component.toggleExpanded()
+        runCurrent()
+
+        assertEquals(false, component.state.value.expanded)
     }
 
     @Test
@@ -82,7 +117,7 @@ class PeerTransferComponentTest {
         component.onCardClick()
         runCurrent()
 
-        assertIs<PeerTransferState.Sent>(component.state.value)
+        assertIs<PeerTransferState.Sent>(component.state.value.transfer)
         assertNull(repo.summary.value)
     }
 

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/PeerTransferComponentTest.kt
@@ -1,6 +1,7 @@
 package com.tubetoast.tether.presentation.transfer
 
 import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.essenty.lifecycle.Lifecycle
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
 import com.tubetoast.tether.presentation.PendingFilesSummary
@@ -15,9 +16,15 @@ import com.tubetoast.tether.transfer.PeerTransferState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -25,6 +32,16 @@ import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PeerTransferComponentTest {
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
     private val peer = Peer(
         id = PeerIdentity("test-peer"),
         device = Device(name = "TestDevice", host = "127.0.0.1", port = 8080),
@@ -34,7 +51,7 @@ class PeerTransferComponentTest {
         pendingFilesRepository: PendingFilesRepository? = null,
         onOpenPicker: () -> Unit = {},
         scope: kotlinx.coroutines.CoroutineScope,
-    ): PeerTransferComponent {
+    ): Pair<PeerTransferComponent, LifecycleRegistry> {
         val lifecycle = LifecycleRegistry()
         lifecycle.resume()
         val context = DefaultComponentContext(lifecycle)
@@ -51,7 +68,7 @@ class PeerTransferComponentTest {
             inboundEvents = MutableSharedFlow(),
             scope = scope,
         )
-        return PeerTransferComponent(
+        val component = PeerTransferComponent(
             componentContext = context,
             peer = peer,
             lifecycleRegistry = lifecycle,
@@ -61,11 +78,12 @@ class PeerTransferComponentTest {
             pendingFilesRepository = pendingFilesRepository,
             onOpenPicker = onOpenPicker,
         )
+        return component to lifecycle
     }
 
     @Test
     fun `state Value mirrors engine StateFlow`() = runTest {
-        val component = buildComponent(scope = backgroundScope)
+        val (component) = buildComponent(scope = backgroundScope)
 
         assertIs<PeerTransferState.Idle>(component.state.value)
 
@@ -78,7 +96,7 @@ class PeerTransferComponentTest {
     @Test
     fun `onCardClick with pending sources starts outbound and clears repo`() = runTest {
         val repo = PendingFilesRepository()
-        val component = buildComponent(
+        val (component) = buildComponent(
             pendingFilesRepository = repo,
             scope = backgroundScope,
         )
@@ -96,7 +114,7 @@ class PeerTransferComponentTest {
     @Test
     fun `onCardClick without pending sources invokes onOpenPicker`() = runTest {
         var pickerInvoked = false
-        val component = buildComponent(
+        val (component) = buildComponent(
             onOpenPicker = { pickerInvoked = true },
             scope = backgroundScope,
         )
@@ -107,8 +125,9 @@ class PeerTransferComponentTest {
     }
 
     @Test
-    fun `destroyContext does not throw`() = runTest {
-        val component = buildComponent(scope = backgroundScope)
+    fun `destroyContext destroys the lifecycle`() = runTest {
+        val (component, lifecycle) = buildComponent(scope = backgroundScope)
         component.destroyContext()
+        assertEquals(Lifecycle.State.DESTROYED, lifecycle.state)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsComponentTest.kt
@@ -19,8 +19,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -29,6 +34,16 @@ import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TransferDetailsComponentTest {
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
     private val peer = Peer(
         id = PeerIdentity("test-peer"),
         device = Device(name = "TestDevice", host = "127.0.0.1", port = 8080),

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsComponentTest.kt
@@ -19,13 +19,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -34,16 +29,6 @@ import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TransferDetailsComponentTest {
-    @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(UnconfinedTestDispatcher())
-    }
-
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
     private val peer = Peer(
         id = PeerIdentity("test-peer"),
         device = Device(name = "TestDevice", host = "127.0.0.1", port = 8080),

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsComponentTest.kt
@@ -11,6 +11,8 @@ import com.tubetoast.tether.transfer.FakeConnectionMonitor
 import com.tubetoast.tether.transfer.FakeFileSource
 import com.tubetoast.tether.transfer.FileSource
 import com.tubetoast.tether.transfer.PeerIdentity
+import com.tubetoast.tether.transfer.PeerTransferEngine
+import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.transfer.PerFileStatus
 import com.tubetoast.tether.transfer.ReceiverWriteFailedException
 import kotlinx.coroutines.Dispatchers
@@ -41,10 +43,8 @@ class TransferDetailsComponentTest {
         lifecycle.resume()
         val context = DefaultComponentContext(lifecycle)
         val monitor = FakeConnectionMonitor()
-        return PeerTransferComponent(
-            componentContext = context,
-            peer = peer,
-            lifecycleRegistry = lifecycle,
+        val engine = PeerTransferEngine(
+            peer = peer.id,
             batchSenderFactory = {
                 BatchSender(
                     sendOne = sendOneOverride ?: { src, onProgress ->
@@ -57,6 +57,13 @@ class TransferDetailsComponentTest {
                 )
             },
             inboundEvents = MutableSharedFlow(),
+            scope = scope,
+        )
+        return PeerTransferComponent(
+            componentContext = context,
+            peer = peer,
+            lifecycleRegistry = lifecycle,
+            engine = engine,
             onShowDetails = {},
             scope = scope,
         )

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsComponentTest.kt
@@ -5,9 +5,7 @@ import com.arkivanov.essenty.lifecycle.LifecycleRegistry
 import com.arkivanov.essenty.lifecycle.resume
 import com.tubetoast.tether.presentation.peer.Peer
 import com.tubetoast.tether.protocol.Device
-import com.tubetoast.tether.transfer.BatchSender
 import com.tubetoast.tether.transfer.FailureReason
-import com.tubetoast.tether.transfer.FakeConnectionMonitor
 import com.tubetoast.tether.transfer.FakeFileSource
 import com.tubetoast.tether.transfer.FileSource
 import com.tubetoast.tether.transfer.PeerIdentity
@@ -15,7 +13,7 @@ import com.tubetoast.tether.transfer.PeerTransferEngine
 import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.transfer.PerFileStatus
 import com.tubetoast.tether.transfer.ReceiverWriteFailedException
-import kotlinx.coroutines.Dispatchers
+import com.tubetoast.tether.transfer.fakeBatchSender
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -25,7 +23,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
-import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TransferDetailsComponentTest {
@@ -42,20 +39,9 @@ class TransferDetailsComponentTest {
         val lifecycle = LifecycleRegistry()
         lifecycle.resume()
         val context = DefaultComponentContext(lifecycle)
-        val monitor = FakeConnectionMonitor()
         val engine = PeerTransferEngine(
             peer = peer.id,
-            batchSenderFactory = {
-                BatchSender(
-                    sendOne = sendOneOverride ?: { src, onProgress ->
-                        pauseChannel?.receive()
-                        onProgress(src.sizeBytes ?: 0L, src.sizeBytes)
-                    },
-                    connectionMonitor = monitor,
-                    progressThrottle = 100.milliseconds,
-                    dispatcher = Dispatchers.Unconfined,
-                )
-            },
+            batchSenderFactory = fakeBatchSender(sendOneOverride = sendOneOverride, pauseChannel = pauseChannel),
             inboundEvents = MutableSharedFlow(),
             scope = scope,
         )

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsComponentTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/presentation/transfer/TransferDetailsComponentTest.kt
@@ -14,11 +14,17 @@ import com.tubetoast.tether.transfer.PeerTransferState
 import com.tubetoast.tether.transfer.PerFileStatus
 import com.tubetoast.tether.transfer.ReceiverWriteFailedException
 import com.tubetoast.tether.transfer.fakeBatchSender
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -26,6 +32,16 @@ import kotlin.test.assertNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TransferDetailsComponentTest {
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
     private val peer = Peer(
         id = PeerIdentity("test-peer"),
         device = Device(name = "TestDevice", host = "127.0.0.1", port = 8080),
@@ -77,12 +93,12 @@ class TransferDetailsComponentTest {
 
         peerComponent.startOutbound(listOf(FakeFileSource("a.txt", 100L), FakeFileSource("b.txt", 100L)))
         runCurrent()
-        assertIs<PeerTransferState.ActiveOutbound>(peerComponent.state.value)
+        assertIs<PeerTransferState.ActiveOutbound>(peerComponent.state.value.transfer)
 
         details.onCancelTransfer()
         runCurrent()
 
-        assertIs<PeerTransferState.Cancelled>(peerComponent.state.value)
+        assertIs<PeerTransferState.Cancelled>(peerComponent.state.value.transfer)
     }
 
     @Test
@@ -123,7 +139,7 @@ class TransferDetailsComponentTest {
         )
         runCurrent()
 
-        val stateOnB = peerComponent.state.value
+        val stateOnB = peerComponent.state.value.transfer
         assertIs<PeerTransferState.ActiveOutbound>(stateOnB)
         assertEquals("b.txt", stateOnB.currentFile)
 
@@ -131,7 +147,7 @@ class TransferDetailsComponentTest {
         runCurrent()
         runCurrent()
 
-        val finalState = peerComponent.state.value
+        val finalState = peerComponent.state.value.transfer
         assertIs<PeerTransferState.Sent>(finalState)
         assertEquals(2, finalState.sent)
         assertEquals(3, finalState.total)
@@ -158,14 +174,14 @@ class TransferDetailsComponentTest {
         )
         runCurrent()
 
-        val activeState = peerComponent.state.value
+        val activeState = peerComponent.state.value.transfer
         assertIs<PeerTransferState.ActiveOutbound>(activeState)
         assertEquals("file1.txt", activeState.currentFile)
 
         details.onCancelFile("file2.txt")
         runCurrent()
 
-        val stateAfterCancel = peerComponent.state.value
+        val stateAfterCancel = peerComponent.state.value.transfer
         assertIs<PeerTransferState.ActiveOutbound>(stateAfterCancel)
         val file2Status = stateAfterCancel.perFile.first { it.name == "file2.txt" }
         assertIs<PerFileStatus.Failed>(file2Status)
@@ -175,7 +191,7 @@ class TransferDetailsComponentTest {
         pauseChannel.send(Unit)
         runCurrent()
 
-        val finalState = peerComponent.state.value
+        val finalState = peerComponent.state.value.transfer
         assertIs<PeerTransferState.Sent>(finalState)
         val finalFile2 = finalState.perFile.first { it.name == "file2.txt" }
         assertIs<PerFileStatus.Failed>(finalFile2)
@@ -200,13 +216,13 @@ class TransferDetailsComponentTest {
 
         peerComponent.startOutbound(listOf(FakeFileSource("a.txt", 100L), FakeFileSource("b.txt", 100L)))
         runCurrent()
-        assertIs<PeerTransferState.Sent>(peerComponent.state.value)
+        assertIs<PeerTransferState.Sent>(peerComponent.state.value.transfer)
 
         details.onRetryAll()
         runCurrent()
 
         assertEquals(1, sendCalls["a.txt"])
         assertEquals(2, sendCalls["b.txt"])
-        assertNull((peerComponent.state.value as? PeerTransferState.Sent)?.partialReason)
+        assertNull((peerComponent.state.value.transfer as? PeerTransferState.Sent)?.partialReason)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/FakeBatchSender.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/FakeBatchSender.kt
@@ -3,9 +3,13 @@ package com.tubetoast.tether.transfer
 import kotlinx.coroutines.Dispatchers
 import kotlin.time.Duration.Companion.milliseconds
 
-internal fun fakeBatchSender(): () -> BatchSender = {
+internal fun fakeBatchSender(
+    sendOneOverride: (suspend (FileSource, (Long, Long?) -> Unit) -> Unit)? = null,
+    pauseChannel: kotlinx.coroutines.channels.Channel<Unit>? = null,
+): () -> BatchSender = {
     BatchSender(
-        sendOne = { src, onProgress ->
+        sendOne = sendOneOverride ?: { src, onProgress ->
+            pauseChannel?.receive()
             onProgress(src.sizeBytes ?: 0L, src.sizeBytes)
         },
         connectionMonitor = FakeConnectionMonitor(),

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineRegistryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineRegistryTest.kt
@@ -1,17 +1,22 @@
 package com.tubetoast.tether.transfer
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertSame
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PeerTransferEngineRegistryTest {
@@ -90,13 +95,28 @@ class PeerTransferEngineRegistryTest {
     @Test
     fun `engines created in parallel for the same peer resolve to one instance`() = runTest {
         val registry = buildRegistry(backgroundScope)
+        val threadCount = 8
+        // CompletableDeferred broadcasts to all waiting threads at once, maximising the chance
+        // that compareAndSet races across real Dispatchers.Default threads.
+        val ready = Semaphore(permits = threadCount, acquiredPermits = threadCount)
+        val go = CompletableDeferred<Unit>()
 
-        val results = (1..8)
+        val results = (1..threadCount)
             .map {
-                async { registry.engineFor(peerA) }
-            }.awaitAll()
+                async {
+                    withContext(Dispatchers.Default) {
+                        ready.release()
+                        go.await()
+                        registry.engineFor(peerA)
+                    }
+                }
+            }
 
-        val distinct = results.toSet()
-        assertEquals(1, distinct.size)
+        repeat(threadCount) { ready.acquire() }
+        go.complete(Unit)
+
+        val engines = results.awaitAll()
+        val expected = engines.first()
+        engines.forEach { assertSame(expected, it) }
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineRegistryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineRegistryTest.kt
@@ -1,0 +1,102 @@
+package com.tubetoast.tether.transfer
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PeerTransferEngineRegistryTest {
+    private val peerA = PeerIdentity("peer-a")
+    private val peerB = PeerIdentity("peer-b")
+
+    private fun buildRegistry(appScope: CoroutineScope): PeerTransferEngineRegistry =
+        PeerTransferEngineRegistry(
+            appScope = appScope,
+            engineFactory = { peer, engineScope ->
+                PeerTransferEngine(
+                    peer = peer,
+                    batchSenderFactory = fakeBatchSender(),
+                    inboundEvents = MutableSharedFlow(),
+                    scope = engineScope,
+                )
+            },
+        )
+
+    @Test
+    fun `engineFor returns the same engine for repeated calls with the same peer`() = runTest {
+        val registry = buildRegistry(backgroundScope)
+
+        val first = registry.engineFor(peerA)
+        val second = registry.engineFor(peerA)
+
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun `engineFor returns distinct engines for distinct peers`() = runTest {
+        val registry = buildRegistry(backgroundScope)
+
+        val engineA = registry.engineFor(peerA)
+        val engineB = registry.engineFor(peerB)
+
+        assertNotEquals(engineA, engineB)
+    }
+
+    @Test
+    fun `evict removes engine so next engineFor creates a fresh instance`() = runTest {
+        val registry = buildRegistry(backgroundScope)
+
+        val before = registry.engineFor(peerA)
+        registry.evict(peerA)
+        val after = registry.engineFor(peerA)
+
+        assertNotEquals(before, after)
+    }
+
+    @Test
+    fun `evict cancels the evicted engine scope`() = runTest {
+        var capturedEngineScope: CoroutineScope? = null
+        val registry = PeerTransferEngineRegistry(
+            appScope = backgroundScope,
+            engineFactory = { peer, engineScope ->
+                capturedEngineScope = engineScope
+                PeerTransferEngine(
+                    peer = peer,
+                    batchSenderFactory = fakeBatchSender(),
+                    inboundEvents = MutableSharedFlow(),
+                    scope = engineScope,
+                )
+            },
+        )
+
+        registry.engineFor(peerA)
+        val scope = capturedEngineScope
+        assertNotNull(scope)
+
+        registry.evict(peerA)
+
+        assertFalse(scope.isActive)
+    }
+
+    @Test
+    fun `engines created in parallel for the same peer resolve to one instance`() = runTest {
+        val registry = buildRegistry(backgroundScope)
+
+        val results = (1..8)
+            .map {
+                async { registry.engineFor(peerA) }
+            }.awaitAll()
+
+        val distinct = results.toSet()
+        assertEquals(1, distinct.size)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineTest.kt
@@ -9,7 +9,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PeerTransferEngineTest {
@@ -336,19 +335,6 @@ class PeerTransferEngineTest {
         val state = engine.state.value
         assertIs<PeerTransferState.Sent>(state)
         assertEquals(PartialOutcome.ConnectionLost, state.partialReason)
-    }
-
-    @Test
-    fun `toggleExpanded flips expanded flag in Idle state`() = runTest {
-        val engine = buildEngine(scope = backgroundScope)
-
-        assertIs<PeerTransferState.Idle>(engine.state.value)
-        assertTrue(!(engine.state.value as PeerTransferState.Idle).expanded)
-
-        engine.toggleExpanded()
-        runCurrent()
-
-        assertTrue((engine.state.value as PeerTransferState.Idle).expanded)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineTest.kt
@@ -1,0 +1,380 @@
+package com.tubetoast.tether.transfer
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PeerTransferEngineTest {
+    private val peer = PeerIdentity("test-peer")
+
+    private fun buildEngine(
+        events: MutableSharedFlow<ReceiveEvent> = MutableSharedFlow(extraBufferCapacity = 16),
+        monitor: FakeConnectionMonitor = FakeConnectionMonitor(),
+        pauseChannel: Channel<Unit>? = null,
+        sendOneOverride: (suspend (FileSource, (Long, Long?) -> Unit) -> Unit)? = null,
+        scope: kotlinx.coroutines.CoroutineScope,
+    ): PeerTransferEngine = PeerTransferEngine(
+        peer = peer,
+        batchSenderFactory = {
+            BatchSender(
+                sendOne = sendOneOverride ?: { src, onProgress ->
+                    pauseChannel?.receive()
+                    onProgress(src.sizeBytes ?: 0L, src.sizeBytes)
+                },
+                connectionMonitor = monitor,
+                progressThrottle = 100.milliseconds,
+                dispatcher = Dispatchers.Unconfined,
+            )
+        },
+        inboundEvents = events,
+        scope = scope,
+    )
+
+    @Test
+    fun `startOutbound while Active is no-op`() = runTest {
+        val pauseChannel = Channel<Unit>(0)
+        val engine = buildEngine(pauseChannel = pauseChannel, scope = backgroundScope)
+
+        engine.startOutbound(listOf(FakeFileSource("a.txt", 100L)))
+        runCurrent()
+        assertIs<PeerTransferState.ActiveOutbound>(engine.state.value)
+        val firstFile = (engine.state.value as PeerTransferState.ActiveOutbound).currentFile
+
+        engine.startOutbound(listOf(FakeFileSource("b.txt", 200L)))
+        runCurrent()
+
+        val state = engine.state.value as PeerTransferState.ActiveOutbound
+        assertEquals(firstFile, state.currentFile)
+    }
+
+    @Test
+    fun `onCancel transitions state to Cancelled`() = runTest {
+        val pauseChannel = Channel<Unit>(0)
+        val engine = buildEngine(pauseChannel = pauseChannel, scope = backgroundScope)
+
+        engine.startOutbound(listOf(FakeFileSource("a.txt", 100L), FakeFileSource("b.txt", 100L)))
+        runCurrent()
+        assertIs<PeerTransferState.ActiveOutbound>(engine.state.value)
+
+        engine.onCancel()
+        runCurrent()
+
+        assertIs<PeerTransferState.Cancelled>(engine.state.value)
+    }
+
+    @Test
+    fun `inbound Started Progress FileCompleted BatchCompleted produces Received`() = runTest {
+        val events = MutableSharedFlow<ReceiveEvent>(extraBufferCapacity = 16)
+        val engine = buildEngine(events = events, scope = backgroundScope)
+        runCurrent()
+
+        events.emit(ReceiveEvent.Started("file.txt", 1))
+        runCurrent()
+        assertIs<PeerTransferState.ActiveInbound>(engine.state.value)
+
+        events.emit(ReceiveEvent.Progress("file.txt", 50L, 100L))
+        runCurrent()
+        assertIs<PeerTransferState.ActiveInbound>(engine.state.value)
+
+        events.emit(ReceiveEvent.FileCompleted("file.txt"))
+        runCurrent()
+        assertIs<PeerTransferState.ActiveInbound>(engine.state.value)
+
+        events.emit(ReceiveEvent.BatchCompleted(received = 1, total = 1))
+        runCurrent()
+
+        val state = engine.state.value
+        assertIs<PeerTransferState.Received>(state)
+        assertEquals(1, state.received)
+        assertEquals(1, state.total)
+    }
+
+    @Test
+    fun `ReceiverSuspended event produces Error ReceiverSuspended`() = runTest {
+        val events = MutableSharedFlow<ReceiveEvent>(extraBufferCapacity = 16)
+        val engine = buildEngine(events = events, scope = backgroundScope)
+        runCurrent()
+
+        events.emit(ReceiveEvent.Started("file.txt", 1))
+        runCurrent()
+        events.emit(ReceiveEvent.ReceiverSuspended)
+        runCurrent()
+
+        val state = engine.state.value
+        assertIs<PeerTransferState.Error>(state)
+        assertEquals(TransferErrorReason.ReceiverSuspended, state.reason)
+    }
+
+    @Test
+    fun `onRetry after ReceiverSuspended does not restart transfer`() = runTest {
+        val events = MutableSharedFlow<ReceiveEvent>(extraBufferCapacity = 16)
+        val engine = buildEngine(events = events, scope = backgroundScope)
+        runCurrent()
+
+        events.emit(ReceiveEvent.Started("file.txt", 1))
+        runCurrent()
+        events.emit(ReceiveEvent.ReceiverSuspended)
+        runCurrent()
+
+        val errorState = engine.state.value
+        assertIs<PeerTransferState.Error>(errorState)
+
+        engine.onRetry()
+        runCurrent()
+
+        assertIs<PeerTransferState.Error>(
+            engine.state.value,
+            "State must remain Error when no retryable sources exist",
+        )
+    }
+
+    @Test
+    fun `BatchCompleted with failed CancelledByUser files produces ReceiverCancelled partial reason`() = runTest {
+        val events = MutableSharedFlow<ReceiveEvent>(extraBufferCapacity = 16)
+        val engine = buildEngine(events = events, scope = backgroundScope)
+        runCurrent()
+
+        events.emit(ReceiveEvent.Started("file.txt", 2))
+        runCurrent()
+        events.emit(ReceiveEvent.Failed("skipped.txt", FailureReason.CancelledByUser))
+        runCurrent()
+        events.emit(ReceiveEvent.BatchCompleted(received = 1, total = 2))
+        runCurrent()
+
+        val state = engine.state.value
+        assertIs<PeerTransferState.Received>(state)
+        assertIs<PartialOutcome.ReceiverCancelled>(state.partialReason)
+    }
+
+    @Test
+    fun `BatchCompleted with partial receive and no cancellations produces ConnectionLost partial reason`() = runTest {
+        val events = MutableSharedFlow<ReceiveEvent>(extraBufferCapacity = 16)
+        val engine = buildEngine(events = events, scope = backgroundScope)
+        runCurrent()
+
+        events.emit(ReceiveEvent.Started("file.txt", 2))
+        runCurrent()
+        events.emit(ReceiveEvent.BatchCompleted(received = 1, total = 2))
+        runCurrent()
+
+        val state = engine.state.value
+        assertIs<PeerTransferState.Received>(state)
+        assertIs<PartialOutcome.ConnectionLost>(state.partialReason)
+    }
+
+    @Test
+    fun `onRetry sends only failed files and skips already succeeded ones`() = runTest {
+        val sendCalls = mutableMapOf("a.txt" to 0, "b.txt" to 0, "c.txt" to 0)
+        val engine = buildEngine(
+            scope = backgroundScope,
+            sendOneOverride = { src, onProgress ->
+                sendCalls[src.name] = (sendCalls[src.name] ?: 0) + 1
+                if (src.name == "b.txt" && sendCalls["b.txt"] == 1) {
+                    throw ReceiverWriteFailedException(507)
+                }
+                onProgress(src.sizeBytes ?: 0L, src.sizeBytes)
+            },
+        )
+
+        engine.startOutbound(
+            listOf(FakeFileSource("a.txt", 100L), FakeFileSource("b.txt", 100L), FakeFileSource("c.txt", 100L)),
+        )
+        runCurrent()
+
+        val afterFirst = engine.state.value
+        assertIs<PeerTransferState.Sent>(afterFirst)
+        assertEquals(2, afterFirst.sent)
+        assertEquals(3, afterFirst.total)
+
+        engine.onRetry()
+        runCurrent()
+
+        assertEquals(1, sendCalls["a.txt"])
+        assertEquals(2, sendCalls["b.txt"])
+        assertEquals(1, sendCalls["c.txt"])
+
+        val finalState = engine.state.value
+        assertIs<PeerTransferState.Sent>(finalState)
+        assertNull(finalState.partialReason)
+    }
+
+    @Test
+    fun `inbound ReceiveEvent Failed sets perFile entry to Failed`() = runTest {
+        val events = MutableSharedFlow<ReceiveEvent>(extraBufferCapacity = 16)
+        val engine = buildEngine(events = events, scope = backgroundScope)
+        runCurrent()
+
+        events.emit(ReceiveEvent.Started("x.txt", 1))
+        runCurrent()
+        events.emit(ReceiveEvent.Progress("x.txt", 50L, 100L))
+        runCurrent()
+        events.emit(ReceiveEvent.Failed("x.txt", FailureReason.ReceiverWriteFailed(null)))
+        runCurrent()
+
+        val state = engine.state.value
+        assertIs<PeerTransferState.ActiveInbound>(state)
+        val xStatus = state.perFile.first { it.name == "x.txt" }
+        assertIs<PerFileStatus.Failed>(xStatus)
+        assertIs<FailureReason.ReceiverWriteFailed>(xStatus.reason)
+    }
+
+    @Test
+    fun `inbound ConnectionLost transitions to Reconnecting Inbound`() = runTest {
+        val events = MutableSharedFlow<ReceiveEvent>(extraBufferCapacity = 16)
+        val engine = buildEngine(events = events, scope = backgroundScope)
+        runCurrent()
+
+        events.emit(ReceiveEvent.Started("file.txt", 1))
+        runCurrent()
+        events.emit(ReceiveEvent.Progress("file.txt", 50L, 100L))
+        runCurrent()
+        events.emit(ReceiveEvent.ConnectionLost(receivedSoFar = 0))
+        runCurrent()
+
+        val state = engine.state.value
+        assertIs<PeerTransferState.Reconnecting>(state)
+        assertEquals(Direction.Inbound, state.direction)
+    }
+
+    @Test
+    fun `inbound BatchCompleted with received less than total sets partialReason`() = runTest {
+        val events = MutableSharedFlow<ReceiveEvent>(extraBufferCapacity = 16)
+        val engine = buildEngine(events = events, scope = backgroundScope)
+        runCurrent()
+
+        events.emit(ReceiveEvent.Started("file.txt", 3))
+        runCurrent()
+        events.emit(ReceiveEvent.BatchCompleted(received = 2, total = 3))
+        runCurrent()
+
+        val state = engine.state.value
+        assertIs<PeerTransferState.Received>(state)
+        assertEquals(2, state.received)
+        assertEquals(3, state.total)
+        assertIs<PartialOutcome>(state.partialReason)
+    }
+
+    @Test
+    fun `onRetryFile resends only the named file`() = runTest {
+        val sendCalls = mutableMapOf("a.txt" to 0, "b.txt" to 0, "c.txt" to 0)
+        val engine = buildEngine(
+            scope = backgroundScope,
+            sendOneOverride = { src, onProgress ->
+                sendCalls[src.name] = (sendCalls[src.name] ?: 0) + 1
+                if (src.name == "b.txt" && sendCalls["b.txt"] == 1) {
+                    throw ReceiverWriteFailedException(507)
+                }
+                onProgress(src.sizeBytes ?: 0L, src.sizeBytes)
+            },
+        )
+
+        engine.startOutbound(
+            listOf(FakeFileSource("a.txt", 100L), FakeFileSource("b.txt", 100L), FakeFileSource("c.txt", 100L)),
+        )
+        runCurrent()
+        assertIs<PeerTransferState.Sent>(engine.state.value)
+
+        engine.onRetryFile("b.txt")
+        runCurrent()
+
+        assertEquals(1, sendCalls["a.txt"])
+        assertEquals(2, sendCalls["b.txt"])
+        assertEquals(1, sendCalls["c.txt"])
+    }
+
+    @Test
+    fun `partial success with all PeerUnreachable failures produces PartialOutcome PeerUnreachable`() = runTest {
+        val engine = buildEngine(
+            scope = backgroundScope,
+            sendOneOverride = { src, onProgress ->
+                if (src.name == "b.txt") throw PeerUnreachableException()
+                onProgress(src.sizeBytes ?: 0L, src.sizeBytes)
+            },
+        )
+
+        engine.startOutbound(listOf(FakeFileSource("a.txt", 100L), FakeFileSource("b.txt", 100L)))
+        runCurrent()
+
+        val state = engine.state.value
+        assertIs<PeerTransferState.Sent>(state)
+        assertEquals(PartialOutcome.PeerUnreachable, state.partialReason)
+    }
+
+    @Test
+    fun `partial success with all ReceiverWriteFailed produces ReceiverWriteFailed partial`() = runTest {
+        val engine = buildEngine(
+            scope = backgroundScope,
+            sendOneOverride = { src, onProgress ->
+                if (src.name == "b.txt") throw ReceiverWriteFailedException(507)
+                onProgress(src.sizeBytes ?: 0L, src.sizeBytes)
+            },
+        )
+
+        engine.startOutbound(listOf(FakeFileSource("a.txt", 100L), FakeFileSource("b.txt", 100L)))
+        runCurrent()
+
+        val state = engine.state.value
+        assertIs<PeerTransferState.Sent>(state)
+        assertEquals(PartialOutcome.ReceiverWriteFailed, state.partialReason)
+    }
+
+    @Test
+    fun `partial success with heterogeneous failures produces PartialOutcome ConnectionLost`() = runTest {
+        val engine = buildEngine(
+            scope = backgroundScope,
+            sendOneOverride = { src, onProgress ->
+                when (src.name) {
+                    "b.txt" -> throw PeerUnreachableException()
+                    "c.txt" -> throw ReceiverWriteFailedException(507)
+                    else -> onProgress(src.sizeBytes ?: 0L, src.sizeBytes)
+                }
+            },
+        )
+
+        engine.startOutbound(
+            listOf(FakeFileSource("a.txt", 100L), FakeFileSource("b.txt", 100L), FakeFileSource("c.txt", 100L)),
+        )
+        runCurrent()
+
+        val state = engine.state.value
+        assertIs<PeerTransferState.Sent>(state)
+        assertEquals(PartialOutcome.ConnectionLost, state.partialReason)
+    }
+
+    @Test
+    fun `toggleExpanded flips expanded flag in Idle state`() = runTest {
+        val engine = buildEngine(scope = backgroundScope)
+
+        assertIs<PeerTransferState.Idle>(engine.state.value)
+        assertTrue(!(engine.state.value as PeerTransferState.Idle).expanded)
+
+        engine.toggleExpanded()
+        runCurrent()
+
+        assertTrue((engine.state.value as PeerTransferState.Idle).expanded)
+    }
+
+    @Test
+    fun `onDismiss from Sent returns to Idle`() = runTest {
+        val engine = buildEngine(scope = backgroundScope)
+
+        engine.startOutbound(listOf(FakeFileSource("a.txt", 100L)))
+        runCurrent()
+        assertIs<PeerTransferState.Sent>(engine.state.value)
+
+        engine.onDismiss()
+        runCurrent()
+
+        assertIs<PeerTransferState.Idle>(engine.state.value)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineTest.kt
@@ -1,6 +1,5 @@
 package com.tubetoast.tether.transfer
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -11,7 +10,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PeerTransferEngineTest {
@@ -19,23 +17,12 @@ class PeerTransferEngineTest {
 
     private fun buildEngine(
         events: MutableSharedFlow<ReceiveEvent> = MutableSharedFlow(extraBufferCapacity = 16),
-        monitor: FakeConnectionMonitor = FakeConnectionMonitor(),
         pauseChannel: Channel<Unit>? = null,
         sendOneOverride: (suspend (FileSource, (Long, Long?) -> Unit) -> Unit)? = null,
         scope: kotlinx.coroutines.CoroutineScope,
     ): PeerTransferEngine = PeerTransferEngine(
         peer = peer,
-        batchSenderFactory = {
-            BatchSender(
-                sendOne = sendOneOverride ?: { src, onProgress ->
-                    pauseChannel?.receive()
-                    onProgress(src.sizeBytes ?: 0L, src.sizeBytes)
-                },
-                connectionMonitor = monitor,
-                progressThrottle = 100.milliseconds,
-                dispatcher = Dispatchers.Unconfined,
-            )
-        },
+        batchSenderFactory = fakeBatchSender(sendOneOverride = sendOneOverride, pauseChannel = pauseChannel),
         inboundEvents = events,
         scope = scope,
     )

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineTest.kt
@@ -102,7 +102,7 @@ class PeerTransferEngineTest {
     }
 
     @Test
-    fun `onRetry after ReceiverSuspended does not restart transfer`() = runTest {
+    fun `onRetryOutbound after ReceiverSuspended does not restart transfer`() = runTest {
         val events = MutableSharedFlow<ReceiveEvent>(extraBufferCapacity = 16)
         val engine = buildEngine(events = events, scope = backgroundScope)
         runCurrent()
@@ -115,7 +115,7 @@ class PeerTransferEngineTest {
         val errorState = engine.state.value
         assertIs<PeerTransferState.Error>(errorState)
 
-        engine.onRetry()
+        engine.onRetryOutbound()
         runCurrent()
 
         assertIs<PeerTransferState.Error>(
@@ -159,7 +159,7 @@ class PeerTransferEngineTest {
     }
 
     @Test
-    fun `onRetry sends only failed files and skips already succeeded ones`() = runTest {
+    fun `onRetryOutbound sends only failed files and skips already succeeded ones`() = runTest {
         val sendCalls = mutableMapOf("a.txt" to 0, "b.txt" to 0, "c.txt" to 0)
         val engine = buildEngine(
             scope = backgroundScope,
@@ -182,7 +182,7 @@ class PeerTransferEngineTest {
         assertEquals(2, afterFirst.sent)
         assertEquals(3, afterFirst.total)
 
-        engine.onRetry()
+        engine.onRetryOutbound()
         runCurrent()
 
         assertEquals(1, sendCalls["a.txt"])

--- a/docs/engineering/presentation-layer.md
+++ b/docs/engineering/presentation-layer.md
@@ -87,6 +87,8 @@ A Component's lifetime is bound to the screen (or flow) it represents. Anything 
 
 In particular: **we do not use `InstanceKeeper` to retain domain state across configuration changes.** The repository in `AppContainer` already outlives the Activity; the Component just rebuilds and re-subscribes on rotation.
 
+When state is **per-peer** (or per any other stable domain identity), the `AppContainer`-owned holder is shaped as a registry keyed by that identity: `engineFor(id)` lazily creates and caches an instance with a per-instance scope, and an `evict(id)` API cancels that scope when the entity is gone for good. Components look up their per-peer holder by identity at construction time and let it outlive their own lifecycle. See `PeerTransferEngineRegistry` for the canonical shape.
+
 ## Screens and previews
 
 A screen is two composables in the same file:

--- a/docs/engineering/presentation-layer.md
+++ b/docs/engineering/presentation-layer.md
@@ -81,6 +81,8 @@ Events are plain method calls on the Component. No `LaunchedEffect` business log
 
 **Components do not own domain logic.** Domain lives in the domain layer in plain Kotlin without framework dependencies. Presentation logic is restricted to mapping domain data to user-facing representation and relaying user actions to the appropriate domain class. Litmus test: if the UI is rewritten ground-up and the logic must still exist — it belongs in the domain layer, not the presentation layer.
 
+**Domain types do not carry view-state fields.** The inverse litmus: if a field would disappear with a different UI (a card's expanded/collapsed flag, hover, selection inside a list) — it does not belong on the domain type. Wrap the domain state in a presentation type that adds those fields, and let the Component combine the domain `StateFlow` with its local view state into the single `Value<PresentationState>` the screen subscribes to.
+
 ## Long-lived state lives outside Components
 
 A Component's lifetime is bound to the screen (or flow) it represents. Anything that must outlive a screen — active file transfers, peer state, long-running connections — lives in repositories owned by `AppContainer`. Components observe these repositories via injected dependencies and never duplicate the state internally.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -25,12 +25,15 @@ Engineering concepts. The vocabulary [`architect`](../.claude/agents/architect.m
 - **Discovery** — the layer that announces a device's presence and finds peers on the local network. _Avoid:_ announce (verb only). (see [discovery.md](engineering/discovery.md))
 - **Rendezvous** — a post-discovery `/hello` mechanism that resolves asymmetric discovery (one side saw the other but not vice versa), primarily for the hotspot scenario. Distinct from Discovery itself.
 - **Peer** — a device visible through discovery, regardless of pairing status. _Avoid:_ node, neighbour; device when pairing status matters (use **Trusted device** then).
+- **Outbound** — a transfer this device initiates and sends to a peer. _Avoid:_ upload, send (verb only).
+- **Inbound** — a transfer this device receives from a peer. _Avoid:_ download, receive (verb only).
 - **FileServer** — the per-device HTTP server that accepts incoming transfers. _Avoid:_ receiver, listener.
 - **FileClient** — the per-device HTTP client that initiates outgoing transfers. _Avoid:_ sender, uploader.
 - **Source set** — a Kotlin Multiplatform compilation source set; platform-to-target mapping and hierarchy live in [architecture-principles.md](engineering/architecture-principles.md). _Avoid:_ saying «JVM» when the audience is end-users — say *Desktop* instead.
 - **Composition root** — the platform entry point that constructs the DI container; by extension, the `AppContainer` instance it constructs. (see [dependency-injection.md](engineering/dependency-injection.md))
 - **Container** — the DI container that holds singletons for one process lifetime; the construct that lives at the composition root.
 - **Session** — the post-rendezvous logical connection between two peers, lasting from `/hello` until either side closes it.
+- **Reconnect window** — the bounded time after a connection drop during which an active transfer waits for the peer to reappear and resumes from where it left off; expiry yields a definitive `NetworkLost` failure.
 - **Drift** — a usage of a term that contradicts its glossary definition, or absence of a glossary entry for a term that recurs across long-lived artifacts.
 - **Living doc** — a `docs/engineering/<name>.md` artifact that captures the present-tense rules for a subsystem; distinct from an ADR (one-time decision) and a knowledge entry (solved-problem note).
 - **Long-lived artifact** — any prose surface that outlives the task that birthed it: `CLAUDE.md`, `docs/`, `.claude/skills/**`, `.claude/agents/**`, `.claude/commands/**`, KDoc, inline comments, error messages. Governed by the discipline in [long-lived-artifacts.md](engineering/long-lived-artifacts.md). _Avoid:_ doc, documentation when the lifetime contrast with task-scoped prose (commit message, PR description) is what matters.

--- a/docs/interview-prep-checklist.md
+++ b/docs/interview-prep-checklist.md
@@ -73,7 +73,7 @@
 
 ### Flow
 - [ ] Cold flow vs Hot flow — новый поток на каждого collector vs один общий
-- [ ] `StateFlow` vs `SharedFlow` — replay, conflation, начальное значение
+- [x] `StateFlow` vs `SharedFlow` — replay, conflation, начальное значение
 - [ ] `StateFlow` под нагрузкой — механизм conflation, 100 collectors + 120 updates/sec
 - [ ] `flatMapLatest` vs `flatMapMerge` vs `flatMapConcat` — параллелизм
 - [ ] `combine` vs `zip` — эмит при любом изменении vs ждёт пару


### PR DESCRIPTION
**What / why.** `PeerTransferComponent` (presentation, Decompose) was carrying the full per-peer transfer state machine — `BatchSender` ownership, `activeJob` / `currentSender` / `confirmedReceived` / `cancelledFileNames`, `inboundEvents.collect`, transitions across Idle / ActiveOutbound / ActiveInbound / Reconnecting / Sent / Cancelled / Error. That contradicts [`presentation-layer.md` §"Components do not own domain logic"](docs/engineering/presentation-layer.md). This PR moves the state machine into a new plain-Kotlin `PeerTransferEngine` (`transfer/` domain package), and the engine itself is retained across Component destruction by a new `PeerTransferEngineRegistry` in `AppContainer` — so active transfers survive mDNS drops, screen navigation, and terminal-state visibility persists until the user dismisses.

**Layering split.**
- Domain `PeerTransferState` carries no view state — `Idle(peer)` is bare.
- Presentation `PeerCardState(transfer, expanded)` wraps domain state with the card's local UI flag. `toggleExpanded()` lives on the Component, not on the Engine.
- Engine and Component now have **independent scopes**: Engine on `Dispatchers.Default + SupervisorJob(appScope)` per-engine (created by registry); Component on `Dispatchers.Main.immediate + withLifecycle(lifecycle)` (dies with peer-visibility, only the bridge dies with it).

**Retention.** [`PeerTransferEngineRegistry`](composeApp/src/commonMain/kotlin/com/tubetoast/tether/transfer/PeerTransferEngineRegistry.kt) — lazy in `AppContainer`, lock-free CAS over `AtomicReference<Map<PeerIdentity, Entry>>`. `engineFor(peer)` returns the same instance across Component lifetimes for one `PeerIdentity`. Eviction: `internal fun evict(peer)` cancels the engine's scope; no production caller wires it yet — un-pair source will (separate issue). The `// Until #319` safety-net TODO on `PeerListComponent.kt:40` is closed: dropping a peer from mDNS destroys the Component but leaves the Engine running.

**👀 Sanity-check.**
- `evict` is `internal` and currently has zero production call sites — wired when un-pair flow lands.
- No `TrustedDeviceStore` observation is added in this PR — that's where the un-pair signal will eventually come from, and the interface today exposes neither `Flow` of trusted devices nor `remove`. Both additions belong with the un-pair feature, not here.
- Process-death state restoration is still non-goal per [adr-presentation-and-navigation.md](docs/engineering/adr/adr-presentation-and-navigation.md).
- Smoke: skipped (no protocol / network / CLI / native / FGS code in the diff); covered by `./gradlew allTests -q` — engine state-matrix tests + Component bridge/routing + new registry concurrency test (real-thread `Dispatchers.Default` barrier with 8 racers, asserts identity via `assertSame`), all green. Manual UI run is a follow-up step the reviewer will do on GitHub.

Closes #319