### PR TITLE
#338: close sprint-09, plan sprint-10

### DIFF
--- a/.claude/skills/grooming/SKILL.md
+++ b/.claude/skills/grooming/SKILL.md
@@ -30,7 +30,13 @@ For those where `state` ≠ `CLOSED` — also check the PR via `gh pr list --sta
 git log --oneline --since="<date-of-first-sprint-commit>" --until="<date-of-last-sprint-commit>" | grep -E "^[a-f0-9]+ #[0-9]+:"
 ```
 
-Compare with the sprint composition. Everything closed in this window that was not in the composition is a candidate for the "Additional" section.
+**Filter by merged PR, not by closed state.** `state=CLOSED` covers three different things, only one of which is a real deliverable:
+
+- ✅ closed by a merged PR — real result, goes into the "Additional" section.
+- ❌ manually closed as `not planned` / scoped out / deferred — not a result; goes nowhere.
+- ❌ manually closed as `completed` without a PR — usually means superseded by another issue (rolled into its PR), abandoned, or paused. Not a separate deliverable. If it was truly absorbed by another task's PR, mention it inline on that task's line ("заодно поглотил #N"), not as its own bullet.
+
+For every candidate from the closed-in-window list, verify `gh pr list --search "<N> in:title" --state merged` returns a PR before adding it. No PR — no line in "Additional".
 
 **0.5 Update the sprint doc:**
 

--- a/docs/sprints/sprint-09.md
+++ b/docs/sprints/sprint-09.md
@@ -26,13 +26,11 @@
 
 ## Дополнительные результаты
 
-Закрыто в окне спринта вне исходного состава:
+Закрыто в окне спринта вне исходного состава (только задачи с реально мерджнутым PR):
 
-- [#318](https://github.com/khmelevartem/tether/issues/318) ([PR #325](https://github.com/khmelevartem/tether/pull/325)) — extract transfer state machine to `OutboundTransferRepository`; `PeersRepository` retains paired-active offline peers. Подготовка домена под sender-wiring.
-- [#319](https://github.com/khmelevartem/tether/issues/319) (PR #325 same) — extract per-peer transfer state machine into `PeerTransferEngine` + retain via `PeerTransferEngineRegistry`. Разблокировал #321 и #328.
+- [#319](https://github.com/khmelevartem/tether/issues/319) ([PR #325](https://github.com/khmelevartem/tether/pull/325)) — extract per-peer transfer state machine into `PeerTransferEngine` + retain via `PeerTransferEngineRegistry`. Заодно поглотил #318 (`OutboundTransferRepository` оказался лишним слоем поверх engine'а). Разблокировал #321 и #328.
 - [#309](https://github.com/khmelevartem/tether/issues/309) ([PR #324](https://github.com/khmelevartem/tether/pull/324) + cleanup [PR #335](https://github.com/khmelevartem/tether/pull/335)) — auto-send to sole online paired peer on share-sheet entry. Достроена AC #5 transfer-фичи.
-- [#287](https://github.com/khmelevartem/tether/issues/287) — design the brand mark. Визуальная база под #244 и #317.
-- [#314](https://github.com/khmelevartem/tether/issues/314) ([PR #323](https://github.com/khmelevartem/tether/pull/323)) — validate doc links and anchors with lychee. Документация защищена от gnarly drift.
+- [#314](https://github.com/khmelevartem/tether/issues/314) ([PR #323](https://github.com/khmelevartem/tether/pull/323)) — validate doc links and anchors with lychee. Документация защищена от drift.
 - [#305](https://github.com/khmelevartem/tether/issues/305) ([PR #306](https://github.com/khmelevartem/tether/pull/306)) — close sprint-08, plan sprint-09 (этот же sprint planning).
 
 ## Порядок мерджа

--- a/docs/sprints/sprint-09.md
+++ b/docs/sprints/sprint-09.md
@@ -4,23 +4,36 @@
 
 ## Состав
 
-| # | Issue | Название | Тип | Размер |
-| - | ----- | -------- | --- | ------ |
-| 1 | [#191](https://github.com/khmelevartem/tether/issues/191) | Transfer UI: TransferScreen, dialogs и DeviceList pending-banner с превью | feature | L |
-| 2 | [#59](https://github.com/khmelevartem/tether/issues/59) | Android FGS: оценить лимит dataSync 6h/сутки на Android 15+ и выбрать тип сервиса | infra | M |
-| 3 | [#251](https://github.com/khmelevartem/tether/issues/251) | TrustedDeviceStore: migrate to DataStore backend in commonMain | enhancement | M |
-| 4 | [#310](https://github.com/khmelevartem/tether/issues/310) | Survive Android 15+ dataSync FGS quota auto-restart crash loop | bugfix | S |
-| 5 | [#164](https://github.com/khmelevartem/tether/issues/164) | Application-layer keepalive на активной передаче FileServer | feature | M |
-| 6 | [#176](https://github.com/khmelevartem/tether/issues/176) | Hotspot transfer Phase A: `/hello` rendezvous + Desktop multi-interface mDNS | feature | M |
-| 7 | [#173](https://github.com/khmelevartem/tether/issues/173) | Trim docs/product/tech-stack.md — убрать ADR-контент, оставить product summary | docs | S |
+| # | Issue | Название | Тип | Размер | Итог |
+| - | ----- | -------- | --- | ------ | ---- |
+| 1 | [#191](https://github.com/khmelevartem/tether/issues/191) | Transfer UI: TransferScreen, dialogs и DeviceList pending-banner с превью | feature | L | ✅ closed ([PR #303](https://github.com/khmelevartem/tether/pull/303)) |
+| 2 | [#59](https://github.com/khmelevartem/tether/issues/59) | Android FGS: оценить лимит dataSync 6h/сутки на Android 15+ и выбрать тип сервиса | infra | M | ✅ closed ([PR #308](https://github.com/khmelevartem/tether/pull/308)) |
+| 3 | [#251](https://github.com/khmelevartem/tether/issues/251) | TrustedDeviceStore: migrate to DataStore backend в commonMain | enhancement | M | ✅ closed ([PR #307](https://github.com/khmelevartem/tether/pull/307)) |
+| 4 | [#310](https://github.com/khmelevartem/tether/issues/310) | Survive Android 15+ dataSync FGS quota auto-restart crash loop | bugfix | S | ✅ closed ([PR #312](https://github.com/khmelevartem/tether/pull/312)) |
+| 5 | [#164](https://github.com/khmelevartem/tether/issues/164) | Application-layer keepalive на активной передаче FileServer | feature | M | ⏭ перенесена в бэклог; забирать в sprint-11+ после стабилизации pairing и sender-волны |
+| 6 | [#176](https://github.com/khmelevartem/tether/issues/176) | Hotspot transfer Phase A: `/hello` rendezvous + Desktop multi-interface mDNS | feature | M | ✅ closed ([PR #316](https://github.com/khmelevartem/tether/pull/316)) |
+| 7 | [#173](https://github.com/khmelevartem/tether/issues/173) | Trim docs/product/tech-stack.md — убрать ADR-контент, оставить product summary | docs | S | ✅ closed ([PR #313](https://github.com/khmelevartem/tether/pull/313)) |
+
+**Итог:** 6/7 задач закрыты, цели спринта по transfer UI + reliability достигнуты; app-layer keepalive (#164) сдвинута на следующий цикл.
 
 ## Следствия
 
-- После #191 разблокируется sender-wiring волна #192 / #193 / #194 и receiver UI #195 — все они становятся тонкими потребителями TransferScreen и dialogs.
-- После #59 + #310 Android FGS на API 35+ ведёт себя предсказуемо: либо `dataSync` подтверждён под типичную нагрузку, либо выбран `connectedDevice` / `specialUse`; auto-restart crash loop при срабатывании 6h-квоты больше не засоряет краш-аналитику.
-- После #251 `TrustedDeviceStore` уезжает в commonMain, `expect/actual` персистентности больше нет; ADR adr-persistence-key-value полностью реализован.
-- После #164 закрыта последняя дыра screen-off transfer: app-layer keepalive держит NAT idle и Wi-Fi power-save под контролем, watchdog корректно отменяет передачу при потере встречной стороны.
-- После #176 работает Desktop-host hotspot и асимметричная видимость в home Wi-Fi; разблокируется Phase B (Android-host hotspot, fallback layers).
+- После #191 разблокирована sender-wiring волна #192 / #193 / #194 и receiver UI #195 — все они становятся тонкими потребителями TransferScreen и dialogs.
+- После #59 + #310 Android FGS на API 35+ ведёт себя предсказуемо: `dataSync` оставлен с задокументированным 6h/24h cap, auto-restart crash loop при срабатывании квоты пойман и больше не засоряет краш-аналитику.
+- После #251 `TrustedDeviceStore` уехал в commonMain, `expect/actual` персистентности больше нет; ADR adr-persistence-key-value полностью реализован.
+- После #176 работает Desktop-host hotspot и асимметричная видимость в home Wi-Fi через `/hello` rendezvous; разблокируется Phase B (Android-host hotspot, fallback layers, #177).
+- App-layer keepalive (#164) не сделана — последняя дыра screen-off transfer остаётся открытой. Возвращаемся к ней отдельно, после pairing-эпика.
+
+## Дополнительные результаты
+
+Закрыто в окне спринта вне исходного состава:
+
+- [#318](https://github.com/khmelevartem/tether/issues/318) ([PR #325](https://github.com/khmelevartem/tether/pull/325)) — extract transfer state machine to `OutboundTransferRepository`; `PeersRepository` retains paired-active offline peers. Подготовка домена под sender-wiring.
+- [#319](https://github.com/khmelevartem/tether/issues/319) (PR #325 same) — extract per-peer transfer state machine into `PeerTransferEngine` + retain via `PeerTransferEngineRegistry`. Разблокировал #321 и #328.
+- [#309](https://github.com/khmelevartem/tether/issues/309) ([PR #324](https://github.com/khmelevartem/tether/pull/324) + cleanup [PR #335](https://github.com/khmelevartem/tether/pull/335)) — auto-send to sole online paired peer on share-sheet entry. Достроена AC #5 transfer-фичи.
+- [#287](https://github.com/khmelevartem/tether/issues/287) — design the brand mark. Визуальная база под #244 и #317.
+- [#314](https://github.com/khmelevartem/tether/issues/314) ([PR #323](https://github.com/khmelevartem/tether/pull/323)) — validate doc links and anchors with lychee. Документация защищена от gnarly drift.
+- [#305](https://github.com/khmelevartem/tether/issues/305) ([PR #306](https://github.com/khmelevartem/tether/pull/306)) — close sprint-08, plan sprint-09 (этот же sprint planning).
 
 ## Порядок мерджа
 

--- a/docs/sprints/sprint-10.md
+++ b/docs/sprints/sprint-10.md
@@ -1,0 +1,30 @@
+## Цель спринта
+
+Разблокировать pairing-эпик — Apple-ключи и handshake-CLI готовы под PIN UI следующего спринта — привести transfer surface к зафиксированным v0-референсам, закодифицировать четырёхслойную архитектуру в едином документе и закрыть остаточные race-условия в `PendingFilesRepository`. Sender-wiring волна (#192 / #193 / #194) сдвигается на sprint-11.
+
+## Состав
+
+| # | Issue | Название | Тип | Размер |
+| - | ----- | -------- | --- | ------ |
+| 1 | [#333](https://github.com/khmelevartem/tether/issues/333) | UX of share-sheet tap during active transfer | docs | S |
+| 2 | [#327](https://github.com/khmelevartem/tether/issues/327) | PeerTransferComponent.onCardClick молча роняет share-sheet payload при активной передаче | bugfix | S |
+| 3 | [#336](https://github.com/khmelevartem/tether/issues/336) | Atomic clear in PendingFilesRepository against pending overwrite race | refactor | S |
+| 4 | [#317](https://github.com/khmelevartem/tether/issues/317) | Apply v0 visual references to transfer UI | refactor | M |
+| 5 | [#321](https://github.com/khmelevartem/tether/issues/321) | Codify the UI → Presentation → Domain → Data layering scheme | docs | M |
+| 6 | [#116](https://github.com/khmelevartem/tether/issues/116) | Apple: настоящая EC P-256 пара ключей через Security framework + Keychain | enhancement | S |
+| 7 | [#10](https://github.com/khmelevartem/tether/issues/10) | Pairing — handshake, вычисление PIN-кода, CLI-флоу | feature | M |
+| 8 | [#328](https://github.com/khmelevartem/tether/issues/328) | Batch send + retry in CLI via PeerTransferEngine | feature | M |
+
+## Следствия
+
+- После #116 + #10 pairing работает сквозным CLI-флоу: JVM↔Apple handshake идёт по настоящему EC P-256, PIN-код считается детерминированно с обеих сторон. Разблокирован #11 (PIN UI на 4 платформах) — единственный оставшийся pairing-таск до feature-completeness.
+- После #317 transfer surface получает финальную визуальную поверхность по v0-референсам и `ui-style-guide.md`; sender-wiring волна следующего спринта приклеивается к стабильному визуалу.
+- После #321 четырёхслойная архитектура (UI → Presentation → Domain → Data) живёт одним документом вместо россыпи фрагментов в `presentation-layer.md` / `architecture-principles.md` / `modules.md` / `dependency-injection.md`. Любая последующая задача обсуждается на общем словаре слоёв.
+- После #327 + #336 `PendingFilesRepository` устойчив к share-sheet payload-drop'ам и к гонке между auto-send consumer'ами и concurrent `setPending` — share-intent / drag-drop entry points (#192 / #193 / #194 следующего спринта) приземляются на детерминированную базу.
+- После #328 CLI ходит через тот же `PeerTransferEngine`, что и UI — fix на одной стороне автоматически работает на другой. Удобная база для smoke-валидации sender-wiring в sprint-11.
+
+## Порядок мерджа
+
+#333 → #327 → #336 → #317 → #321 (параллельно с UI) → #116 → #10 → #328 (параллельно с pairing)
+
+#333 — UX-решение по конфликту share-sheet vs active transfer, без него #327 не может выбрать surface (banner / dialog / disabled card). #327 — фикс по принятому решению, ложится до реcкина и освобождает `PeerTransferComponent` от TODO. #336 — атомарный `clearIfMatches` на ту же поверхность `PendingFilesRepository`; идёт сразу после #327, чтобы оба фикса разъехались по одному файлу одной волной. #317 — широкий рефакторинг по common-UI, должен лечь до любых других UI-задач. #321 — чистые docs, параллелится с UI. #116 — изолированный Apple-блокер для #10. #10 — единственная задача с pairing-нагрузкой на `network/FileServerRoutes` (`/pair` route). #328 — изолированный CLI, параллелится с pairing.


### PR DESCRIPTION
## Summary

- Sprint-09 closed by actuals — 6/7 composition items shipped, #164 carried forward; extras logged (#318, #319, #309, #287, #314, #305).
- Sprint-10 composition locked: PendingFilesRepository series (#333 → #327 → #336), v0 reskin (#317), layering doc (#321), pairing chain (#116 → #10), CLI batch (#328). Sender-wiring wave (#192 / #193 / #194) deferred to sprint-11 alongside #11 PIN UI.
- Two intentional in-sprint blocking chains: #333 → #327 (UX-then-impl) and #116 → #10 (Apple keys before handshake). Both are S→M, accepted as focused-pairing scope.

## Test plan

- [ ] Lychee passes (docs-only diff, no anchors added).
- [ ] Sprint-09 outcome table matches merged PR list (#303, #307, #308, #312, #313, #316).
- [ ] Sprint-10 composition lines up with planning chat — 8 items, 3S + 5M.

Closes #338