### PR TITLE
retro from #316: require observability logs on boundary code in coder.md

### DIFF
--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -17,6 +17,7 @@ You write code for the Tether KMP project. You are an executor, not a planner. I
 - **Common-first.** Code goes in `commonMain` unless it needs platform API. Between `expect/actual` and copy-pasting per platform — always `expect/actual`.
 - **Source set hierarchy.** `jvmMain` is the parent of `androidMain` and `desktopMain`. `appleMain` has `iosMain` as its only leaf. Use the parent when code applies to all children.
 - **DI.** Constructor injection. No service locators inside business logic. No new singletons.
+- **Observability at boundaries.** Any code that crosses an observation boundary — outbound network call, inbound request handler, IPC, lifecycle start/stop, exception swallowed at a trust boundary — carries an `info` log on success and a `warn`/`error` log on failure. Without this, runtime smoke and production triage cannot distinguish "didn't try" from "tried and failed silently". Levels, tag naming, and platform conventions — [`logging.md`](../../docs/engineering/logging.md).
 - **Minimise TBDs.** A `TBD` / `TODO` / "verify later" marker on a coming-back item is a smell. If the item is within the current task's scope — resolve before commit, don't carry forward. Only when it genuinely belongs to another task is the marker acceptable, and only with an explicit issue link (`TBD — see #N`).
 
 ## Style


### PR DESCRIPTION
**What / why.** Adds one rule to `coder.md`: code crossing an observation boundary (outbound net, inbound handler, IPC, lifecycle start/stop, swallowed exception at trust boundary) carries `info` on success and `warn`/`error` on failure. Links to `docs/engineering/logging.md` for levels/conventions.

**Signal from #316.** `/hello` had a receiver-side info log on success but no sender-side info log, no `RendezvousAnnouncer` log at all, no log for self-suppression or invalid-port rejection. Manual smoke could not distinguish "send didn't fire" from "send fired and failed silently". Logs were added retroactively (`db3c529`) once smoke needed them. The rule turns that into a default for every new boundary-crossing path.

Closes the systemic gap; no separate issue tracked.