### PR TITLE
#17: make create-issue skill description pushier and bilingual

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-issue
-description: Create a GitHub issue via `gh` CLI. Use when the user asks to file a task, open a ticket, or mentions `gh issue create`. Single issue or epic + sub-issues.
+description: Create a GitHub issue via `gh` CLI — single issue or epic + sub-issues. Trigger whenever the user asks to file a task, open a ticket, draft an issue, log a bug into the tracker, or split a large task into an epic + children — including colloquial / non-English phrasings like "заведи задачу", "заведи тикет", "создай issue", "оформи задачу", "запиши в трекер", "оформи багу". Also trigger when the user describes a feature or bug and implies it goes into the tracker, even without saying the word "issue". Do NOT trigger for in-chat discussion, writing into a spec / UX brief (that's spec-writer / `/document`), or creating a PR / starting implementation (that's `/implement`).
 ---
 
 # Create Issue
@@ -13,14 +13,15 @@ The body answers **what** and **why**, plus where to start looking. **How** is d
 
 Default — **English**. Titles and bodies are in English; technical terms (class names, files, flags, APIs) stay in English as-is. Switch language only on explicit user request or in a non-English repository (confirm in one sentence first).
 
-## When to apply
+## Self-check before drafting
 
-- User says "create an issue / task / ticket", "file a task on github", "open an issue about X".
-- User describes a feature or bug and implies it goes into the tracker.
-- User asks to split a large task into an epic + children.
-- User mentions `gh issue create`.
+The matcher in the frontmatter already filtered positive cases. One last check before you start the process: this skill is for **filing a new GitHub issue**. If the request is actually one of the below, hand off instead of proceeding:
 
-Do not apply for **discussion**, writing into a spec document, or creating a PR — those are different.
+- writing or extending a spec / UX brief — `spec-writer` or `/document`
+- starting implementation / opening a PR — `/implement`
+- in-chat discussion that doesn't need a tracker entry — answer in chat
+
+Aborting early here is cheaper than walking the user through Recon → Interview → Draft and discovering at approval time that the wrong skill ran.
 
 ## Process
 


### PR DESCRIPTION
## Summary

The `create-issue` skill's frontmatter `description` listed only English positive triggers ("file a task", "open a ticket", `gh issue create`). The matcher selects skills by this string, so colloquial / Russian phrasings ("заведи задачу", "создай issue", "оформи багу") under-triggered — agents ignored the skill until told to use it by name.

Per the [Anthropic skill-creator guide](https://github.com/anthropics/claude-plugins-official/blob/main/plugins/skill-creator/skills/skill-creator/SKILL.md): the description is the **only** triggering mechanism, should be "pushy" to combat under-triggering, and should carry all positive *and* negative scope. The body is read only after the skill is selected, so duplicating positive triggers there has no effect on matching — only negative scope ("am I sure this is my case?") earns its space.

Changes to [.claude/skills/create-issue/SKILL.md](.claude/skills/create-issue/SKILL.md):

- `description`: enumerate Russian / colloquial phrasings explicitly; broaden to implicit "this should go into the tracker" cases; state negative scope inline so the matcher can disambiguate against `/document` (specs) and `/implement` (PRs).
- Body: replace the duplicate "When to apply" positive list with a short **Self-check before drafting** section that lists only the hand-off cases — useful right after selection to abort cheaply if the matcher misfired.

## Test plan

- [ ] In a fresh chat, write "заведи задачу про X" → `create-issue` skill triggers without naming it.
- [ ] "оформи багу с краш на старте" → triggers.
- [ ] "давай обсудим архитектуру X" → does **not** trigger (negative scope).
- [ ] "напиши спеку на X" → does **not** trigger (spec-writer / `/document` instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)