### PR TITLE
retro from #319: enforce TODO(#N) convention via pre-commit hook and rule

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
@@ -56,11 +56,6 @@ class FileClient(
         )
     }
 
-    suspend fun ping(device: Device): Boolean {
-        // TODO: GET http://${device.host}:${device.port}/health
-        throw NotImplementedError("ping() is not yet implemented")
-    }
-
     suspend fun send(
         device: Device,
         channel: ByteReadChannel,

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/ui/designsystem/ConfirmDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/ui/designsystem/ConfirmDialog.kt
@@ -67,7 +67,7 @@ internal fun ConfirmDialogContent(
 
     // Compose has no Role.AlertDialog; mergeDescendants ensures the container is a single
     // focusable unit while Dialog() itself handles focus trapping.
-    // TODO(#follow-up): revisit if CMP adds native alertdialog role support.
+    // TODO(#330): revisit when CMP adds native alertdialog role support.
     Column(
         modifier = modifier
             .fillMaxWidth()

--- a/docs/engineering/long-lived-artifacts.md
+++ b/docs/engineering/long-lived-artifacts.md
@@ -32,6 +32,12 @@ When reading: verify against the code before acting on the claim.
 
 When writing: prefer the product invariant («pairing keyed by stable device identity») over the description of the current implementation. If a runtime detail is unavoidable, keep the minimum needed for comprehension.
 
+## Deferred work carries a tracker
+
+A `TODO` (or `FIXME`) in code is a deferred-work marker. It must point to a tracked issue — the form does not matter (`TODO(#123)`, `todo #123`, `TODO[123]`, `// TODO - 123: ...`), only that the digits identify a GitHub issue a reader can open.
+
+Without a tracker, a `TODO` has no half-life: nobody owns it, nobody cancels it, and grepping the codebase for «what is deferred» returns prose instead of a worklist. File the issue first; reference it from the comment.
+
 ## Link over inline-copy
 
 A long-lived artifact references rules / tokens / tables from another artifact — link (`see docs/engineering/X.md §Y`), do not embed.

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -38,6 +38,32 @@ git diff --name-only | grep '\.kt$' | xargs -r git add
 
 echo "✅ KtLint format done"
 
+# Check TODO/FIXME comments reference a tracker
+# Rule: docs/engineering/long-lived-artifacts.md §Deferred work carries a tracker.
+# Catches // TODO, /* TODO, * TODO (KDoc), case-insensitive, that lack any digits on the line.
+# Kotlin's `TODO("...")` builtin is excluded (no // or * prefix before TODO).
+echo "🔖 Checking TODO/FIXME tracker references..."
+TODO_VIOLATORS=""
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+  bad=$(awk 'tolower($0) ~ /(\/\/|\/?\*)[[:space:]]*(todo|fixme)/ && $0 !~ /[0-9]/ { print FILENAME":"NR": "$0 }' "$f" 2>/dev/null) || true
+  if [ -n "$bad" ]; then
+    TODO_VIOLATORS="${TODO_VIOLATORS}${bad}
+"
+  fi
+done < <(git diff --cached --name-only --diff-filter=ACM | grep '\.kt$')
+
+if [ -n "$TODO_VIOLATORS" ]; then
+  echo "❌ TODO/FIXME without a tracker reference — commit aborted."
+  echo "   Any form is fine (TODO(#123), todo #123, TODO[123]) — the line must contain digits."
+  echo "   See docs/engineering/long-lived-artifacts.md §Deferred work carries a tracker."
+  echo ""
+  printf "%s" "$TODO_VIOLATORS"
+  exit 1
+fi
+echo "✅ TODOs reference issues"
+
 # Check doc links with lychee
 if ! command -v lychee &> /dev/null; then
   echo "ℹ️  lychee not found — skipping link check. Install: brew install lychee or https://github.com/lycheeverse/lychee#installation"


### PR DESCRIPTION
**What / why.** During #319 / #325 a bare `// TODO: ...` was added; the guides reviewer flagged it manually, citing precedent in the codebase. A grep over `commonMain` confirmed two more pre-existing violations (`FileClient.kt`, `ConfirmDialog.kt`) of an unwritten convention that 9 of 11 TODO sites already follow. Without an enforcement mechanism the rule erodes — agents and contributors rediscover it via review feedback only.

**Changes.**
- **Rule on paper.** New §"Deferred work carries a tracker" in [`long-lived-artifacts.md`](docs/engineering/long-lived-artifacts.md). Form-agnostic: any `TODO` / `FIXME` must include digits on the same line that identify a GitHub issue. CLAUDE.md already cross-links long-lived-artifacts.md, so no edit there.
- **Pre-commit hook.** Extended `scripts/install-hooks.sh` with an `awk` pass over staged `*.kt`: catches `// TODO`, `/* TODO`, ` * TODO` (KDoc), case-insensitive, that lack any digits on the line. Kotlin's `TODO(\"...\")` builtin is excluded by construction (no comment prefix). Verified: bare TODO blocks commit; `TODO(#N)`, `todo #N`, `TODO[N]` etc. all pass.
- **Pre-existing cleanup.**
  - `FileClient.ping()` deleted — dead method (zero callers, body was `throw NotImplementedError`).
  - `ConfirmDialog.kt:70 TODO(#follow-up)` tied to new follow-up #330 (`ConfirmDialog: revisit when CMP adds native Role.AlertDialog`).

**👀 Sanity-check.**
- Hook runs after KtLint (so it sees formatted state) and before lychee. Runs only on `.kt` files staged in the current commit — unrelated commits aren't blocked by random drift elsewhere.
- Regex is intentionally lenient on form (any digits anywhere on the line) per «look at substance, not format» — false-passes (e.g. `// TODO: bump to 100ms`) are accepted; reviewers handle nuance. Strict-format enforcement would have rejected the codebase's own existing conventions.
- The hook re-stages the `.kt` files KtLint formatted before the TODO check runs — no race.

Closes #319 retro signal.

Follow-up issue filed: #330.