### PR TITLE
#328: drive CLI send + retry through PeerTransferEngine

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -25,395 +25,123 @@ All these items must appear in the **"Manual verification required"** section of
 
 ## Starting the CLI
 
-```bash
-./gradlew :composeApp:cliJar -q
-JAR=$(ls composeApp/build/libs/tether-cli*.jar 2>/dev/null | head -1)
-[ -z "$JAR" ] && { echo "cli jar not found"; exit 1; }
-java -jar "$JAR" --name SmokeMacA --port 0 < fifo
-```
-
-The FIFO keeps stdin open for `list`, `send`, `quit` commands.
+The FIFO keeps stdin open for `list`, `send`, `quit` commands. All blocks that launch a CLI instance follow this pattern — see `block-1-desktop-cli-a.sh` for the canonical form.
 
 ## Run plan
 
-The skill executes blocks sequentially. A block failure does not prevent subsequent blocks from running. Cleanup is performed **always**, even if there were earlier FAILs.
+Execute blocks sequentially. A block failure does not prevent subsequent blocks from running. Run cleanup (`block-7-cleanup.sh`) **always**, even after earlier FAILs.
+
+All scripts live in `.claude/skills/smoke-test/` and are self-contained — run them from that directory or the repo root.
 
 ### Block 0: Preparation
 
-1. Make sure no CLI instances are running:
-   ```bash
-   pgrep -fl 'com.tubetoast.tether-.*\.jar|composeApp:run' || echo "clean"
-   ```
-   If there are — `kill` them: external mDNS services interfere with the run.
-2. Build the CLI jar:
-   ```bash
-   ./gradlew :composeApp:cliJar -q
-   JAR=$(ls composeApp/build/libs/tether-cli-*.jar composeApp/build/libs/tether-cli.jar 2>/dev/null | head -1)
-   ```
-   Remember the path.
+Run: `./block-0-preparation.sh`
 
-If the build fails or the JAR is not found — all remaining blocks SKIP with reason "cli jar build failed".
+Kills lingering CLI instances, builds the CLI jar, and sets `$JAR`.
+
+FAIL → all remaining blocks SKIP with reason "cli jar build failed".
 
 ### Block 1: Desktop CLI (instance A)
 
-Launch via FIFO (stdin keeper). Name — `SmokeMacA`, must match what Block 2 looks for in instance B's log.
+Run: `./block-1-desktop-cli-a.sh`
 
-```bash
-LOG_A=/tmp/smoke-cliA.log
-mkfifo /tmp/smoke-cliA-in
-sleep 600 > /tmp/smoke-cliA-in &
-KEEPER_A=$!; disown $KEEPER_A
-echo $KEEPER_A > /tmp/smoke-cliA-keeper.pid
+Launches CLI A (`SmokeMacA`, random port), then checks:
 
-nohup java -jar "$JAR" --name SmokeMacA --port 0 < /tmp/smoke-cliA-in > "$LOG_A" 2>&1 &
-JPID_A=$!; disown $JPID_A
-echo $JPID_A > /tmp/smoke-cliA.pid
-```
+1. **Startup** — port parsed, java pid alive. PASS if both.
+2. **`/health`** — must return `Tether OK`.
+3. **`/pair` — X.509 EC P-256 shape.** Response must be 91 bytes, first byte `0x30`, byte 26 `0x04`. Verifies real key material, not a placeholder.
+4. **Port LISTEN** — java listener shown by `lsof`.
+5. **mDNS publish (log)** — `mDNS started → advertising 'SmokeMacA'` in the log.
+6. **mDNS publish (dns-sd, optional)** — `dns-sd -B` browse. SKIP if `dns-sd` unavailable (Linux).
+7. **stdin `list`** — must produce a `[list]` or `[peers]` line.
 
-Wait up to 30 sec, polling the log:
-```bash
-for i in $(seq 1 30); do grep -q 'FileServer started' $LOG_A && break; sleep 1; done
-PORT_A=$(grep -oE 'port[[:space:]]*:[[:space:]]*[0-9]+' $LOG_A | grep -oE '[0-9]+' | head -1)
-```
-
-Scenarios:
-1. **Startup** — port parsed, java pid is alive (`ps -p $JPID_A`). PASS if both conditions met.
-2. **`/health`** — `curl -sf --max-time 5 http://localhost:$PORT_A/health` → must return `Tether OK`.
-3. **`/pair` — public key format.** The endpoint returns an X.509-encoded EC P-256 SubjectPublicKeyInfo: exactly 91 bytes, first byte `0x30` (DER `SEQUENCE`), byte 26 — `0x04` (uncompressed EC point marker). We check the shape, not "non-empty response" — a placeholder would pass a superficial check.
-   ```bash
-   PAIR_RESP=$(curl -sf --max-time 5 -X POST http://localhost:$PORT_A/pair \
-     -H "Content-Type: application/json" \
-     -d '{"publicKey":[1,2,3], "deviceName":"smoke"}')
-   echo "$PAIR_RESP" | jq -e '.publicKey | length == 91 and .[0] == 48 and .[26] == 4' > /dev/null \
-     && echo "PASS: X.509 EC P-256 SubjectPublicKeyInfo" \
-     || { echo "FAIL: bad publicKey shape: $PAIR_RESP"; }
-   ```
-4. **Port LISTEN** — `lsof -nP -iTCP:$PORT_A | head -3` shows a java listener.
-5. **mDNS publish (primary)** — poll the CLI log, look for `mDNS started → advertising 'SmokeMacA' on port`.
-6. **mDNS publish (secondary, optional)** — `( dns-sd -B _tether._tcp. local. 2>&1 & DNSSD_PID=$!; sleep 8; kill $DNSSD_PID 2>/dev/null ) | grep SmokeMacA`. If `dns-sd` is unavailable (Linux) — this step SKIP, the overall result is still PASS via primary.
-7. **stdin `list`** — `echo "list" > /tmp/smoke-cliA-in &; sleep 1; tail $LOG_A` — must print a `[list]` or `[peers]` line.
-
-Keep instance A alive until the end of Block 3. Graceful `quit` check — in Block 4.
+CLI A stays alive through Block 3. Graceful quit — Block 4.
 
 ### Block 2: Desktop ↔ Desktop send (via CLI)
 
-**Important:** send must go via the **CLI `send` command**, not via `curl POST /upload`. This is a smoke test of the user scenario, not of the endpoint.
+**Important:** send must go via the CLI `send` command, not via `curl POST /upload`.
 
-Start a second CLI instance (`SmokeMacB`) in parallel with A, wait until mDNS lets both see each other. The CLI's terminal output is `[send] done — N/N sent` (success), `[send] partial — N/M sent` (partial), or `[send] error — <reason>`. The `savedPath` is not in the log; verify by walking the receiver's downloads dir (`$HOME/Downloads/Tether/`).
-
-```bash
-LOG_B=/tmp/smoke-cliB.log
-mkfifo /tmp/smoke-cliB-in
-sleep 600 > /tmp/smoke-cliB-in & KEEPER_B=$!; disown $KEEPER_B
-echo $KEEPER_B > /tmp/smoke-cliB-keeper.pid
-nohup java -jar "$JAR" --name SmokeMacB --port 0 < /tmp/smoke-cliB-in > "$LOG_B" 2>&1 &
-JPID_B=$!; disown $JPID_B
-echo $JPID_B > /tmp/smoke-cliB.pid
-
-# Names must exactly match the --name above.
-for i in $(seq 1 30); do
-  grep -q 'SmokeMacA' $LOG_B 2>/dev/null && \
-  grep -q 'SmokeMacB' $LOG_A 2>/dev/null && break
-  sleep 1
-done
-
-DOWNLOADS_B="$HOME/Downloads/Tether"
-```
+Scenario 2.1 starts CLI B (`SmokeMacB`) and waits for mutual mDNS discovery; 2.2 and 2.3 assume B is still alive. Each scenario is independently re-runnable (re-running 2.2 or 2.3 alone requires B to already be running).
 
 #### Scenario 2.1 — single-file send
 
-```bash
-SEND1_NAME="smoke-send-$(date +%s).txt"
-SEND1_SRC="/tmp/$SEND1_NAME"
-echo "send-via-cli-$(date +%s)" > "$SEND1_SRC"
-echo "send SmokeMacB $SEND1_SRC" > /tmp/smoke-cliA-in &
+Run: `./block-2.1-single-file-send.sh`
 
-for i in $(seq 1 15); do
-  grep -qE "^\[send\] (done|partial|error)" $LOG_A && break
-  sleep 1
-done
-grep -qE "^\[send\] done" $LOG_A && [ -f "$DOWNLOADS_B/$SEND1_NAME" ] && \
-  diff "$SEND1_SRC" "$DOWNLOADS_B/$SEND1_NAME" >/dev/null && echo PASS || echo FAIL
-```
-
-PASS if `[send] done` appears in log A AND the file lands at `$DOWNLOADS_B/$SEND1_NAME` byte-identical to the source.
+Sends one file from A to B. PASS if `[send] done` appears in A's log AND the file lands at `$HOME/Downloads/Tether/` byte-identical to the source.
 
 #### Scenario 2.2 — multi-file send (3 files in one `send` command)
 
-```bash
-TS=$(date +%s)
-M1="/tmp/smoke-multi-${TS}-1.txt"; echo "m1-$TS" > "$M1"
-M2="/tmp/smoke-multi-${TS}-2.txt"; echo "m2-$TS" > "$M2"
-M3="/tmp/smoke-multi-${TS}-3.txt"; echo "m3-$TS" > "$M3"
-echo "send SmokeMacB $M1 $M2 $M3" > /tmp/smoke-cliA-in &
+Run: `./block-2.2-multi-file-send.sh`
 
-PREV_DONE=$(grep -cE "^\[send\] done" $LOG_A 2>/dev/null || echo 0)
-for i in $(seq 1 20); do
-  NOW_DONE=$(grep -cE "^\[send\] done" $LOG_A 2>/dev/null || echo 0)
-  [ "$NOW_DONE" -gt "$PREV_DONE" ] && break
-  sleep 1
-done
-grep -qE '^\[send\] done — 3/3 sent' $LOG_A && \
-  diff "$M1" "$DOWNLOADS_B/$(basename $M1)" >/dev/null && \
-  diff "$M2" "$DOWNLOADS_B/$(basename $M2)" >/dev/null && \
-  diff "$M3" "$DOWNLOADS_B/$(basename $M3)" >/dev/null && echo PASS || echo FAIL
-```
-
-PASS if `[send] done — 3/3 sent` appears AND all 3 files land byte-identical.
+Sends 3 files in one command. PASS if `[send] done — 3/3 sent` appears AND all 3 files land byte-identical.
 
 #### Scenario 2.3 — `retry` happy path
 
-Provoke partial by mixing a non-existent path in. The CLI's `handleSend` validates paths up front and returns `Failed` when any path is missing — so for `retry` we drive a real engine-level failure: stop instance B, send to it, expect `error`, restart B, then `retry`.
+Run: `./block-2.3-retry.sh`
 
-Simpler reproducible trigger: send while B is stopped → `[send] error` → start B → `retry SmokeMacB` → `[send] done`.
-
-```bash
-# Stop B
-kill $(cat /tmp/smoke-cliB.pid) 2>/dev/null
-sleep 2
-
-RETRY_NAME="smoke-retry-$(date +%s).txt"
-RETRY_SRC="/tmp/$RETRY_NAME"
-echo "retry-payload-$(date +%s)" > "$RETRY_SRC"
-PREV_ERR=$(grep -cE "^\[send\] error" $LOG_A 2>/dev/null || echo 0)
-echo "send SmokeMacB $RETRY_SRC" > /tmp/smoke-cliA-in &
-for i in $(seq 1 15); do
-  NOW_ERR=$(grep -cE "^\[send\] error" $LOG_A 2>/dev/null || echo 0)
-  [ "$NOW_ERR" -gt "$PREV_ERR" ] && break
-  sleep 1
-done
-
-# Restart B with the same name so the engine's PeerIdentity resolves again
-nohup java -jar "$JAR" --name SmokeMacB --port 0 < /tmp/smoke-cliB-in > "$LOG_B" 2>&1 &
-JPID_B=$!; disown $JPID_B
-echo $JPID_B > /tmp/smoke-cliB.pid
-for i in $(seq 1 30); do
-  grep -q 'SmokeMacB' $LOG_A 2>/dev/null && break
-  sleep 1
-done
-
-PREV_DONE=$(grep -cE "^\[send\] done" $LOG_A 2>/dev/null || echo 0)
-echo "retry SmokeMacB" > /tmp/smoke-cliA-in &
-for i in $(seq 1 15); do
-  NOW_DONE=$(grep -cE "^\[send\] done" $LOG_A 2>/dev/null || echo 0)
-  [ "$NOW_DONE" -gt "$PREV_DONE" ] && break
-  sleep 1
-done
-[ -f "$DOWNLOADS_B/$RETRY_NAME" ] && diff "$RETRY_SRC" "$DOWNLOADS_B/$RETRY_NAME" >/dev/null && echo PASS || echo FAIL
-```
-
-PASS if the file lands byte-identical after `retry`. If `[send] done` did not increment, retry silently no-op'd — FAIL.
+Stops B to provoke `[send] error`, restarts B, then issues `retry SmokeMacB`. PASS if the file lands byte-identical after retry.
 
 #### Scenario 2.4 — exit code on `quit`
 
-The REPL accumulates a `lastExit` from each `send`/`retry`; `quit` exits with it. Verified later in Block 4 — see the exit-code check there.
-
-Cleanup of instance B and the scratch files — in Block 7.
+Verified in Block 4 — `lastExit` accumulates per `send`/`retry`; after the retry the last result was AllSent → expected exit code 0.
 
 ### Block 3: Same-name discovery
 
-Verifies that three peers with the same requested service name see each other after mDNS conflict-rename: a third instance is launched with the same `--name SmokeMacA` as A, in parallel with A and B.
+Run: `./block-3-same-name-discovery.sh`
 
-```bash
-LOG_C=/tmp/smoke-cliC.log
-mkfifo /tmp/smoke-cliC-in
-sleep 600 > /tmp/smoke-cliC-in & KEEPER_C=$!; disown $KEEPER_C
-echo $KEEPER_C > /tmp/smoke-cliC-keeper.pid
-nohup java -jar "$JAR" --name SmokeMacA --port 0 < /tmp/smoke-cliC-in > "$LOG_C" 2>&1 &
-JPID_C=$!; disown $JPID_C
-echo $JPID_C > /tmp/smoke-cliC.pid
+Launches a third instance (`SmokeMacA` — same name as A) to verify mDNS conflict-rename: each of A/B/C must see ≥ 2 unique SmokeMac peers within 20 s.
 
-for i in $(seq 1 20); do
-  echo "list" > /tmp/smoke-cliA-in &
-  echo "list" > /tmp/smoke-cliB-in &
-  echo "list" > /tmp/smoke-cliC-in &
-  sleep 1
-  # `[peers]` lines append on each change; take the last, catch name up to `@` to capture
-  # the renamed form `SmokeMacA (2)`.
-  A_OK=$(grep -aE "\[peers\]" $LOG_A | tail -1 | grep -oE 'SmokeMac[A-Z][^@]*' | sort -u | wc -l | tr -d ' ')
-  B_OK=$(grep -aE "\[peers\]" $LOG_B | tail -1 | grep -oE 'SmokeMac[A-Z][^@]*' | sort -u | wc -l | tr -d ' ')
-  C_OK=$(grep -aE "\[peers\]" $LOG_C | tail -1 | grep -oE 'SmokeMac[A-Z][^@]*' | sort -u | wc -l | tr -d ' ')
-  [ "$A_OK" -ge 2 ] && [ "$B_OK" -ge 2 ] && [ "$C_OK" -ge 2 ] && break
-done
-```
-
-PASS if each of A/B/C sees ≥ 2 unique SmokeMac peers within 20 sec. FAIL — attach the last `[peers]` lines from all three logs in Details.
+FAIL → attach the last `[peers]` lines from all three logs in Details.
 
 Cleanup of instance C — in Block 7.
 
-### Block 3.5: Device name rename — peer sees the new name
+### Block 3.5: Device name rename
 
-stdin `name <new>` on A; B must see the new name via mDNS republish.
+Run: `./block-3.5-rename.sh`
 
-```bash
-echo "name RenamedA" > /tmp/smoke-cliA-in &
-for i in $(seq 1 15); do
-  grep -q "RenamedA" $LOG_B && break
-  sleep 1
-done
-grep -q "RenamedA" $LOG_B && echo PASS || echo FAIL
-```
+Sends `name RenamedA` to A via stdin; B must see the new name via mDNS republish within 15 s.
 
 ### Block 4: Graceful quit of instance A — and `lastExit` propagation
 
-`echo "quit" > /tmp/smoke-cliA-in &`, wait up to 8 sec, check `ps -p $JPID_A`. PASS if the process exited.
+Run: `./block-4-graceful-quit.sh`
 
-Then check the exit code matches `lastExit` from the most recent send/retry. After the Block 2 retry scenario, the last result was `AllSent` → exit code 0:
+Sends `quit` to A, waits up to 8 s, checks exit. PASS if the process exited.
 
-```bash
-wait $JPID_A 2>/dev/null
-EXIT_A=$?
-[ "$EXIT_A" = "0" ] && echo "PASS: exit=0 (last send AllSent)" || echo "FAIL: exit=$EXIT_A"
-```
-
-If `quit` didn't exit — FAIL "not graceful", `kill -9` and move on; exit-code check SKIP.
+Checks exit code = 0 (last send was AllSent after the retry scenario). If the process had to be force-killed — exit-code check SKIP.
 
 ### Block 5: Android (conditional)
 
-First check for a device:
-```bash
-adb devices | awk '/device$/ && !/List/ {print $1}'
-```
+Run: `./block-5-android.sh`
 
-If empty — the entire block SKIP with reason "no adb device connected".
+SKIP if no adb device connected. If present:
 
-If a device is present:
-
-1. **Install:** `./gradlew -q :composeApp:installDebug`
-2. **Logcat clear:** `adb logcat -c`
-3. **Start activity:**
-   ```bash
-   adb shell am start -n com.tubetoast.tether/.MainActivity
-   ```
-4. **Wait for `NSD service registered` as the readiness anchor.**
-   The anchor for the cross-discovery metric is placed **after** the Android side has published — the delta measures only network propagation + JmDNS resolve, without Android boot/init:
-   ```bash
-   DEADLINE=$(($(date +%s) + 12))
-   while [ $(date +%s) -lt $DEADLINE ]; do
-     adb logcat -d 2>/dev/null | grep -q "NSD service registered" && break
-     sleep 1
-   done
-   NSD_READY_MS=$(python3 -c "import time; print(int(time.time() * 1000))")
-   ```
-   Parse:
-   - `TetherFGService: FileServer started on port <N>` → `ANDROID_PORT`
-   - `Starting NSD: name=Tether-...` and `NSD service registered: ...` — time difference = NSD probing latency, output in Details.
-5. **Get IP** via `ip addr`, not `ip route` — the format differs on some vendors (ColorOS, MIUI):
-   ```bash
-   ANDROID_IP=$(adb shell ip addr show wlan0 2>&1 | grep "inet " | awk '{print $2}' | cut -d/ -f1 | head -1)
-   ```
-   If emulator and IP is `10.0.2.x` — host access via `adb forward tcp:18080 tcp:$ANDROID_PORT` and `localhost:18080`. For a physical device — directly `$ANDROID_IP:$ANDROID_PORT`.
-6. **`/health` sanity:** `curl -sf http://$ANDROID_IP:$ANDROID_PORT/health` → `Tether OK`. This is the only place where curl is acceptable — endpoint sanity, not a user flow.
-7. **Cross-discovery with timing:** parse the Desktop CLI's `[peers]` line by the Android device's IP — Android advertises under the device name (`CPH2653`, `Pixel 7`, vendor-specific), not under any `Tether-*` prefix. Match the entry that ends with `@$ANDROID_IP:port` and strip everything after `@`:
-   ```bash
-   for i in $(seq 1 30); do
-     sleep 1
-     grep -aE "\[peers\] .*@${ANDROID_IP}:" $LOG_A | tail -1 | grep -q . && break
-   done
-   NOW_MS=$(python3 -c "import time; print(int(time.time() * 1000))")
-   DELTA_MS=$((NOW_MS - NSD_READY_MS))
-   ANDROID_NAME=$(grep -aE "\[peers\]" $LOG_A | tail -1 | grep -oE '[^, ]+@'"$ANDROID_IP" | head -1 | sed 's/@.*//')
-   echo "cross-discovery: ${DELTA_MS}ms, peer=$ANDROID_NAME"
-   ```
-   In the report: `Android | cross-discovery | ✓ PASS | 250 ms` — network-propagation + JmDNS resolve.
-8. **Send Desktop → Android (via CLI):**
-   ```bash
-   if echo "$ANDROID_IP" | grep -q "^10\.0\.2\."; then
-     echo "SKIP: Android emulator detected — QEMU user-mode NAT drops host→guest TCP payload; see docs/knowledge/android-emulator-networking.md"
-   elif [ -z "$ANDROID_NAME" ]; then
-     echo "SKIP: cross-discovery did not surface Android peer"
-   else
-     ANDROID_NAME_FILE="smoke-android-$(date +%s).txt"
-     ANDROID_SRC="/tmp/$ANDROID_NAME_FILE"
-     echo "send-to-android-$(date +%s)" > "$ANDROID_SRC"
-     PREV_DONE=$(grep -cE "^\[send\] done" $LOG_A 2>/dev/null || echo 0)
-     echo "send $ANDROID_NAME $ANDROID_SRC" > /tmp/smoke-cliA-in &
-     for i in $(seq 1 15); do
-       NOW_DONE=$(grep -cE "^\[send\] done" $LOG_A 2>/dev/null || echo 0)
-       [ "$NOW_DONE" -gt "$PREV_DONE" ] && break
-       sleep 1
-     done
-     # The CLI no longer prints savedPath — Android stores under app-private external storage;
-     # the filename matches the source. Locate it via shell glob, then diff.
-     ANDROID_DEST=$(adb shell run-as com.tubetoast.tether ls -1 \
-       "/data/data/com.tubetoast.tether/files/Tether/$ANDROID_NAME_FILE" 2>/dev/null \
-       || adb shell ls -1 "/sdcard/Android/data/com.tubetoast.tether/files/Tether/$ANDROID_NAME_FILE" 2>/dev/null)
-     ANDROID_DEST=$(echo "$ANDROID_DEST" | tr -d '\r' | head -1)
-     [ -n "$ANDROID_DEST" ] && adb shell cat "$ANDROID_DEST" 2>/dev/null \
-       | diff - "$ANDROID_SRC" && echo PASS || echo FAIL
-   fi
-   ```
-   PASS if Desktop CLI log shows a `[send] done` increment AND the file on Android (located by name under the app's external/private Tether dir) is identical. SKIP if `10.0.2.x` (QEMU NAT) or ANDROID_NAME is empty — not FAIL.
-9. **Stop service:** `adb shell am force-stop com.tubetoast.tether`. PASS if the app exited. (Notification "Stop" tap — manual.)
-
-Mark each sub-scenario separately: install, FGS+mDNS up (with NSD probing latency), /health sanity, cross-discovery (with ms), send-desktop-to-android, stop.
+1. `installDebug`
+2. Start activity, wait for `NSD service registered`.
+3. Parse Android port and IP.
+4. `/health` sanity.
+5. Cross-discovery with timing (ms from NSD ready to peer appearing on Desktop A).
+6. Send Desktop → Android via CLI `send`. SKIP if emulator with QEMU NAT (`10.0.2.x`) or Android peer not discovered.
+7. `force-stop`.
 
 ### Block 5.5: iOS simulator runtime (conditional)
 
-Pre-checks (any fail → entire block SKIP with reason):
-- `xcrun simctl help >/dev/null 2>&1` — Xcode CLI tools installed.
-- `[ -d iosApp/iosApp.xcodeproj ]` — project exists.
+Run: `./block-5.5-ios.sh`
 
-Otherwise:
+SKIP if Xcode CLI tools absent or `iosApp/iosApp.xcodeproj` not found.
 
-1. **Resolve + boot the simulator.** Default `iPhone 17` (as in `scripts/run-all.sh`). If another is needed — variable `IOS_DEVICE`.
-   ```bash
-   IOS_DEVICE="${IOS_DEVICE:-iPhone 17}"
-   UDID=$(xcrun simctl list devices available \
-     | awk -F '[()]' -v n="$IOS_DEVICE" '$0 ~ n && $0 !~ /unavailable/ { print $2; exit }')
-   [ -z "$UDID" ] && { echo "SKIP: no available simulator matching '$IOS_DEVICE'"; }
-   xcrun simctl boot "$UDID" 2>/dev/null || true
-   open -a Simulator
-   ```
-2. **Build + install + launch.** Use `build/ios` as derivedDataPath to reuse the cache between runs.
-   ```bash
-   IOS_DERIVED=build/ios
-   IOS_APP="$IOS_DERIVED/Build/Products/Debug-iphonesimulator/Tether.app"
-   IOS_BUNDLE_ID=com.tubetoast.tether.Tether
-   xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp \
-     -configuration Debug \
-     -destination "platform=iOS Simulator,id=$UDID" \
-     -derivedDataPath "$IOS_DERIVED" \
-     build > /tmp/smoke-ios-build.log 2>&1
-   xcrun simctl install "$UDID" "$IOS_APP"
-   xcrun simctl launch "$UDID" "$IOS_BUNDLE_ID" > /tmp/smoke-ios-launch.log 2>&1
-   ```
-   PASS if build exit=0, install exit=0, launch exit=0. FAIL — tail `/tmp/smoke-ios-build.log`.
-3. **mDNS publish.** Poll `dns-sd` for up to 30 sec:
-   ```bash
-   IOS_NAME=""
-   for i in $(seq 1 30); do
-     # `dns-sd -B` prints each match as a tab-separated line ending with the instance name;
-     # the name is the trailing token after the last tab. The previous regex `[…]*iPhone[…]*`
-     # captured leading junk (`tcp.        iPhone 17 Pro`) and broke the subsequent TXT query.
-     IOS_NAME=$( ( dns-sd -B _tether._tcp local. & DNSSD=$!; sleep 2; kill $DNSSD 2>/dev/null ) \
-       | awk -F'\t' '/_tether._tcp/ && NF>1 { print $NF }' \
-       | grep -E 'iPhone|iPad' | head -1 | tr -d '\r' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-     [ -n "$IOS_NAME" ] && break
-     sleep 1
-   done
-   ```
-   PASS if `IOS_NAME` is non-empty. FAIL reason — most likely a Local Network Privacy prompt (see "What the skill does NOT check").
-4. **TXT publish.** `dns-sd -q "${IOS_NAME}._tether._tcp.local." TXT` for ~3 sec, must return `4 bytes: 03 76 3D 31` (`v=1`). PASS if the binary pattern matched.
-5. **Cross-discovery.** Wait up to 30 sec for the iOS peer to appear in Desktop CLI A's log:
-   ```bash
-   for i in $(seq 1 30); do grep -q "$IOS_NAME" "$LOG_A" && break; sleep 1; done
-   ```
-   PASS if a line with `IOS_NAME` appeared in log A.
+1. Resolve + boot simulator (default `iPhone 17`; override via `IOS_DEVICE` env var).
+2. `xcodebuild`, install, launch.
+3. mDNS publish — `dns-sd -B` for up to 30 s.
+4. TXT record — must return `03 76 3D 31` (`v=1`).
+5. Cross-discovery — iOS peer must appear in Desktop A's log within 30 s.
 
 iOS cleanup — in Block 7.
 
 ### Block 7: Cleanup
 
-Executed **always**:
-- `kill $(cat /tmp/smoke-cliA.pid /tmp/smoke-cliB.pid /tmp/smoke-cliC.pid /tmp/smoke-cliA-keeper.pid /tmp/smoke-cliB-keeper.pid /tmp/smoke-cliC-keeper.pid 2>/dev/null) 2>/dev/null`
-- `pkill -f 'com.tubetoast.tether.*\.jar'` (safety net)
-- `rm -f /tmp/smoke-cli*-in /tmp/smoke-cli*.log /tmp/smoke-cli*.pid /tmp/smoke-cli*-keeper.pid /tmp/smoke-send.txt /tmp/smoke-android.txt`
-- Files in `~/Downloads/Tether/` that we created — clean up by name: `rm -f "$DOWNLOADS_B/$SEND1_NAME" "$DOWNLOADS_B/$(basename $M1)" "$DOWNLOADS_B/$(basename $M2)" "$DOWNLOADS_B/$(basename $M3)" "$DOWNLOADS_B/$RETRY_NAME"`.
-- `adb shell rm -f /sdcard/Android/data/com.tubetoast.tether/files/Tether/smoke-android.txt` (or by `SAVED_PATH` if parsed)
-- `adb shell am force-stop com.tubetoast.tether`
-- `xcrun simctl terminate "$UDID" com.tubetoast.tether.Tether 2>/dev/null || true` (if `UDID` was resolved in Block 5.5)
-- `rm -f /tmp/smoke-ios-build.log /tmp/smoke-ios-launch.log`
+Run: `./block-7-cleanup.sh` — **always**.
+
+Kills all CLI instances and keepers, removes FIFOs, logs, PIDs, scratch files in `$HOME/Downloads/Tether/`, Android device files, iOS simulator app, and build logs.
 
 ## Report format
 
@@ -505,14 +233,14 @@ Don't ask the user for clarification — the skill must be "zero-question": ever
 
 - **Gradle daemon busy** — don't kill it, it will be reused.
 - **CLI jar stale (code changed)** — `cliJar` will rebuild what's needed. Don't run `clean`.
-- **Jar name may contain version** — determine dynamically via glob `composeApp/build/libs/tether-cli-*.jar composeApp/build/libs/tether-cli.jar | head -1`. Don't hardcode the filename.
+- **Jar name may contain version** — determine dynamically via glob. Don't hardcode the filename.
 - **`dns-sd` not on macOS** — unavailable on Linux; secondary mDNS check SKIP with reason "dns-sd not available". Primary check (grep CLI log for `mDNS started`) still works.
 - **`timeout` absent on macOS** — use pattern `( cmd & PID=$!; sleep N; kill $PID )` instead of `timeout`.
 - **FIFO writer keeper died early** — readLine() returns null, CLI exits; check `ps -p $KEEPER`.
-- **Android emulator in NAT (10.0.2.x)** — cross-discovery works both ways (multicast passes). QEMU user-mode NAT does not proxy host→guest TCP payload: handshake passes, data doesn't arrive. Send block (step 8) — SKIP at `10.0.2.x`, not FAIL. Health is accessible via `adb forward`. See `docs/knowledge/android-emulator-networking.md`.
+- **Android emulator in NAT (10.0.2.x)** — cross-discovery works both ways (multicast passes). QEMU user-mode NAT does not proxy host→guest TCP payload: handshake passes, data doesn't arrive. Send block — SKIP at `10.0.2.x`, not FAIL. Health is accessible via `adb forward`. See `docs/knowledge/android-emulator-networking.md`.
 - **`ip route` unreliable on some vendors** (ColorOS, MIUI return subnet instead of src) — use `ip addr show wlan0`.
 - **Multiple adb devices** — pick the first or fail with a clarification. Don't hang the skill on a specific serial.
-- **Receiver downloads path** — Desktop receiver writes to `$HOME/Downloads/Tether/` by default; smoke walks that dir by filename. If the smoke run sets a non-default `downloadsDir`, update `DOWNLOADS_B`. On Android, the location is app-private — locate by basename under the app's Tether dir, not by parsed path.
+- **Receiver downloads path** — Desktop receiver writes to `$HOME/Downloads/Tether/` by default; smoke walks that dir by filename. On Android, the location is app-private — locate by basename under the app's Tether dir, not by parsed path.
 - **Terminal output format** — `[send] done — N/N sent` (success), `[send] partial — N/M sent` (partial), `[send] error — <reason>` (failure). No `savedPath` in the log.
 
 ## What NOT to do

--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -99,7 +99,7 @@ Keep instance A alive until the end of Block 3. Graceful `quit` check — in Blo
 
 **Important:** send must go via the **CLI `send` command**, not via `curl POST /upload`. This is a smoke test of the user scenario, not of the endpoint.
 
-Start a second CLI instance (`SmokeMacB`) in parallel with A, wait until mDNS lets both see each other, send `send SmokeMacB <path>` to stdin A.
+Start a second CLI instance (`SmokeMacB`) in parallel with A, wait until mDNS lets both see each other. The CLI drives the same `PeerTransferEngine` as the UI — terminal output is `[send] done — N/N sent` (success), `[send] partial — N/M sent` (partial), or `[send] error — …`. The savedPath is not in the log; verify by walking the receiver's downloads dir (`$HOME/Downloads/Tether/`).
 
 ```bash
 LOG_B=/tmp/smoke-cliB.log
@@ -117,30 +117,98 @@ for i in $(seq 1 30); do
   sleep 1
 done
 
-echo "send-via-cli-$(date +%s)" > /tmp/smoke-send.txt
-echo "send SmokeMacB /tmp/smoke-send.txt" > /tmp/smoke-cliA-in &
-
-for i in $(seq 1 15); do
-  grep -qE "^\[send\] (OK|FAIL)" $LOG_A && break
-  sleep 1
-done
-SEND_LINE=$(grep -E "^\[send\] (OK|FAIL)" $LOG_A | tail -1)
-echo "$SEND_LINE"
-
-# Parse savedPath from the line "[send] OK — <ms> ms → <savedPath>", don't guess the directory.
-SAVED_B=$(echo "$SEND_LINE" | sed -nE 's/.*→[[:space:]]+(.+)$/\1/p')
-if [ -n "$SAVED_B" ] && [ -f "$SAVED_B" ]; then
-  diff /tmp/smoke-send.txt "$SAVED_B" && echo PASS || echo FAIL
-else
-  echo "FAIL: savedPath not parsed or file missing"
-fi
+DOWNLOADS_B="$HOME/Downloads/Tether"
 ```
 
-PASS if:
-1. log A contains `[send] OK — <ms> ms → <savedPath>`
-2. the file at `savedPath` is identical to the original
+#### Scenario 2.1 — single-file send
 
-Cleanup of instance B — in Block 7.
+```bash
+SEND1_NAME="smoke-send-$(date +%s).txt"
+SEND1_SRC="/tmp/$SEND1_NAME"
+echo "send-via-cli-$(date +%s)" > "$SEND1_SRC"
+echo "send SmokeMacB $SEND1_SRC" > /tmp/smoke-cliA-in &
+
+for i in $(seq 1 15); do
+  grep -qE "^\[send\] (done|partial|error)" $LOG_A && break
+  sleep 1
+done
+grep -qE "^\[send\] done" $LOG_A && [ -f "$DOWNLOADS_B/$SEND1_NAME" ] && \
+  diff "$SEND1_SRC" "$DOWNLOADS_B/$SEND1_NAME" >/dev/null && echo PASS || echo FAIL
+```
+
+PASS if `[send] done` appears in log A AND the file lands at `$DOWNLOADS_B/$SEND1_NAME` byte-identical to the source.
+
+#### Scenario 2.2 — multi-file send (3 files in one `send` command)
+
+```bash
+TS=$(date +%s)
+M1="/tmp/smoke-multi-${TS}-1.txt"; echo "m1-$TS" > "$M1"
+M2="/tmp/smoke-multi-${TS}-2.txt"; echo "m2-$TS" > "$M2"
+M3="/tmp/smoke-multi-${TS}-3.txt"; echo "m3-$TS" > "$M3"
+echo "send SmokeMacB $M1 $M2 $M3" > /tmp/smoke-cliA-in &
+
+PREV_DONE=$(grep -cE "^\[send\] done" $LOG_A 2>/dev/null || echo 0)
+for i in $(seq 1 20); do
+  NOW_DONE=$(grep -cE "^\[send\] done" $LOG_A 2>/dev/null || echo 0)
+  [ "$NOW_DONE" -gt "$PREV_DONE" ] && break
+  sleep 1
+done
+grep -qE '^\[send\] done — 3/3 sent' $LOG_A && \
+  diff "$M1" "$DOWNLOADS_B/$(basename $M1)" >/dev/null && \
+  diff "$M2" "$DOWNLOADS_B/$(basename $M2)" >/dev/null && \
+  diff "$M3" "$DOWNLOADS_B/$(basename $M3)" >/dev/null && echo PASS || echo FAIL
+```
+
+PASS if `[send] done — 3/3 sent` appears AND all 3 files land byte-identical.
+
+#### Scenario 2.3 — `retry` happy path
+
+Provoke partial by mixing a non-existent path in. The CLI's `handleSend` validates paths up front and returns `Failed` when any path is missing — so for `retry` we drive a real engine-level failure: stop instance B, send to it, expect `error`, restart B, then `retry`.
+
+Simpler reproducible trigger: send while B is stopped → `[send] error` → start B → `retry SmokeMacB` → `[send] done`.
+
+```bash
+# Stop B
+kill $(cat /tmp/smoke-cliB.pid) 2>/dev/null
+sleep 2
+
+RETRY_NAME="smoke-retry-$(date +%s).txt"
+RETRY_SRC="/tmp/$RETRY_NAME"
+echo "retry-payload-$(date +%s)" > "$RETRY_SRC"
+PREV_ERR=$(grep -cE "^\[send\] error" $LOG_A 2>/dev/null || echo 0)
+echo "send SmokeMacB $RETRY_SRC" > /tmp/smoke-cliA-in &
+for i in $(seq 1 15); do
+  NOW_ERR=$(grep -cE "^\[send\] error" $LOG_A 2>/dev/null || echo 0)
+  [ "$NOW_ERR" -gt "$PREV_ERR" ] && break
+  sleep 1
+done
+
+# Restart B with the same name so the engine's PeerIdentity resolves again
+nohup java -jar "$JAR" --name SmokeMacB --port 0 < /tmp/smoke-cliB-in > "$LOG_B" 2>&1 &
+JPID_B=$!; disown $JPID_B
+echo $JPID_B > /tmp/smoke-cliB.pid
+for i in $(seq 1 30); do
+  grep -q 'SmokeMacB' $LOG_A 2>/dev/null && break
+  sleep 1
+done
+
+PREV_DONE=$(grep -cE "^\[send\] done" $LOG_A 2>/dev/null || echo 0)
+echo "retry SmokeMacB" > /tmp/smoke-cliA-in &
+for i in $(seq 1 15); do
+  NOW_DONE=$(grep -cE "^\[send\] done" $LOG_A 2>/dev/null || echo 0)
+  [ "$NOW_DONE" -gt "$PREV_DONE" ] && break
+  sleep 1
+done
+[ -f "$DOWNLOADS_B/$RETRY_NAME" ] && diff "$RETRY_SRC" "$DOWNLOADS_B/$RETRY_NAME" >/dev/null && echo PASS || echo FAIL
+```
+
+PASS if the file lands byte-identical after `retry`. If `[send] done` did not increment, retry silently no-op'd — FAIL.
+
+#### Scenario 2.4 — exit code on `quit`
+
+Per #328, the REPL accumulates a `lastExit` from each `send`/`retry`; `quit` exits with it. Verified later in Block 4 — see the exit-code check there.
+
+Cleanup of instance B and the scratch files — in Block 7.
 
 ### Block 3: Same-name discovery
 
@@ -186,9 +254,19 @@ done
 grep -q "RenamedA" $LOG_B && echo PASS || echo FAIL
 ```
 
-### Block 4: Graceful quit of instance A
+### Block 4: Graceful quit of instance A — and `lastExit` propagation
 
-`echo "quit" > /tmp/smoke-cliA-in &`, wait up to 8 sec, check `ps -p $JPID_A`. PASS if the process exited. If not — FAIL "not graceful", `kill -9` and move on.
+`echo "quit" > /tmp/smoke-cliA-in &`, wait up to 8 sec, check `ps -p $JPID_A`. PASS if the process exited.
+
+Then check the exit code matches `lastExit` from the most recent send/retry (per #328: REPL accumulates `lastExit` from each `send`/`retry`; `quit` exits with it). After the Block 2 retry scenario, the last result was `AllSent` → exit code 0:
+
+```bash
+wait $JPID_A 2>/dev/null
+EXIT_A=$?
+[ "$EXIT_A" = "0" ] && echo "PASS: exit=0 (last send AllSent)" || echo "FAIL: exit=$EXIT_A"
+```
+
+If `quit` didn't exit — FAIL "not graceful", `kill -9` and move on; exit-code check SKIP.
 
 ### Block 5: Android (conditional)
 
@@ -245,19 +323,27 @@ If a device is present:
    elif [ -z "$ANDROID_NAME" ]; then
      echo "SKIP: cross-discovery did not surface Android peer"
    else
-     echo "send-to-android-$(date +%s)" > /tmp/smoke-android.txt
-     echo "send $ANDROID_NAME /tmp/smoke-android.txt" > /tmp/smoke-cliA-in &
+     ANDROID_NAME_FILE="smoke-android-$(date +%s).txt"
+     ANDROID_SRC="/tmp/$ANDROID_NAME_FILE"
+     echo "send-to-android-$(date +%s)" > "$ANDROID_SRC"
+     PREV_DONE=$(grep -cE "^\[send\] done" $LOG_A 2>/dev/null || echo 0)
+     echo "send $ANDROID_NAME $ANDROID_SRC" > /tmp/smoke-cliA-in &
      for i in $(seq 1 15); do
-       grep -qE "^\[send\] (OK|FAIL)" $LOG_A && break
+       NOW_DONE=$(grep -cE "^\[send\] done" $LOG_A 2>/dev/null || echo 0)
+       [ "$NOW_DONE" -gt "$PREV_DONE" ] && break
        sleep 1
      done
-     SEND_LINE=$(grep -E "^\[send\] (OK|FAIL)" $LOG_A | tail -1)
-     # On Android savedPath is absolute — cat it directly via adb shell
-     SAVED_PATH=$(echo "$SEND_LINE" | sed -nE 's/.*→[[:space:]]+(.+)$/\1/p')
-     adb shell cat "$SAVED_PATH" 2>/dev/null | diff - /tmp/smoke-android.txt && echo PASS || echo FAIL
+     # The CLI no longer prints savedPath — Android stores under app-private external storage;
+     # the filename matches the source. Locate it via shell glob, then diff.
+     ANDROID_DEST=$(adb shell run-as com.tubetoast.tether ls -1 \
+       "/data/data/com.tubetoast.tether/files/Tether/$ANDROID_NAME_FILE" 2>/dev/null \
+       || adb shell ls -1 "/sdcard/Android/data/com.tubetoast.tether/files/Tether/$ANDROID_NAME_FILE" 2>/dev/null)
+     ANDROID_DEST=$(echo "$ANDROID_DEST" | tr -d '\r' | head -1)
+     [ -n "$ANDROID_DEST" ] && adb shell cat "$ANDROID_DEST" 2>/dev/null \
+       | diff - "$ANDROID_SRC" && echo PASS || echo FAIL
    fi
    ```
-   PASS if Desktop CLI log has `[send] OK` AND the file on Android at the parsed savedPath is identical. SKIP if `10.0.2.x` (QEMU NAT) or ANDROID_NAME is empty — not FAIL.
+   PASS if Desktop CLI log shows a `[send] done` increment AND the file on Android (located by name under the app's external/private Tether dir) is identical. SKIP if `10.0.2.x` (QEMU NAT) or ANDROID_NAME is empty — not FAIL.
 9. **Stop service:** `adb shell am force-stop com.tubetoast.tether`. PASS if the app exited. (Notification "Stop" tap — manual.)
 
 Mark each sub-scenario separately: install, FGS+mDNS up (with NSD probing latency), /health sanity, cross-discovery (with ms), send-desktop-to-android, stop.
@@ -361,7 +447,10 @@ At the end of the run print a markdown report:
 | Desktop CLI A | mDNS publish (log) | ✓ PASS | advertising 'SmokeMacA' |
 | Desktop CLI A | mDNS publish (dns-sd) | ✓ PASS | SmokeMacA in browse |
 | Desktop CLI A | stdin `list` | ✓ PASS | peer printed |
-| Desktop↔Desktop | send via CLI | ✓ PASS | savedPath parsed, diff empty |
+| Desktop↔Desktop | single-file send | ✓ PASS | file lands in receiver downloads, diff empty |
+| Desktop↔Desktop | multi-file send (3 files) | ✓ PASS | `[send] done — 3/3 sent`, all 3 diff empty |
+| Desktop↔Desktop | retry after error | ✓ PASS | file lands after `retry`, diff empty |
+| Desktop CLI A | exit code on `quit` | ✓ PASS | exit=0 (last send AllSent) |
 | Same-name discovery | A/B/C convergence | ✓ PASS | each sees 2 SmokeMac peers in 3s |
 | Device name | rename via stdin | ✓ PASS | peer sees new name in <15s |
 | Desktop CLI A | graceful `quit` | ✓ PASS | exit in 3s |
@@ -423,7 +512,8 @@ Don't ask the user for clarification — the skill must be "zero-question": ever
 - **Android emulator in NAT (10.0.2.x)** — cross-discovery works both ways (multicast passes). QEMU user-mode NAT does not proxy host→guest TCP payload: handshake passes, data doesn't arrive. Send block (step 8) — SKIP at `10.0.2.x`, not FAIL. Health is accessible via `adb forward`. See `docs/knowledge/android-emulator-networking.md`.
 - **`ip route` unreliable on some vendors** (ColorOS, MIUI return subnet instead of src) — use `ip addr show wlan0`.
 - **Multiple adb devices** — pick the first or fail with a clarification. Don't hang the skill on a specific serial.
-- **`savedPath` must always be parsed from the log**, don't guess `$HOME/Downloads/Tether/...` — the downloads directory is user-configurable.
+- **Receiver downloads path** — Desktop receiver writes to `$HOME/Downloads/Tether/` by default; smoke walks that dir by filename. If the smoke run sets a non-default `downloadsDir`, update `DOWNLOADS_B`. On Android, the location is app-private — locate by basename under the app's Tether dir, not by parsed path.
+- **`[send] OK` is gone** — since #328 the CLI drives `PeerTransferEngine`; the terminal output is `[send] done — N/N sent` (success), `[send] partial — N/M sent`, or `[send] error — <reason>`. No `savedPath` in the log.
 
 ## What NOT to do
 

--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -228,8 +228,8 @@ for i in $(seq 1 20); do
   echo "list" > /tmp/smoke-cliB-in &
   echo "list" > /tmp/smoke-cliC-in &
   sleep 1
-  # The `[peers]` line starts with an ANSI escape (`\x1b[1A\r\x1b[K`); catch name up to `@`,
-  # to capture the renamed form `SmokeMacA (2)`.
+  # `[peers]` lines append on each change; take the last, catch name up to `@` to capture
+  # the renamed form `SmokeMacA (2)`.
   A_OK=$(grep -aE "\[peers\]" $LOG_A | tail -1 | grep -oE 'SmokeMac[A-Z][^@]*' | sort -u | wc -l | tr -d ' ')
   B_OK=$(grep -aE "\[peers\]" $LOG_B | tail -1 | grep -oE 'SmokeMac[A-Z][^@]*' | sort -u | wc -l | tr -d ' ')
   C_OK=$(grep -aE "\[peers\]" $LOG_C | tail -1 | grep -oE 'SmokeMac[A-Z][^@]*' | sort -u | wc -l | tr -d ' ')

--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -99,7 +99,7 @@ Keep instance A alive until the end of Block 3. Graceful `quit` check — in Blo
 
 **Important:** send must go via the **CLI `send` command**, not via `curl POST /upload`. This is a smoke test of the user scenario, not of the endpoint.
 
-Start a second CLI instance (`SmokeMacB`) in parallel with A, wait until mDNS lets both see each other. The CLI drives the same `PeerTransferEngine` as the UI — terminal output is `[send] done — N/N sent` (success), `[send] partial — N/M sent` (partial), or `[send] error — …`. The savedPath is not in the log; verify by walking the receiver's downloads dir (`$HOME/Downloads/Tether/`).
+Start a second CLI instance (`SmokeMacB`) in parallel with A, wait until mDNS lets both see each other. The CLI's terminal output is `[send] done — N/N sent` (success), `[send] partial — N/M sent` (partial), or `[send] error — <reason>`. The `savedPath` is not in the log; verify by walking the receiver's downloads dir (`$HOME/Downloads/Tether/`).
 
 ```bash
 LOG_B=/tmp/smoke-cliB.log
@@ -206,7 +206,7 @@ PASS if the file lands byte-identical after `retry`. If `[send] done` did not in
 
 #### Scenario 2.4 — exit code on `quit`
 
-Per #328, the REPL accumulates a `lastExit` from each `send`/`retry`; `quit` exits with it. Verified later in Block 4 — see the exit-code check there.
+The REPL accumulates a `lastExit` from each `send`/`retry`; `quit` exits with it. Verified later in Block 4 — see the exit-code check there.
 
 Cleanup of instance B and the scratch files — in Block 7.
 
@@ -258,7 +258,7 @@ grep -q "RenamedA" $LOG_B && echo PASS || echo FAIL
 
 `echo "quit" > /tmp/smoke-cliA-in &`, wait up to 8 sec, check `ps -p $JPID_A`. PASS if the process exited.
 
-Then check the exit code matches `lastExit` from the most recent send/retry (per #328: REPL accumulates `lastExit` from each `send`/`retry`; `quit` exits with it). After the Block 2 retry scenario, the last result was `AllSent` → exit code 0:
+Then check the exit code matches `lastExit` from the most recent send/retry. After the Block 2 retry scenario, the last result was `AllSent` → exit code 0:
 
 ```bash
 wait $JPID_A 2>/dev/null
@@ -409,7 +409,7 @@ Executed **always**:
 - `kill $(cat /tmp/smoke-cliA.pid /tmp/smoke-cliB.pid /tmp/smoke-cliC.pid /tmp/smoke-cliA-keeper.pid /tmp/smoke-cliB-keeper.pid /tmp/smoke-cliC-keeper.pid 2>/dev/null) 2>/dev/null`
 - `pkill -f 'com.tubetoast.tether.*\.jar'` (safety net)
 - `rm -f /tmp/smoke-cli*-in /tmp/smoke-cli*.log /tmp/smoke-cli*.pid /tmp/smoke-cli*-keeper.pid /tmp/smoke-send.txt /tmp/smoke-android.txt`
-- Files in `~/Downloads/Tether/` that we created — clean up by `savedPath` from log A.
+- Files in `~/Downloads/Tether/` that we created — clean up by name: `rm -f "$DOWNLOADS_B/$SEND1_NAME" "$DOWNLOADS_B/$(basename $M1)" "$DOWNLOADS_B/$(basename $M2)" "$DOWNLOADS_B/$(basename $M3)" "$DOWNLOADS_B/$RETRY_NAME"`.
 - `adb shell rm -f /sdcard/Android/data/com.tubetoast.tether/files/Tether/smoke-android.txt` (or by `SAVED_PATH` if parsed)
 - `adb shell am force-stop com.tubetoast.tether`
 - `xcrun simctl terminate "$UDID" com.tubetoast.tether.Tether 2>/dev/null || true` (if `UDID` was resolved in Block 5.5)
@@ -461,7 +461,7 @@ At the end of the run print a markdown report:
 | Android | mDNS publish | ✓ PASS | Tether-<MODEL> |
 | Android | /health (over WiFi) | ✓ PASS | "Tether OK" |
 | Android | cross-discovery | ✓ PASS | 2154ms (launch→peer-on-Desktop) |
-| Android | send Desktop→Android | ✓ PASS | savedPath parsed, diff empty |
+| Android | send Desktop→Android | ✓ PASS | file lands in app Tether dir, diff empty |
 | Android | force-stop | ✓ PASS | process killed |
 | iOS | xcodebuild + install | ✓ PASS | UDID=<...>, 28s |
 | iOS | launch | ✓ PASS | pid=<...> |
@@ -513,7 +513,7 @@ Don't ask the user for clarification — the skill must be "zero-question": ever
 - **`ip route` unreliable on some vendors** (ColorOS, MIUI return subnet instead of src) — use `ip addr show wlan0`.
 - **Multiple adb devices** — pick the first or fail with a clarification. Don't hang the skill on a specific serial.
 - **Receiver downloads path** — Desktop receiver writes to `$HOME/Downloads/Tether/` by default; smoke walks that dir by filename. If the smoke run sets a non-default `downloadsDir`, update `DOWNLOADS_B`. On Android, the location is app-private — locate by basename under the app's Tether dir, not by parsed path.
-- **`[send] OK` is gone** — since #328 the CLI drives `PeerTransferEngine`; the terminal output is `[send] done — N/N sent` (success), `[send] partial — N/M sent`, or `[send] error — <reason>`. No `savedPath` in the log.
+- **Terminal output format** — `[send] done — N/N sent` (success), `[send] partial — N/M sent` (partial), `[send] error — <reason>` (failure). No `savedPath` in the log.
 
 ## What NOT to do
 
@@ -523,4 +523,4 @@ Don't ask the user for clarification — the skill must be "zero-question": ever
 - **Don't go into `~/Downloads`** beyond your own files — that is user content.
 - **Don't run `./gradlew clean`** — it will eat the cache and slow down the next run.
 - **Don't send anything over the network** other than localhost and `$ANDROID_IP` (the latter — only if an adb device is connected).
-- **Don't guess file destination paths** — always parse from `[send] OK — ... → <savedPath>`.
+- **Don't guess file destination paths** — verify by filename: walk `$DOWNLOADS_B` (Desktop receiver) or the app-private Tether dir (Android) for the expected filename, then diff against the source.

--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -51,7 +51,7 @@ Launches CLI A (`SmokeMacA`, random port), then checks:
 2. **`/health`** — must return `Tether OK`.
 3. **`/pair` — X.509 EC P-256 shape.** Response must be 91 bytes, first byte `0x30`, byte 26 `0x04`. Verifies real key material, not a placeholder.
 4. **Port LISTEN** — java listener shown by `lsof`.
-5. **mDNS publish (log)** — `mDNS started → advertising 'SmokeMacA'` in the log.
+5. **mDNS publish (log)** — the CLI's startup log shows that mDNS advertising started for its configured instance name.
 6. **mDNS publish (dns-sd, optional)** — `dns-sd -B` browse. SKIP if `dns-sd` unavailable (Linux).
 7. **stdin `list`** — must produce a `[list]` or `[peers]` line.
 

--- a/.claude/skills/smoke-test/block-0-preparation.sh
+++ b/.claude/skills/smoke-test/block-0-preparation.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Kill any lingering CLI instances to avoid mDNS interference.
+set +e
+pgrep -fl 'com.tubetoast.tether-.*\.jar|composeApp:run' || echo "clean"
+pkill -f 'com.tubetoast.tether.*\.jar' 2>/dev/null
+set -e
+
+cd "$(git rev-parse --show-toplevel)"
+
+./gradlew :composeApp:cliJar -q
+
+JAR=$(ls composeApp/build/libs/tether-cli-*.jar composeApp/build/libs/tether-cli.jar 2>/dev/null | head -1)
+[ -z "$JAR" ] && { echo "FAIL: cli jar not found after build"; exit 1; }
+
+echo "JAR=$JAR"
+export JAR

--- a/.claude/skills/smoke-test/block-1-desktop-cli-a.sh
+++ b/.claude/skills/smoke-test/block-1-desktop-cli-a.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Requires: block-0 already executed (JAR env var set, or re-derive below).
+
+cd "$(git rev-parse --show-toplevel)"
+
+JAR="${JAR:-$(ls composeApp/build/libs/tether-cli-*.jar composeApp/build/libs/tether-cli.jar 2>/dev/null | head -1)}"
+[ -z "$JAR" ] && { echo "FAIL: cli jar not found — run block-0 first"; exit 1; }
+
+LOG_A=/tmp/smoke-cliA.log
+rm -f /tmp/smoke-cliA-in
+mkfifo /tmp/smoke-cliA-in
+sleep 600 > /tmp/smoke-cliA-in &
+KEEPER_A=$!; disown $KEEPER_A
+echo $KEEPER_A > /tmp/smoke-cliA-keeper.pid
+
+nohup java -jar "$JAR" --name SmokeMacA --port 0 < /tmp/smoke-cliA-in > "$LOG_A" 2>&1 &
+JPID_A=$!; disown $JPID_A
+echo $JPID_A > /tmp/smoke-cliA.pid
+
+echo "Waiting for FileServer to start..."
+for i in $(seq 1 30); do
+  set +e; grep -q 'FileServer started' "$LOG_A" 2>/dev/null; RC=$?; set -e
+  [ $RC -eq 0 ] && break
+  sleep 1
+done
+
+set +e; grep -q 'FileServer started' "$LOG_A" 2>/dev/null; RC=$?; set -e
+[ $RC -ne 0 ] && { echo "FAIL: FileServer did not start within 30s"; exit 1; }
+
+PORT_A=$(grep -oE 'port[[:space:]]*:[[:space:]]*[0-9]+' "$LOG_A" | grep -oE '[0-9]+' | head -1)
+echo "PASS: startup — pid=$JPID_A, port=$PORT_A"
+
+# /health
+HEALTH=$(curl -sf --max-time 5 "http://localhost:$PORT_A/health" || echo "FAIL")
+[ "$HEALTH" = "Tether OK" ] && echo "PASS: /health — $HEALTH" || echo "FAIL: /health returned: $HEALTH"
+
+# /pair — X.509 EC P-256 SubjectPublicKeyInfo shape check
+PAIR_RESP=$(curl -sf --max-time 5 -X POST "http://localhost:$PORT_A/pair" \
+  -H "Content-Type: application/json" \
+  -d '{"publicKey":[1,2,3], "deviceName":"smoke"}' || echo "")
+set +e
+echo "$PAIR_RESP" | jq -e '.publicKey | length == 91 and .[0] == 48 and .[26] == 4' > /dev/null 2>&1
+RC=$?
+set -e
+[ $RC -eq 0 ] && echo "PASS: /pair X.509 EC P-256 SubjectPublicKeyInfo" || echo "FAIL: bad publicKey shape: $PAIR_RESP"
+
+# Port LISTEN
+set +e; lsof -nP -iTCP:"$PORT_A" 2>/dev/null | head -3; set -e
+echo "PASS: port LISTEN check printed above"
+
+# mDNS publish (log)
+set +e; grep -q "mDNS started" "$LOG_A" 2>/dev/null; RC=$?; set -e
+[ $RC -eq 0 ] && echo "PASS: mDNS publish (log)" || echo "FAIL: mDNS started not in log"
+
+# mDNS publish (dns-sd, optional)
+if command -v dns-sd >/dev/null 2>&1; then
+  set +e
+  DNS_RESULT=$( ( dns-sd -B _tether._tcp. local. 2>&1 & DNSSD_PID=$!; sleep 8; kill $DNSSD_PID 2>/dev/null ) | grep SmokeMacA | head -1 )
+  set -e
+  [ -n "$DNS_RESULT" ] && echo "PASS: mDNS publish (dns-sd) — $DNS_RESULT" || echo "FAIL: SmokeMacA not seen via dns-sd"
+else
+  echo "SKIP: mDNS publish (dns-sd) — dns-sd not available"
+fi
+
+# stdin list
+echo "list" > /tmp/smoke-cliA-in &
+sleep 1
+set +e; tail "$LOG_A" | grep -qE "\[list\]|\[peers\]"; RC=$?; set -e
+[ $RC -eq 0 ] && echo "PASS: stdin list" || echo "FAIL: no [list] or [peers] line in log"
+
+echo ""
+echo "CLI A alive. PORT_A=$PORT_A  JPID_A=$JPID_A  LOG_A=$LOG_A"

--- a/.claude/skills/smoke-test/block-2.1-single-file-send.sh
+++ b/.claude/skills/smoke-test/block-2.1-single-file-send.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Requires: block-1 already executed (CLI A alive at $LOG_A / $JPID_A / fifo /tmp/smoke-cliA-in).
+# This script starts CLI B and waits for mutual discovery before the send scenario.
+# block-2.2 and block-2.3 assume CLI B is still alive after this script.
+
+LOG_A="${LOG_A:-/tmp/smoke-cliA.log}"
+DOWNLOADS_B="${DOWNLOADS_B:-$HOME/Downloads/Tether}"
+JAR="${JAR:-$(ls "$(git rev-parse --show-toplevel)"/composeApp/build/libs/tether-cli-*.jar \
+  "$(git rev-parse --show-toplevel)"/composeApp/build/libs/tether-cli.jar 2>/dev/null | head -1)}"
+
+LOG_B=/tmp/smoke-cliB.log
+rm -f /tmp/smoke-cliB-in
+mkfifo /tmp/smoke-cliB-in
+sleep 600 > /tmp/smoke-cliB-in &
+KEEPER_B=$!; disown $KEEPER_B
+echo $KEEPER_B > /tmp/smoke-cliB-keeper.pid
+
+nohup java -jar "$JAR" --name SmokeMacB --port 0 < /tmp/smoke-cliB-in > "$LOG_B" 2>&1 &
+JPID_B=$!; disown $JPID_B
+echo $JPID_B > /tmp/smoke-cliB.pid
+
+echo "Waiting for mutual mDNS discovery..."
+for i in $(seq 1 30); do
+  set +e
+  grep -q 'SmokeMacA' "$LOG_B" 2>/dev/null && grep -q 'SmokeMacB' "$LOG_A" 2>/dev/null
+  RC=$?
+  set -e
+  [ $RC -eq 0 ] && break
+  sleep 1
+done
+
+# Single-file send scenario
+SEND1_NAME="smoke-send-$(date +%s).txt"
+SEND1_SRC="/tmp/$SEND1_NAME"
+echo "send-via-cli-$(date +%s)" > "$SEND1_SRC"
+echo "send SmokeMacB $SEND1_SRC" > /tmp/smoke-cliA-in &
+
+for i in $(seq 1 15); do
+  set +e; grep -qE "^\[send\] (done|partial|error)" "$LOG_A" 2>/dev/null; RC=$?; set -e
+  [ $RC -eq 0 ] && break
+  sleep 1
+done
+
+set +e
+grep -qE "^\[send\] done" "$LOG_A" 2>/dev/null && \
+  [ -f "$DOWNLOADS_B/$SEND1_NAME" ] && \
+  diff "$SEND1_SRC" "$DOWNLOADS_B/$SEND1_NAME" >/dev/null 2>&1
+RC=$?
+set -e
+
+[ $RC -eq 0 ] && echo "PASS: single-file send — $SEND1_NAME byte-identical" || echo "FAIL: single-file send"
+export SEND1_NAME SEND1_SRC LOG_B JPID_B

--- a/.claude/skills/smoke-test/block-2.2-multi-file-send.sh
+++ b/.claude/skills/smoke-test/block-2.2-multi-file-send.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Requires: block-1 already executed (CLI A alive at $LOG_A / $JPID_A / fifo /tmp/smoke-cliA-in).
+# Requires: CLI B alive with name SmokeMacB.
+
+LOG_A="${LOG_A:-/tmp/smoke-cliA.log}"
+DOWNLOADS_B="${DOWNLOADS_B:-$HOME/Downloads/Tether}"
+
+TS=$(date +%s)
+M1="/tmp/smoke-multi-${TS}-1.txt"; echo "m1-$TS" > "$M1"
+M2="/tmp/smoke-multi-${TS}-2.txt"; echo "m2-$TS" > "$M2"
+M3="/tmp/smoke-multi-${TS}-3.txt"; echo "m3-$TS" > "$M3"
+
+set +e
+PREV_DONE=$(grep -cE "^\[send\] done" "$LOG_A" 2>/dev/null || echo 0)
+set -e
+
+echo "send SmokeMacB $M1 $M2 $M3" > /tmp/smoke-cliA-in &
+
+for i in $(seq 1 20); do
+  set +e; NOW_DONE=$(grep -cE "^\[send\] done" "$LOG_A" 2>/dev/null || echo 0); set -e
+  [ "$NOW_DONE" -gt "$PREV_DONE" ] && break
+  sleep 1
+done
+
+set +e
+grep -qE '^\[send\] done — 3/3 sent' "$LOG_A" 2>/dev/null && \
+  diff "$M1" "$DOWNLOADS_B/$(basename "$M1")" >/dev/null 2>&1 && \
+  diff "$M2" "$DOWNLOADS_B/$(basename "$M2")" >/dev/null 2>&1 && \
+  diff "$M3" "$DOWNLOADS_B/$(basename "$M3")" >/dev/null 2>&1
+RC=$?
+set -e
+
+[ $RC -eq 0 ] && echo "PASS: multi-file send — 3/3 sent, all byte-identical" || echo "FAIL: multi-file send"
+export M1 M2 M3

--- a/.claude/skills/smoke-test/block-2.3-retry.sh
+++ b/.claude/skills/smoke-test/block-2.3-retry.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Requires: block-1 already executed (CLI A alive at $LOG_A / $JPID_A / fifo /tmp/smoke-cliA-in).
+# Requires: CLI B was alive (this script stops and restarts it).
+
+LOG_A="${LOG_A:-/tmp/smoke-cliA.log}"
+LOG_B="${LOG_B:-/tmp/smoke-cliB.log}"
+DOWNLOADS_B="${DOWNLOADS_B:-$HOME/Downloads/Tether}"
+JAR="${JAR:-$(ls "$(git rev-parse --show-toplevel)"/composeApp/build/libs/tether-cli-*.jar \
+  "$(git rev-parse --show-toplevel)"/composeApp/build/libs/tether-cli.jar 2>/dev/null | head -1)}"
+
+# Stop B to trigger an error on send.
+set +e; kill "$(cat /tmp/smoke-cliB.pid 2>/dev/null)" 2>/dev/null; set -e
+sleep 2
+
+RETRY_NAME="smoke-retry-$(date +%s).txt"
+RETRY_SRC="/tmp/$RETRY_NAME"
+echo "retry-payload-$(date +%s)" > "$RETRY_SRC"
+
+set +e; PREV_ERR=$(grep -cE "^\[send\] error" "$LOG_A" 2>/dev/null || echo 0); set -e
+echo "send SmokeMacB $RETRY_SRC" > /tmp/smoke-cliA-in &
+
+for i in $(seq 1 15); do
+  set +e; NOW_ERR=$(grep -cE "^\[send\] error" "$LOG_A" 2>/dev/null || echo 0); set -e
+  [ "$NOW_ERR" -gt "$PREV_ERR" ] && break
+  sleep 1
+done
+
+# Restart B with the same name so the engine's PeerIdentity resolves again.
+nohup java -jar "$JAR" --name SmokeMacB --port 0 < /tmp/smoke-cliB-in > "$LOG_B" 2>&1 &
+JPID_B=$!; disown $JPID_B
+echo $JPID_B > /tmp/smoke-cliB.pid
+
+for i in $(seq 1 30); do
+  set +e; grep -q 'SmokeMacB' "$LOG_A" 2>/dev/null; RC=$?; set -e
+  [ $RC -eq 0 ] && break
+  sleep 1
+done
+
+set +e; PREV_DONE=$(grep -cE "^\[send\] done" "$LOG_A" 2>/dev/null || echo 0); set -e
+echo "retry SmokeMacB" > /tmp/smoke-cliA-in &
+
+for i in $(seq 1 15); do
+  set +e; NOW_DONE=$(grep -cE "^\[send\] done" "$LOG_A" 2>/dev/null || echo 0); set -e
+  [ "$NOW_DONE" -gt "$PREV_DONE" ] && break
+  sleep 1
+done
+
+set +e
+[ -f "$DOWNLOADS_B/$RETRY_NAME" ] && diff "$RETRY_SRC" "$DOWNLOADS_B/$RETRY_NAME" >/dev/null 2>&1
+RC=$?
+set -e
+
+[ $RC -eq 0 ] && echo "PASS: retry — file landed byte-identical after retry" || echo "FAIL: retry"
+export RETRY_NAME RETRY_SRC

--- a/.claude/skills/smoke-test/block-3-same-name-discovery.sh
+++ b/.claude/skills/smoke-test/block-3-same-name-discovery.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Requires: block-1 and block-2 already executed (CLI A and B alive).
+
+LOG_A="${LOG_A:-/tmp/smoke-cliA.log}"
+LOG_B="${LOG_B:-/tmp/smoke-cliB.log}"
+JAR="${JAR:-$(ls "$(git rev-parse --show-toplevel)"/composeApp/build/libs/tether-cli-*.jar \
+  "$(git rev-parse --show-toplevel)"/composeApp/build/libs/tether-cli.jar 2>/dev/null | head -1)}"
+
+LOG_C=/tmp/smoke-cliC.log
+rm -f /tmp/smoke-cliC-in
+mkfifo /tmp/smoke-cliC-in
+sleep 600 > /tmp/smoke-cliC-in &
+KEEPER_C=$!; disown $KEEPER_C
+echo $KEEPER_C > /tmp/smoke-cliC-keeper.pid
+
+nohup java -jar "$JAR" --name SmokeMacA --port 0 < /tmp/smoke-cliC-in > "$LOG_C" 2>&1 &
+JPID_C=$!; disown $JPID_C
+echo $JPID_C > /tmp/smoke-cliC.pid
+
+for i in $(seq 1 20); do
+  echo "list" > /tmp/smoke-cliA-in &
+  echo "list" > /tmp/smoke-cliB-in &
+  echo "list" > /tmp/smoke-cliC-in &
+  sleep 1
+  set +e
+  A_OK=$(grep -aE "\[peers\]" "$LOG_A" 2>/dev/null | tail -1 | grep -oE 'SmokeMac[A-Z][^@]*' | sort -u | wc -l | tr -d ' ')
+  B_OK=$(grep -aE "\[peers\]" "$LOG_B" 2>/dev/null | tail -1 | grep -oE 'SmokeMac[A-Z][^@]*' | sort -u | wc -l | tr -d ' ')
+  C_OK=$(grep -aE "\[peers\]" "$LOG_C" 2>/dev/null | tail -1 | grep -oE 'SmokeMac[A-Z][^@]*' | sort -u | wc -l | tr -d ' ')
+  set -e
+  A_OK="${A_OK:-0}"; B_OK="${B_OK:-0}"; C_OK="${C_OK:-0}"
+  [ "$A_OK" -ge 2 ] && [ "$B_OK" -ge 2 ] && [ "$C_OK" -ge 2 ] && break
+done
+
+if [ "$A_OK" -ge 2 ] && [ "$B_OK" -ge 2 ] && [ "$C_OK" -ge 2 ]; then
+  echo "PASS: same-name discovery — each instance sees ≥2 SmokeMac peers"
+else
+  echo "FAIL: same-name discovery — A=$A_OK B=$B_OK C=$C_OK (need ≥2 each)"
+  echo "Last [peers] lines:"
+  set +e
+  grep -aE "\[peers\]" "$LOG_A" 2>/dev/null | tail -1
+  grep -aE "\[peers\]" "$LOG_B" 2>/dev/null | tail -1
+  grep -aE "\[peers\]" "$LOG_C" 2>/dev/null | tail -1
+  set -e
+fi
+
+export LOG_C JPID_C

--- a/.claude/skills/smoke-test/block-3.5-rename.sh
+++ b/.claude/skills/smoke-test/block-3.5-rename.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Requires: block-1 already executed (CLI A alive / fifo /tmp/smoke-cliA-in).
+# Requires: CLI B alive at $LOG_B (needs to see the rename propagated via mDNS).
+
+LOG_B="${LOG_B:-/tmp/smoke-cliB.log}"
+
+echo "name RenamedA" > /tmp/smoke-cliA-in &
+
+for i in $(seq 1 15); do
+  set +e; grep -q "RenamedA" "$LOG_B" 2>/dev/null; RC=$?; set -e
+  [ $RC -eq 0 ] && break
+  sleep 1
+done
+
+set +e; grep -q "RenamedA" "$LOG_B" 2>/dev/null; RC=$?; set -e
+[ $RC -eq 0 ] && echo "PASS: device name rename — B sees RenamedA within 15s" || echo "FAIL: RenamedA not seen in B's log"

--- a/.claude/skills/smoke-test/block-4-graceful-quit.sh
+++ b/.claude/skills/smoke-test/block-4-graceful-quit.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Requires: block-1 already executed (CLI A alive, $JPID_A known / /tmp/smoke-cliA.pid written).
+# After block-2 retry scenario the last result was AllSent → expected exit code 0.
+
+JPID_A="${JPID_A:-$(cat /tmp/smoke-cliA.pid 2>/dev/null)}"
+[ -z "$JPID_A" ] && { echo "FAIL: JPID_A unknown — cannot check graceful quit"; exit 1; }
+
+echo "quit" > /tmp/smoke-cliA-in &
+
+EXITED=0
+for i in $(seq 1 8); do
+  set +e; ps -p "$JPID_A" > /dev/null 2>&1; ALIVE=$?; set -e
+  if [ $ALIVE -ne 0 ]; then
+    EXITED=1
+    break
+  fi
+  sleep 1
+done
+
+if [ $EXITED -eq 0 ]; then
+  echo "FAIL: CLI A did not exit gracefully within 8s — killing"
+  set +e; kill -9 "$JPID_A" 2>/dev/null; set -e
+  echo "SKIP: exit-code check (process had to be force-killed)"
+else
+  set +e; wait "$JPID_A" 2>/dev/null; EXIT_A=$?; set -e
+  echo "PASS: graceful quit — exited"
+  [ "$EXIT_A" = "0" ] && echo "PASS: exit code — exit=$EXIT_A (last send AllSent)" || echo "FAIL: exit code — exit=$EXIT_A"
+fi

--- a/.claude/skills/smoke-test/block-5-android.sh
+++ b/.claude/skills/smoke-test/block-5-android.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Requires: block-1 already executed (CLI A alive, LOG_A set or /tmp/smoke-cliA.log present).
+
+LOG_A="${LOG_A:-/tmp/smoke-cliA.log}"
+
+cd "$(git rev-parse --show-toplevel)"
+
+ADB_DEVICE=$(adb devices 2>/dev/null | awk '/device$/ && !/List/ {print $1}' | head -1)
+if [ -z "$ADB_DEVICE" ]; then
+  echo "SKIP: no adb device connected"
+  exit 0
+fi
+echo "adb device: $ADB_DEVICE"
+
+./gradlew -q :composeApp:installDebug
+echo "PASS: install"
+
+adb logcat -c
+
+adb shell am start -n com.tubetoast.tether/.MainActivity
+
+DEADLINE=$(($(date +%s) + 12))
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+  set +e; adb logcat -d 2>/dev/null | grep -q "NSD service registered"; RC=$?; set -e
+  [ $RC -eq 0 ] && break
+  sleep 1
+done
+NSD_READY_MS=$(python3 -c "import time; print(int(time.time() * 1000))")
+
+ANDROID_PORT=$(adb logcat -d 2>/dev/null | grep "FileServer started on port" | grep -oE '[0-9]+$' | tail -1)
+echo "Android port: $ANDROID_PORT"
+
+ANDROID_IP=$(adb shell ip addr show wlan0 2>&1 | grep "inet " | awk '{print $2}' | cut -d/ -f1 | head -1)
+echo "Android IP: $ANDROID_IP"
+
+if echo "$ANDROID_IP" | grep -q "^10\.0\.2\."; then
+  echo "INFO: emulator detected — /health via adb forward"
+  adb forward "tcp:18080" "tcp:$ANDROID_PORT"
+  HEALTH_HOST="localhost:18080"
+else
+  HEALTH_HOST="$ANDROID_IP:$ANDROID_PORT"
+fi
+
+set +e
+HEALTH=$(curl -sf --max-time 5 "http://$HEALTH_HOST/health" || echo "FAIL")
+set -e
+[ "$HEALTH" = "Tether OK" ] && echo "PASS: /health — $HEALTH" || echo "FAIL: /health — $HEALTH"
+
+# Cross-discovery with timing
+for i in $(seq 1 30); do
+  set +e; grep -aE "\[peers\] .*@${ANDROID_IP}:" "$LOG_A" 2>/dev/null | tail -1 | grep -q .; RC=$?; set -e
+  [ $RC -eq 0 ] && break
+  sleep 1
+done
+NOW_MS=$(python3 -c "import time; print(int(time.time() * 1000))")
+DELTA_MS=$((NOW_MS - NSD_READY_MS))
+set +e
+ANDROID_NAME=$(grep -aE "\[peers\]" "$LOG_A" 2>/dev/null | tail -1 | grep -oE "[^, ]+@${ANDROID_IP}" | head -1 | sed 's/@.*//')
+set -e
+echo "cross-discovery: ${DELTA_MS}ms, peer=${ANDROID_NAME:-unknown}"
+[ -n "$ANDROID_NAME" ] && echo "PASS: cross-discovery" || echo "FAIL: Android peer not seen on Desktop"
+
+# Send Desktop → Android
+if echo "$ANDROID_IP" | grep -q "^10\.0\.2\."; then
+  echo "SKIP: send Desktop→Android — QEMU user-mode NAT drops host→guest TCP payload; see docs/knowledge/android-emulator-networking.md"
+elif [ -z "$ANDROID_NAME" ]; then
+  echo "SKIP: send Desktop→Android — cross-discovery did not surface Android peer"
+else
+  ANDROID_NAME_FILE="smoke-android-$(date +%s).txt"
+  ANDROID_SRC="/tmp/$ANDROID_NAME_FILE"
+  echo "send-to-android-$(date +%s)" > "$ANDROID_SRC"
+  set +e; PREV_DONE=$(grep -cE "^\[send\] done" "$LOG_A" 2>/dev/null || echo 0); set -e
+  echo "send $ANDROID_NAME $ANDROID_SRC" > /tmp/smoke-cliA-in &
+  for i in $(seq 1 15); do
+    set +e; NOW_DONE=$(grep -cE "^\[send\] done" "$LOG_A" 2>/dev/null || echo 0); set -e
+    [ "$NOW_DONE" -gt "$PREV_DONE" ] && break
+    sleep 1
+  done
+  set +e
+  ANDROID_DEST=$(adb shell run-as com.tubetoast.tether ls -1 \
+    "/data/data/com.tubetoast.tether/files/Tether/$ANDROID_NAME_FILE" 2>/dev/null \
+    || adb shell ls -1 "/sdcard/Android/data/com.tubetoast.tether/files/Tether/$ANDROID_NAME_FILE" 2>/dev/null)
+  ANDROID_DEST=$(echo "$ANDROID_DEST" | tr -d '\r' | head -1)
+  set -e
+  if [ -n "$ANDROID_DEST" ]; then
+    set +e; adb shell cat "$ANDROID_DEST" 2>/dev/null | diff - "$ANDROID_SRC"; RC=$?; set -e
+    [ $RC -eq 0 ] && echo "PASS: send Desktop→Android" || echo "FAIL: send Desktop→Android — diff mismatch"
+  else
+    echo "FAIL: send Desktop→Android — file not found on device"
+  fi
+fi
+
+adb shell am force-stop com.tubetoast.tether
+echo "PASS: force-stop"

--- a/.claude/skills/smoke-test/block-5.5-ios.sh
+++ b/.claude/skills/smoke-test/block-5.5-ios.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Requires: block-1 already executed (CLI A alive, LOG_A set or /tmp/smoke-cliA.log present).
+
+LOG_A="${LOG_A:-/tmp/smoke-cliA.log}"
+
+# Pre-checks
+if ! xcrun simctl help >/dev/null 2>&1; then
+  echo "SKIP: Xcode CLI tools not installed"
+  exit 0
+fi
+if [ ! -d "$(git rev-parse --show-toplevel)/iosApp/iosApp.xcodeproj" ]; then
+  echo "SKIP: iosApp/iosApp.xcodeproj not found"
+  exit 0
+fi
+
+cd "$(git rev-parse --show-toplevel)"
+
+IOS_DEVICE="${IOS_DEVICE:-iPhone 17}"
+UDID=$(xcrun simctl list devices available \
+  | awk -F '[()]' -v n="$IOS_DEVICE" '$0 ~ n && $0 !~ /unavailable/ { print $2; exit }')
+if [ -z "$UDID" ]; then
+  echo "SKIP: no available simulator matching '$IOS_DEVICE'"
+  exit 0
+fi
+
+set +e; xcrun simctl boot "$UDID" 2>/dev/null; set -e
+open -a Simulator
+
+IOS_DERIVED=build/ios
+IOS_APP="$IOS_DERIVED/Build/Products/Debug-iphonesimulator/Tether.app"
+IOS_BUNDLE_ID=com.tubetoast.tether.Tether
+
+xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp \
+  -configuration Debug \
+  -destination "platform=iOS Simulator,id=$UDID" \
+  -derivedDataPath "$IOS_DERIVED" \
+  build > /tmp/smoke-ios-build.log 2>&1
+echo "PASS: xcodebuild"
+
+xcrun simctl install "$UDID" "$IOS_APP"
+echo "PASS: install"
+
+xcrun simctl launch "$UDID" "$IOS_BUNDLE_ID" > /tmp/smoke-ios-launch.log 2>&1
+echo "PASS: launch"
+
+# mDNS publish
+IOS_NAME=""
+for i in $(seq 1 30); do
+  set +e
+  IOS_NAME=$( ( dns-sd -B _tether._tcp local. & DNSSD=$!; sleep 2; kill $DNSSD 2>/dev/null ) \
+    | awk -F'\t' '/_tether._tcp/ && NF>1 { print $NF }' \
+    | grep -E 'iPhone|iPad' | head -1 | tr -d '\r' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+  set -e
+  [ -n "$IOS_NAME" ] && break
+  sleep 1
+done
+[ -n "$IOS_NAME" ] && echo "PASS: mDNS publish — $IOS_NAME" || echo "FAIL: mDNS publish — no iOS service seen (check Local Network Privacy prompt)"
+
+# TXT record
+set +e
+TXT_OK=$( ( dns-sd -q "${IOS_NAME}._tether._tcp.local." TXT & DNSSD=$!; sleep 3; kill $DNSSD 2>/dev/null ) 2>&1 | grep -c '03 76 3D 31' || echo 0)
+set -e
+[ "$TXT_OK" -gt 0 ] && echo "PASS: TXT publish — v=1 record present" || echo "FAIL: TXT publish — 03 76 3D 31 not seen"
+
+# Cross-discovery
+for i in $(seq 1 30); do
+  set +e; grep -q "$IOS_NAME" "$LOG_A" 2>/dev/null; RC=$?; set -e
+  [ $RC -eq 0 ] && break
+  sleep 1
+done
+set +e; grep -q "$IOS_NAME" "$LOG_A" 2>/dev/null; RC=$?; set -e
+[ $RC -eq 0 ] && echo "PASS: cross-discovery — iOS peer seen on Desktop A" || echo "FAIL: cross-discovery — $IOS_NAME not seen in Desktop A log"
+
+export UDID

--- a/.claude/skills/smoke-test/block-7-cleanup.sh
+++ b/.claude/skills/smoke-test/block-7-cleanup.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Always run this block — even after earlier FAILs.
+
+DOWNLOADS_B="${DOWNLOADS_B:-$HOME/Downloads/Tether}"
+
+set +e
+
+kill "$(cat /tmp/smoke-cliA.pid /tmp/smoke-cliB.pid /tmp/smoke-cliC.pid \
+  /tmp/smoke-cliA-keeper.pid /tmp/smoke-cliB-keeper.pid /tmp/smoke-cliC-keeper.pid 2>/dev/null)" 2>/dev/null
+
+pkill -f 'com.tubetoast.tether.*\.jar' 2>/dev/null
+
+rm -f /tmp/smoke-cli*-in /tmp/smoke-cli*.log /tmp/smoke-cli*.pid /tmp/smoke-cli*-keeper.pid \
+  /tmp/smoke-send.txt /tmp/smoke-android.txt
+
+# Remove scratch files created by block-2 scenarios (by exported names if available, else glob).
+for VAR in SEND1_NAME M1 M2 M3 RETRY_NAME; do
+  FILE="${!VAR:-}"
+  [ -n "$FILE" ] && rm -f "$DOWNLOADS_B/$FILE" "$DOWNLOADS_B/$(basename "$FILE")" 2>/dev/null
+done
+# Safety glob for any leftover smoke files in the downloads dir.
+rm -f "$DOWNLOADS_B"/smoke-*.txt 2>/dev/null
+
+adb shell rm -f /sdcard/Android/data/com.tubetoast.tether/files/Tether/smoke-android*.txt 2>/dev/null
+adb shell am force-stop com.tubetoast.tether 2>/dev/null
+
+UDID="${UDID:-}"
+if [ -n "$UDID" ]; then
+  xcrun simctl terminate "$UDID" com.tubetoast.tether.Tether 2>/dev/null || true
+fi
+rm -f /tmp/smoke-ios-build.log /tmp/smoke-ios-launch.log
+
+set -e
+echo "Cleanup done."

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/di/AppContainer.kt
@@ -27,6 +27,7 @@ import com.tubetoast.tether.transfer.AutoSendDispatcher
 import com.tubetoast.tether.transfer.BatchSender
 import com.tubetoast.tether.transfer.ConnectionMonitor
 import com.tubetoast.tether.transfer.NoOpConnectionMonitor
+import com.tubetoast.tether.transfer.PeerIdentity
 import com.tubetoast.tether.transfer.PeerTransferEngine
 import com.tubetoast.tether.transfer.PeerTransferEngineRegistry
 import com.tubetoast.tether.transfer.PeerUnreachableException
@@ -64,8 +65,8 @@ abstract class AppContainer {
     open val connectionMonitor: ConnectionMonitor = NoOpConnectionMonitor
 
     // Factory: BatchSender holds per-transfer state — one instance per concurrent peer transfer.
-    open val batchSenderFactory: () -> BatchSender by lazy {
-        {
+    open val batchSenderFactory: (PeerIdentity) -> BatchSender by lazy {
+        { _ ->
             BatchSender(
                 sendOne = { _, _ -> throw PeerUnreachableException() },
                 connectionMonitor = connectionMonitor,
@@ -91,7 +92,7 @@ abstract class AppContainer {
             engineFactory = { peer, engineScope ->
                 PeerTransferEngine(
                     peer = peer,
-                    batchSenderFactory = batchSenderFactory,
+                    batchSenderFactory = { batchSenderFactory(peer) },
                     // TODO(#195): wire real ReceiveEvent source when Receiver UI lands
                     reconnectionTimeout = ReconnectionTimeout.DEFAULT,
                     scope = engineScope,

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/discovery/RendezvousAnnouncer.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/discovery/RendezvousAnnouncer.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import ru.pocketbyte.kydra.log.KydraLog
-import ru.pocketbyte.kydra.log.debug
+import ru.pocketbyte.kydra.log.info
 import ru.pocketbyte.kydra.log.wrapper.withTag
 import kotlin.concurrent.Volatile
 
@@ -28,7 +28,7 @@ class RendezvousAnnouncer(
                 val info = selfAnnouncementProvider.get()
                 for (device in devices) {
                     if (device.id in acknowledgedIds.value) continue
-                    log.debug { "announce → ${device.id}" }
+                    log.info { "announce → ${device.id}" }
                     val ok = client.sendHello(device, info)
                     if (ok) acknowledgedIds.update { it + device.id }
                 }

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/discovery/RendezvousAnnouncer.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/discovery/RendezvousAnnouncer.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import ru.pocketbyte.kydra.log.KydraLog
-import ru.pocketbyte.kydra.log.info
+import ru.pocketbyte.kydra.log.debug
 import ru.pocketbyte.kydra.log.wrapper.withTag
 import kotlin.concurrent.Volatile
 
@@ -28,7 +28,7 @@ class RendezvousAnnouncer(
                 val info = selfAnnouncementProvider.get()
                 for (device in devices) {
                     if (device.id in acknowledgedIds.value) continue
-                    log.info { "announce → ${device.id}" }
+                    log.debug { "announce → ${device.id}" }
                     val ok = client.sendHello(device, info)
                     if (ok) acknowledgedIds.update { it + device.id }
                 }

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
@@ -65,10 +65,13 @@ open class FileClient(
             setBody(ownInfo)
         }
         val ok = response.status.isSuccess()
-        if (ok) log.info { "hello sent → ${target.host}:${target.port}" }
+        if (ok) log.debug { "hello sent → ${target.host}:${target.port}" }
         ok
     } catch (e: Exception) {
-        log.error { "hello failed → ${target.host}:${target.port} — ${e.message}" }
+        // Hello attempts churn on stale mDNS records (peer left, advertisement TTL not expired) —
+        // each retry surfaces a Connection refused. Demoted to DEBUG so default CLI/UI stays clean;
+        // the rendezvous announcer retries on its own and acknowledgedIds tracks success.
+        log.debug { "hello failed → ${target.host}:${target.port} — ${e.message}" }
         false
     }
 

--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
@@ -65,13 +65,10 @@ open class FileClient(
             setBody(ownInfo)
         }
         val ok = response.status.isSuccess()
-        if (ok) log.debug { "hello sent → ${target.host}:${target.port}" }
+        if (ok) log.info { "hello sent → ${target.host}:${target.port}" }
         ok
     } catch (e: Exception) {
-        // Hello attempts churn on stale mDNS records (peer left, advertisement TTL not expired) —
-        // each retry surfaces a Connection refused. Demoted to DEBUG so default CLI/UI stays clean;
-        // the rendezvous announcer retries on its own and acknowledgedIds tracks success.
-        log.debug { "hello failed → ${target.host}:${target.port} — ${e.message}" }
+        log.error { "hello failed → ${target.host}:${target.port} — ${e.message}" }
         false
     }
 

--- a/composeApp/src/desktopCli/kotlin/com/tubetoast/tether/Main.kt
+++ b/composeApp/src/desktopCli/kotlin/com/tubetoast/tether/Main.kt
@@ -40,8 +40,6 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlin.io.path.exists
 import kotlin.time.Duration.Companion.seconds
 
-private const val ESC = ""
-
 sealed class CliBatchResult {
     data object AllSent : CliBatchResult()
 
@@ -128,20 +126,13 @@ class TetherCommand :
         }
 
         val discovery = container.mdnsDiscovery
-        var peersLinePrinted = false
         var lastPeerIds: String? = null
         launch {
             discovery.discoveredDevices.collect { peers ->
                 val ids = if (peers.isEmpty()) "none" else peers.joinToString(", ") { it.id }
                 if (ids == lastPeerIds) return@collect
                 lastPeerIds = ids
-                if (peersLinePrinted) {
-                    print("$ESC[1A\r$ESC[K[peers] $ids\n")
-                } else {
-                    print("[peers] $ids\n")
-                    peersLinePrinted = true
-                }
-                System.out.flush()
+                echo("[peers] $ids")
             }
         }
 

--- a/composeApp/src/desktopCli/kotlin/com/tubetoast/tether/Main.kt
+++ b/composeApp/src/desktopCli/kotlin/com/tubetoast/tether/Main.kt
@@ -126,12 +126,9 @@ class TetherCommand :
         }
 
         val discovery = container.mdnsDiscovery
-        var lastPeerIds: String? = null
         launch {
             discovery.discoveredDevices.collect { peers ->
                 val ids = if (peers.isEmpty()) "none" else peers.joinToString(", ") { it.id }
-                if (ids == lastPeerIds) return@collect
-                lastPeerIds = ids
                 echo("[peers] $ids")
             }
         }

--- a/composeApp/src/desktopCli/kotlin/com/tubetoast/tether/Main.kt
+++ b/composeApp/src/desktopCli/kotlin/com/tubetoast/tether/Main.kt
@@ -8,12 +8,15 @@ import com.tubetoast.tether.config.DeviceNameStore
 import com.tubetoast.tether.config.EphemeralDeviceNamePersistence
 import com.tubetoast.tether.di.DefaultDesktopAppConfig
 import com.tubetoast.tether.di.DesktopAppContainer
+import com.tubetoast.tether.discovery.DiscoveredDevicesStore
 import com.tubetoast.tether.logging.initTetherLogging
 import com.tubetoast.tether.logging.isDebugEnabled
+import com.tubetoast.tether.network.FileClient
 import com.tubetoast.tether.protocol.Device
 import com.tubetoast.tether.protocol.DeviceType
 import com.tubetoast.tether.protocol.SendResult
 import com.tubetoast.tether.transfer.BatchSender
+import com.tubetoast.tether.transfer.ConnectionMonitor
 import com.tubetoast.tether.transfer.JvmPathFileSource
 import com.tubetoast.tether.transfer.PeerIdentity
 import com.tubetoast.tether.transfer.PeerTransferEngine
@@ -25,7 +28,8 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -34,7 +38,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.io.path.exists
-import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 private const val ESC = ""
 
@@ -78,16 +82,20 @@ class TetherCommand :
         initTetherLogging(debugEnabled = isDebugEnabled())
 
         val activeEngineRef = AtomicReference<PeerTransferEngine?>(null)
-        val containerRef = AtomicReference<DesktopAppContainer?>(null)
 
-        val container = DesktopAppContainer(
+        lateinit var container: DesktopAppContainer
+        container = DesktopAppContainer(
             DefaultDesktopAppConfig(port = port ?: 0, namePersistenceOverride = EphemeralDeviceNamePersistence()),
             ownDeviceType = DeviceType.Cli,
             batchSenderFactoryOverride = { peer ->
-                buildCliBatchSender(peer, containerRef)
+                buildCliBatchSender(
+                    peer = peer,
+                    fileClient = container.fileClient,
+                    connectionMonitor = container.connectionMonitor,
+                    discoveredDevicesStore = container.discoveredDevicesStore,
+                )
             },
         )
-        containerRef.set(container)
 
         container.nameStore.init()
         nameOverride?.let { name ->
@@ -199,17 +207,15 @@ class TetherCommand :
 
 private fun buildCliBatchSender(
     peer: PeerIdentity,
-    containerRef: AtomicReference<DesktopAppContainer?>,
-): BatchSender {
-    // Factory is called after containerRef.set(container) — safe to require non-null.
-    val container = requireNotNull(containerRef.get())
-    val fileClient = container.fileClient
-    val connectionMonitor = container.connectionMonitor
-    return BatchSender(
-        sendOne = { source, onProgress ->
-            val device = container.discoveredDevicesStore.devices.value
-                .firstOrNull { it.toPeerIdentity() == peer }
-                ?: throw PeerUnreachableException()
+    fileClient: FileClient,
+    connectionMonitor: ConnectionMonitor,
+    discoveredDevicesStore: DiscoveredDevicesStore,
+): BatchSender = BatchSender(
+    sendOne = { source, onProgress ->
+        val device = discoveredDevicesStore.devices.value
+            .firstOrNull { it.toPeerIdentity() == peer }
+            ?: throw PeerUnreachableException()
+        try {
             // FileClient.send swallows all exceptions into SendResult.Failure — map to typed exceptions.
             when (
                 val result = fileClient.send(
@@ -223,10 +229,12 @@ private fun buildCliBatchSender(
                 is SendResult.Success -> Unit
                 is SendResult.Failure -> throw PeerUnreachableException(RuntimeException(result.reason))
             }
-        },
-        connectionMonitor = connectionMonitor,
-    )
-}
+        } finally {
+            source.close()
+        }
+    },
+    connectionMonitor = connectionMonitor,
+)
 
 suspend fun handleSend(
     engineRegistry: PeerTransferEngineRegistry,
@@ -288,12 +296,13 @@ suspend fun handleRetry(
         return CliBatchResult.AllSent
     }
 
-    engine.onRetryOutbound()
-
-    val transitioned = withTimeoutOrNull(50.milliseconds) {
-        engine.state.filter { !it.isTerminal() }.first()
+    // Subscribe before triggering the retry so no transition is missed between the call and the collect.
+    val next = coroutineScope {
+        val observer = async { engine.state.first { it !== stateBefore } }
+        engine.onRetryOutbound()
+        withTimeoutOrNull(2.seconds) { observer.await() }.also { observer.cancel() }
     }
-    if (transitioned == null) {
+    if (next == null || next.isTerminal()) {
         output("[retry] nothing to retry on '$peerName'")
         return CliBatchResult.AllSent
     }
@@ -323,17 +332,15 @@ private suspend fun awaitAndRenderTerminal(
     errorOutput: (String) -> Unit,
 ): CliBatchResult = collectUntilTerminal(engine, output, errorOutput)
 
-// Renders state transitions and returns only after the terminal state was rendered.
 // `state.first { terminal }` returning before the separate renderer observed the terminal would
 // drop the final "done/error/cancelled" line — this collapses both into one collector.
 private suspend fun collectUntilTerminal(
     engine: PeerTransferEngine,
     output: (String) -> Unit,
     errorOutput: (String) -> Unit,
-): CliBatchResult {
+): CliBatchResult = coroutineScope {
     val terminalSeen = CompletableDeferred<PeerTransferState>()
-    val rendererScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-    val rendererJob = rendererScope.launch {
+    val rendererJob = launch {
         var lastState: PeerTransferState? = null
         engine.state.collect { state ->
             renderStateTransition(lastState, state, output, errorOutput)
@@ -343,7 +350,7 @@ private suspend fun collectUntilTerminal(
     }
     val terminal = terminalSeen.await()
     rendererJob.cancel()
-    return terminalToResult(terminal)
+    terminalToResult(terminal)
 }
 
 private fun renderStateTransition(

--- a/composeApp/src/desktopCli/kotlin/com/tubetoast/tether/Main.kt
+++ b/composeApp/src/desktopCli/kotlin/com/tubetoast/tether/Main.kt
@@ -10,25 +10,54 @@ import com.tubetoast.tether.di.DefaultDesktopAppConfig
 import com.tubetoast.tether.di.DesktopAppContainer
 import com.tubetoast.tether.logging.initTetherLogging
 import com.tubetoast.tether.logging.isDebugEnabled
-import com.tubetoast.tether.network.FileClient
-import com.tubetoast.tether.network.send
 import com.tubetoast.tether.protocol.Device
 import com.tubetoast.tether.protocol.DeviceType
 import com.tubetoast.tether.protocol.SendResult
-import com.tubetoast.tether.transfer.ByteFormatting
+import com.tubetoast.tether.transfer.BatchSender
+import com.tubetoast.tether.transfer.JvmPathFileSource
+import com.tubetoast.tether.transfer.PeerIdentity
+import com.tubetoast.tether.transfer.PeerTransferEngine
+import com.tubetoast.tether.transfer.PeerTransferEngineRegistry
+import com.tubetoast.tether.transfer.PeerTransferState
+import com.tubetoast.tether.transfer.PeerUnreachableException
+import com.tubetoast.tether.transfer.toPeerIdentity
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.io.path.exists
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.TimeSource
 
-private const val ESC = ""
+private const val ESC = ""
+
+sealed class CliBatchResult {
+    data object AllSent : CliBatchResult()
+
+    data object Partial : CliBatchResult()
+
+    data object Failed : CliBatchResult()
+
+    data object Cancelled : CliBatchResult()
+}
+
+fun CliBatchResult.toExitCode(): Int = when (this) {
+    CliBatchResult.AllSent -> 0
+    CliBatchResult.Partial -> 1
+    CliBatchResult.Failed -> 2
+    CliBatchResult.Cancelled -> 130
+}
+
+private fun PeerTransferState.isTerminal(): Boolean = this is PeerTransferState.Sent ||
+    this is PeerTransferState.Error ||
+    this is PeerTransferState.Cancelled
 
 class TetherCommand :
     CliktCommand(
@@ -47,10 +76,18 @@ class TetherCommand :
 
     override fun run() = runBlocking {
         initTetherLogging(debugEnabled = isDebugEnabled())
+
+        val activeEngineRef = AtomicReference<PeerTransferEngine?>(null)
+        val containerRef = AtomicReference<DesktopAppContainer?>(null)
+
         val container = DesktopAppContainer(
             DefaultDesktopAppConfig(port = port ?: 0, namePersistenceOverride = EphemeralDeviceNamePersistence()),
             ownDeviceType = DeviceType.Cli,
+            batchSenderFactoryOverride = { peer ->
+                buildCliBatchSender(peer, containerRef)
+            },
         )
+        containerRef.set(container)
 
         container.nameStore.init()
         nameOverride?.let { name ->
@@ -78,7 +115,9 @@ class TetherCommand :
         echo("FileServer started  →  http://localhost:${handle.port}/health")
         echo("mDNS started → advertising '$deviceName' on port ${handle.port}\n")
 
-        registerShutdownHook(handle)
+        registerShutdownHook(handle) {
+            activeEngineRef.get()?.onCancel()
+        }
 
         val discovery = container.mdnsDiscovery
         var peersLinePrinted = false
@@ -95,12 +134,12 @@ class TetherCommand :
             }
         }
 
-        val fileClient = container.fileClient
         val cliScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-        echo("Commands: send <peer-name> <path>, list, name <new-name>, quit")
+        echo("Commands: send <peer-name> <path> [path2 ...], retry <peer-name>, list, name <new-name>, quit")
         echo("  Tip: use quotes for names/paths with spaces — send \"My Peer\" \"/my path/file.txt\"")
 
+        var lastExit = 0
         var running = true
         while (running) {
             val line = try {
@@ -125,22 +164,240 @@ class TetherCommand :
                 }
                 "send" -> {
                     if (tokens.size < 3) {
-                        echo("usage: send <peer-name> <path>")
+                        echo("usage: send <peer-name> <path> [path2 ...]")
                         continue
                     }
-                    handleSend(
-                        client = fileClient,
+                    val result = handleSend(
+                        engineRegistry = container.peerTransferEngineRegistry,
                         peers = discovery.discoveredDevices.value,
                         peerName = tokens[1],
-                        file = Path.of(tokens[2]),
+                        paths = tokens.drop(2).map { Path.of(it) },
+                        onActiveEngine = { activeEngineRef.set(it) },
                     )
+                    lastExit = result.toExitCode()
+                }
+                "retry" -> {
+                    if (tokens.size < 2) {
+                        echo("usage: retry <peer-name>")
+                        continue
+                    }
+                    val result = handleRetry(
+                        engineRegistry = container.peerTransferEngineRegistry,
+                        peers = discovery.discoveredDevices.value,
+                        peerName = tokens[1],
+                        onActiveEngine = { activeEngineRef.set(it) },
+                    )
+                    lastExit = result.toExitCode()
                 }
                 "quit" -> running = false
-                else -> echo("unknown command: '${tokens[0]}'. Available: send, list, name, quit.")
+                else -> echo("unknown command: '${tokens[0]}'. Available: send, retry, list, name, quit.")
             }
         }
-        System.exit(0)
+        throw ProgramResult(lastExit)
     }
+}
+
+private fun buildCliBatchSender(
+    peer: PeerIdentity,
+    containerRef: AtomicReference<DesktopAppContainer?>,
+): BatchSender {
+    // Factory is called after containerRef.set(container) — safe to require non-null.
+    val container = requireNotNull(containerRef.get())
+    val fileClient = container.fileClient
+    val connectionMonitor = container.connectionMonitor
+    return BatchSender(
+        sendOne = { source, onProgress ->
+            val device = container.discoveredDevicesStore.devices.value
+                .firstOrNull { it.toPeerIdentity() == peer }
+                ?: throw PeerUnreachableException()
+            // FileClient.send swallows all exceptions into SendResult.Failure — map to typed exceptions.
+            when (
+                val result = fileClient.send(
+                    device,
+                    source.openReadChannel(),
+                    source.name,
+                    source.sizeBytes,
+                    onProgress,
+                )
+            ) {
+                is SendResult.Success -> Unit
+                is SendResult.Failure -> throw PeerUnreachableException(RuntimeException(result.reason))
+            }
+        },
+        connectionMonitor = connectionMonitor,
+    )
+}
+
+suspend fun handleSend(
+    engineRegistry: PeerTransferEngineRegistry,
+    peers: List<Device>,
+    peerName: String,
+    paths: List<Path>,
+    output: (String) -> Unit = ::println,
+    errorOutput: (String) -> Unit = System.err::println,
+    onActiveEngine: (PeerTransferEngine?) -> Unit = {},
+): CliBatchResult {
+    val matching = peers.filter { it.name == peerName }
+    if (matching.isEmpty()) {
+        output("[send] ERROR: peer '$peerName' not found. Use 'list' to see known peers.")
+        return CliBatchResult.Failed
+    }
+    if (matching.size > 1) {
+        errorOutput("WARN: multiple peers named '$peerName', using first")
+    }
+    val peer = matching.first()
+
+    val missing = paths.filter { !it.exists() }
+    if (missing.isNotEmpty()) {
+        missing.forEach { output("[send] ERROR: file not found: $it") }
+        return CliBatchResult.Failed
+    }
+
+    val sources = paths.map { JvmPathFileSource(it) }
+    val engine = engineRegistry.engineFor(peer.toPeerIdentity())
+    onActiveEngine(engine)
+    return try {
+        runEngineAndRender(engine, sources, output, errorOutput) { engine.startOutbound(it) }
+    } finally {
+        onActiveEngine(null)
+    }
+}
+
+suspend fun handleRetry(
+    engineRegistry: PeerTransferEngineRegistry,
+    peers: List<Device>,
+    peerName: String,
+    output: (String) -> Unit = ::println,
+    errorOutput: (String) -> Unit = System.err::println,
+    onActiveEngine: (PeerTransferEngine?) -> Unit = {},
+): CliBatchResult {
+    val matching = peers.filter { it.name == peerName }
+    if (matching.isEmpty()) {
+        output("[retry] ERROR: peer '$peerName' not found. Use 'list' to see known peers.")
+        return CliBatchResult.Failed
+    }
+    if (matching.size > 1) {
+        errorOutput("WARN: multiple peers named '$peerName', using first")
+    }
+    val peer = matching.first()
+    val engine = engineRegistry.engineFor(peer.toPeerIdentity())
+
+    val stateBefore = engine.state.value
+    if (!stateBefore.isTerminal()) {
+        output("[retry] '$peerName' has no terminal state to retry from")
+        return CliBatchResult.AllSent
+    }
+
+    engine.onRetryOutbound()
+
+    val transitioned = withTimeoutOrNull(50.milliseconds) {
+        engine.state.filter { !it.isTerminal() }.first()
+    }
+    if (transitioned == null) {
+        output("[retry] nothing to retry on '$peerName'")
+        return CliBatchResult.AllSent
+    }
+
+    onActiveEngine(engine)
+    return try {
+        awaitAndRenderTerminal(engine, output, errorOutput)
+    } finally {
+        onActiveEngine(null)
+    }
+}
+
+private suspend fun runEngineAndRender(
+    engine: PeerTransferEngine,
+    sources: List<com.tubetoast.tether.transfer.FileSource>,
+    output: (String) -> Unit,
+    errorOutput: (String) -> Unit,
+    startFn: (List<com.tubetoast.tether.transfer.FileSource>) -> Unit,
+): CliBatchResult {
+    startFn(sources)
+    return collectUntilTerminal(engine, output, errorOutput)
+}
+
+private suspend fun awaitAndRenderTerminal(
+    engine: PeerTransferEngine,
+    output: (String) -> Unit,
+    errorOutput: (String) -> Unit,
+): CliBatchResult = collectUntilTerminal(engine, output, errorOutput)
+
+// Renders state transitions and returns only after the terminal state was rendered.
+// `state.first { terminal }` returning before the separate renderer observed the terminal would
+// drop the final "done/error/cancelled" line — this collapses both into one collector.
+private suspend fun collectUntilTerminal(
+    engine: PeerTransferEngine,
+    output: (String) -> Unit,
+    errorOutput: (String) -> Unit,
+): CliBatchResult {
+    val terminalSeen = CompletableDeferred<PeerTransferState>()
+    val rendererScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val rendererJob = rendererScope.launch {
+        var lastState: PeerTransferState? = null
+        engine.state.collect { state ->
+            renderStateTransition(lastState, state, output, errorOutput)
+            lastState = state
+            if (state.isTerminal()) terminalSeen.complete(state)
+        }
+    }
+    val terminal = terminalSeen.await()
+    rendererJob.cancel()
+    return terminalToResult(terminal)
+}
+
+private fun renderStateTransition(
+    prev: PeerTransferState?,
+    current: PeerTransferState,
+    output: (String) -> Unit,
+    @Suppress("UNUSED_PARAMETER") errorOutput: (String) -> Unit,
+) {
+    when (current) {
+        is PeerTransferState.Reconnecting -> {
+            output("[send] reconnecting… ${current.remainingSeconds}s remaining")
+        }
+        is PeerTransferState.ActiveOutbound.Sending -> {
+            val prevPerFile = (prev as? PeerTransferState.ActiveOutbound)?.perFile ?: emptyList()
+            current.perFile.forEachIndexed { i, status ->
+                val prevStatus = prevPerFile.getOrNull(i)
+                if (prevStatus == null || prevStatus::class != status::class) {
+                    output("[send] ${status.name}  ${status.label()}")
+                }
+            }
+        }
+        is PeerTransferState.Sent -> {
+            if (current.partialReason != null) {
+                output("[send] partial — ${current.sent}/${current.total} sent")
+            } else {
+                output("[send] done — ${current.sent}/${current.total} sent")
+            }
+        }
+        is PeerTransferState.Error -> {
+            output("[send] error — ${current.reason}")
+        }
+        is PeerTransferState.Cancelled -> {
+            output("[send] cancelled — ${current.sent} sent")
+        }
+        else -> Unit
+    }
+}
+
+private fun com.tubetoast.tether.transfer.PerFileStatus.label(): String = when (this) {
+    is com.tubetoast.tether.transfer.PerFileStatus.Queued -> "queued"
+    is com.tubetoast.tether.transfer.PerFileStatus.InProgress -> "in progress"
+    is com.tubetoast.tether.transfer.PerFileStatus.Done -> "done"
+    is com.tubetoast.tether.transfer.PerFileStatus.Failed -> "failed: $reason"
+}
+
+private fun terminalToResult(state: PeerTransferState): CliBatchResult = when (state) {
+    is PeerTransferState.Sent -> if (state.partialReason == null && state.sent == state.total) {
+        CliBatchResult.AllSent
+    } else {
+        CliBatchResult.Partial
+    }
+    is PeerTransferState.Error -> CliBatchResult.Failed
+    is PeerTransferState.Cancelled -> CliBatchResult.Cancelled
+    else -> CliBatchResult.Failed
 }
 
 suspend fun handleName(
@@ -152,61 +409,6 @@ suspend fun handleName(
         onSuccess = { name -> output("OK name=$name") },
         onFailure = { output("ERR ${it.message}") },
     )
-}
-
-suspend fun handleSend(
-    client: FileClient,
-    peers: List<Device>,
-    peerName: String,
-    file: Path,
-    output: (String) -> Unit = ::println,
-    errorOutput: (String) -> Unit = System.err::println,
-    progressOutput: (String) -> Unit = { text ->
-        print(text)
-        System.out.flush()
-    },
-) {
-    if (!file.exists()) {
-        output("[send] ERROR: file not found: $file")
-        return
-    }
-
-    val matching = peers.filter { it.name == peerName }
-    if (matching.isEmpty()) {
-        output("[send] ERROR: peer '$peerName' not found. Use 'list' to see known peers.")
-        return
-    }
-    if (matching.size > 1) {
-        errorOutput("WARN: multiple peers named '$peerName', using first")
-    }
-    val peer = matching.first()
-
-    val started = TimeSource.Monotonic.markNow()
-    var lastPrint = started
-    var lastBytes = 0L
-
-    val result = client.send(peer, file) { transferred, total ->
-        val now = TimeSource.Monotonic.markNow()
-        if ((now - lastPrint) >= 500.milliseconds) {
-            val intervalSec = (now - lastPrint).inWholeMilliseconds / 1000.0
-            val speed = if (intervalSec > 0) (transferred - lastBytes) / intervalSec else 0.0
-            val formattedTotal = total?.let { " / ${ByteFormatting.formatSize(it)}" } ?: ""
-            progressOutput(
-                "\r[send] ${ByteFormatting.formatSize(
-                    transferred,
-                )}$formattedTotal  (${ByteFormatting.formatSize(speed.toLong())}/s)   ",
-            )
-            lastPrint = now
-            lastBytes = transferred
-        }
-    }
-
-    progressOutput("\n")
-    val elapsed = started.elapsedNow()
-    when (result) {
-        is SendResult.Success -> output("[send] OK — ${elapsed.inWholeMilliseconds} ms  →  ${result.savedPath}")
-        is SendResult.Failure -> output("[send] FAIL: ${result.reason}")
-    }
 }
 
 fun parseTokens(line: String): List<String> {

--- a/composeApp/src/desktopCli/kotlin/com/tubetoast/tether/Main.kt
+++ b/composeApp/src/desktopCli/kotlin/com/tubetoast/tether/Main.kt
@@ -263,6 +263,10 @@ suspend fun handleSend(
 
     val sources = paths.map { JvmPathFileSource(it) }
     val engine = engineRegistry.engineFor(peer.toPeerIdentity())
+    // A fresh `send` discards any prior terminal state; without this the engine sits in
+    // Sent/Error/Cancelled and startOutbound silently no-ops. `retry` reads the terminal
+    // *before* this path runs and so is unaffected.
+    if (engine.state.value.isTerminal()) engine.onDismiss()
     onActiveEngine(engine)
     return try {
         runEngineAndRender(engine, sources, output, errorOutput) { engine.startOutbound(it) }

--- a/composeApp/src/desktopCli/kotlin/com/tubetoast/tether/Main.kt
+++ b/composeApp/src/desktopCli/kotlin/com/tubetoast/tether/Main.kt
@@ -129,9 +129,12 @@ class TetherCommand :
 
         val discovery = container.mdnsDiscovery
         var peersLinePrinted = false
+        var lastPeerIds: String? = null
         launch {
             discovery.discoveredDevices.collect { peers ->
                 val ids = if (peers.isEmpty()) "none" else peers.joinToString(", ") { it.id }
+                if (ids == lastPeerIds) return@collect
+                lastPeerIds = ids
                 if (peersLinePrinted) {
                     print("$ESC[1A\r$ESC[K[peers] $ids\n")
                 } else {

--- a/composeApp/src/desktopCli/kotlin/com/tubetoast/tether/Main.kt
+++ b/composeApp/src/desktopCli/kotlin/com/tubetoast/tether/Main.kt
@@ -6,14 +6,13 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.int
 import com.tubetoast.tether.config.DeviceNameStore
 import com.tubetoast.tether.config.EphemeralDeviceNamePersistence
+import com.tubetoast.tether.di.CliAppContainer
 import com.tubetoast.tether.di.DefaultDesktopAppConfig
-import com.tubetoast.tether.di.DesktopAppContainer
 import com.tubetoast.tether.discovery.DiscoveredDevicesStore
 import com.tubetoast.tether.logging.initTetherLogging
 import com.tubetoast.tether.logging.isDebugEnabled
 import com.tubetoast.tether.network.FileClient
 import com.tubetoast.tether.protocol.Device
-import com.tubetoast.tether.protocol.DeviceType
 import com.tubetoast.tether.protocol.SendResult
 import com.tubetoast.tether.transfer.BatchSender
 import com.tubetoast.tether.transfer.ConnectionMonitor
@@ -81,18 +80,8 @@ class TetherCommand :
 
         val activeEngineRef = AtomicReference<PeerTransferEngine?>(null)
 
-        lateinit var container: DesktopAppContainer
-        container = DesktopAppContainer(
+        val container = CliAppContainer(
             DefaultDesktopAppConfig(port = port ?: 0, namePersistenceOverride = EphemeralDeviceNamePersistence()),
-            ownDeviceType = DeviceType.Cli,
-            batchSenderFactoryOverride = { peer ->
-                buildCliBatchSender(
-                    peer = peer,
-                    fileClient = container.fileClient,
-                    connectionMonitor = container.connectionMonitor,
-                    discoveredDevicesStore = container.discoveredDevicesStore,
-                )
-            },
         )
 
         container.nameStore.init()
@@ -196,7 +185,7 @@ class TetherCommand :
     }
 }
 
-private fun buildCliBatchSender(
+internal fun buildCliBatchSender(
     peer: PeerIdentity,
     fileClient: FileClient,
     connectionMonitor: ConnectionMonitor,

--- a/composeApp/src/desktopCli/kotlin/com/tubetoast/tether/di/CliAppContainer.kt
+++ b/composeApp/src/desktopCli/kotlin/com/tubetoast/tether/di/CliAppContainer.kt
@@ -1,0 +1,22 @@
+package com.tubetoast.tether.di
+
+import com.tubetoast.tether.buildCliBatchSender
+import com.tubetoast.tether.protocol.DeviceType
+import com.tubetoast.tether.transfer.BatchSender
+import com.tubetoast.tether.transfer.PeerIdentity
+
+class CliAppContainer(
+    config: DesktopAppConfig,
+) : DesktopAppContainer(
+        config = config,
+        ownDeviceType = DeviceType.Cli,
+    ) {
+    override val batchSenderFactory: (PeerIdentity) -> BatchSender = { peer ->
+        buildCliBatchSender(
+            peer = peer,
+            fileClient = fileClient,
+            connectionMonitor = connectionMonitor,
+            discoveredDevicesStore = discoveredDevicesStore,
+        )
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/DesktopBackend.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/DesktopBackend.kt
@@ -71,9 +71,10 @@ internal suspend fun DesktopAppContainer.startBackendOrFail(): BackendHandle {
     }
 }
 
-internal fun registerShutdownHook(handle: BackendHandle) {
+internal fun registerShutdownHook(handle: BackendHandle, onCancel: () -> Unit = {}) {
     Runtime.getRuntime().addShutdownHook(
         Thread {
+            runCatching { onCancel() }
             val cleanup = Thread {
                 runCatching { handle.close() }.onFailure {
                     log.warn { "backend cleanup failed — ${it.message}" }

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/di/DesktopAppContainer.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/di/DesktopAppContainer.kt
@@ -10,15 +10,12 @@ import com.tubetoast.tether.discovery.MdnsDiscovery
 import com.tubetoast.tether.preferences.DefaultFileTransferPreferences
 import com.tubetoast.tether.preferences.FileTransferPreferences
 import com.tubetoast.tether.protocol.DeviceType
-import com.tubetoast.tether.transfer.BatchSender
-import com.tubetoast.tether.transfer.PeerIdentity
 import okio.Path.Companion.toPath
 import java.io.File
 
-class DesktopAppContainer(
+open class DesktopAppContainer(
     config: DesktopAppConfig,
     override val ownDeviceType: DeviceType = DeviceType.Desktop,
-    batchSenderFactoryOverride: ((PeerIdentity) -> BatchSender)? = null,
 ) : JvmAppContainer(config) {
     override val dataStore: DataStore<Preferences> = PreferenceDataStoreFactory.createWithPath {
         File(config.preferencesFilePath).also { it.parentFile?.mkdirs() }.absolutePath.toPath()
@@ -42,7 +39,4 @@ class DesktopAppContainer(
         defaultSaveLocation = File(System.getProperty("user.home"), "Downloads").absolutePath,
         saveLocationWritable = true,
     )
-    override val batchSenderFactory: (PeerIdentity) -> BatchSender by lazy {
-        batchSenderFactoryOverride ?: super.batchSenderFactory
-    }
 }

--- a/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/di/DesktopAppContainer.kt
+++ b/composeApp/src/desktopMain/kotlin/com/tubetoast/tether/di/DesktopAppContainer.kt
@@ -10,12 +10,15 @@ import com.tubetoast.tether.discovery.MdnsDiscovery
 import com.tubetoast.tether.preferences.DefaultFileTransferPreferences
 import com.tubetoast.tether.preferences.FileTransferPreferences
 import com.tubetoast.tether.protocol.DeviceType
+import com.tubetoast.tether.transfer.BatchSender
+import com.tubetoast.tether.transfer.PeerIdentity
 import okio.Path.Companion.toPath
 import java.io.File
 
 class DesktopAppContainer(
     config: DesktopAppConfig,
     override val ownDeviceType: DeviceType = DeviceType.Desktop,
+    batchSenderFactoryOverride: ((PeerIdentity) -> BatchSender)? = null,
 ) : JvmAppContainer(config) {
     override val dataStore: DataStore<Preferences> = PreferenceDataStoreFactory.createWithPath {
         File(config.preferencesFilePath).also { it.parentFile?.mkdirs() }.absolutePath.toPath()
@@ -39,4 +42,7 @@ class DesktopAppContainer(
         defaultSaveLocation = File(System.getProperty("user.home"), "Downloads").absolutePath,
         saveLocationWritable = true,
     )
+    override val batchSenderFactory: (PeerIdentity) -> BatchSender by lazy {
+        batchSenderFactoryOverride ?: super.batchSenderFactory
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/CliBatchResultExitCodeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/CliBatchResultExitCodeTest.kt
@@ -4,9 +4,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 /**
- * Pins the exit-code contract from issue #328's DoD (0=AllSent, 1=Partial, 2=Failed, 130=Cancelled)
- * so that future edits to the mapping fail here and require explicit re-confirmation against the
- * user-facing contract, not just a passing build.
+ * Pins the CLI's user-facing exit-code contract: 0=AllSent, 1=Partial, 2=Failed, 130=Cancelled.
+ * Any change to the mapping fails this test, requiring the author to verify the user-facing
+ * contract is intentionally updated.
  */
 class CliBatchResultExitCodeTest {
     @Test

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/CliBatchResultExitCodeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/CliBatchResultExitCodeTest.kt
@@ -3,6 +3,11 @@ package com.tubetoast.tether
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+/**
+ * Pins the exit-code contract from issue #328's DoD (0=AllSent, 1=Partial, 2=Failed, 130=Cancelled)
+ * so that future edits to the mapping fail here and require explicit re-confirmation against the
+ * user-facing contract, not just a passing build.
+ */
 class CliBatchResultExitCodeTest {
     @Test
     fun `AllSent maps to exit code 0`() = assertEquals(0, CliBatchResult.AllSent.toExitCode())

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/CliBatchResultExitCodeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/CliBatchResultExitCodeTest.kt
@@ -1,0 +1,18 @@
+package com.tubetoast.tether
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CliBatchResultExitCodeTest {
+    @Test
+    fun `AllSent maps to exit code 0`() = assertEquals(0, CliBatchResult.AllSent.toExitCode())
+
+    @Test
+    fun `Partial maps to exit code 1`() = assertEquals(1, CliBatchResult.Partial.toExitCode())
+
+    @Test
+    fun `Failed maps to exit code 2`() = assertEquals(2, CliBatchResult.Failed.toExitCode())
+
+    @Test
+    fun `Cancelled maps to exit code 130`() = assertEquals(130, CliBatchResult.Cancelled.toExitCode())
+}

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/CliSendTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/CliSendTest.kt
@@ -13,12 +13,17 @@ import com.tubetoast.tether.transfer.NoOpConnectionMonitor
 import com.tubetoast.tether.transfer.PeerTransferEngine
 import com.tubetoast.tether.transfer.PeerTransferEngineRegistry
 import com.tubetoast.tether.transfer.PeerUnreachableException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.io.File
 import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.io.path.writeBytes
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -74,17 +79,23 @@ class CliSendTest {
                     batchSenderFactory = {
                         BatchSender(
                             sendOne = { source, onProgress ->
-                                when (
-                                    val r = client.send(
-                                        target,
-                                        source.openReadChannel(),
-                                        source.name,
-                                        source.sizeBytes,
-                                        onProgress,
-                                    )
-                                ) {
-                                    is SendResult.Success -> Unit
-                                    is SendResult.Failure -> throw PeerUnreachableException(RuntimeException(r.reason))
+                                try {
+                                    when (
+                                        val r = client.send(
+                                            target,
+                                            source.openReadChannel(),
+                                            source.name,
+                                            source.sizeBytes,
+                                            onProgress,
+                                        )
+                                    ) {
+                                        is SendResult.Success -> Unit
+                                        is SendResult.Failure -> throw PeerUnreachableException(
+                                            RuntimeException(r.reason),
+                                        )
+                                    }
+                                } finally {
+                                    source.close()
                                 }
                             },
                             connectionMonitor = NoOpConnectionMonitor,
@@ -248,41 +259,29 @@ class CliSendTest {
 
     @Test
     fun `retry after partial sends only the failed file`() {
-        // Use one real file and one path that won't exist to force partial on first send.
         val realFile = Files.createTempFile("cli-retry-real", ".txt")
         realFile.writeBytes("real content".toByteArray())
-        val missingPath = Files.createTempDirectory("cli-retry-missing").resolve("missing.bin")
+        val realFile2 = Files.createTempFile("cli-retry-real2", ".txt")
+        realFile2.writeBytes("real content 2".toByteArray())
 
-        val messages = mutableListOf<String>()
+        val callCount = AtomicInteger(0)
+        val (partialRegistry, _) = buildPartialRegistry(device, fileClient, callCount, failOnCall = 2)
 
-        // First send — partial because missingPath doesn't exist
-        val firstResult = runBlocking {
-            handleSend(
-                engineRegistry = engineRegistry,
-                peers = listOf(device),
-                peerName = device.name,
-                paths = listOf(realFile, missingPath),
-                output = messages::add,
-            )
-        }
-
-        // The real file exists and the missing one is caught pre-engine — returns Failed (both paths validated up-front)
-        // Alternatively: partial only happens when the engine detects a missing file mid-flight.
-        // Since our handleSend validates all paths up-front and returns Failed early, we test retry
-        // from an Error terminal state: build a registry that fails one file inside the engine.
+        // First send — 2 files, second fails inside engine
         val partialMessages = mutableListOf<String>()
-        val partialRegistry = buildPartialRegistry(device, fileClient, failSecond = true)
         val partialResult = runBlocking {
             handleSend(
                 engineRegistry = partialRegistry,
                 peers = listOf(device),
                 peerName = device.name,
-                paths = listOf(realFile, realFile), // second will fail inside engine
+                paths = listOf(realFile, realFile2),
                 output = partialMessages::add,
             )
         }
+        // callCount == 2: both files attempted, second failed
+        assertEquals(2, callCount.get(), "Expected 2 send attempts on first batch: $callCount")
 
-        // After partial, retry
+        // After partial, retry — should attempt only the failed file (realFile2)
         val retryMessages = mutableListOf<String>()
         val retryResult = runBlocking {
             handleRetry(
@@ -293,17 +292,200 @@ class CliSendTest {
             )
         }
 
-        // Retry should have attempted — result may vary, but must not be a pre-flight error
-        assertFalse(
-            retryMessages.any { it.contains("nothing to retry") && retryMessages.size == 1 },
-            "Retry should attempt something: $retryMessages",
+        assertEquals(CliBatchResult.AllSent, retryResult, "Retry should complete successfully: $retryMessages")
+        // callCount == 3: first batch 2 calls + retry 1 call (only the failed file)
+        assertEquals(3, callCount.get(), "Retry should attempt only the 1 failed file, total calls=3: $callCount")
+
+        // Both files should be in downloads dir after retry
+        val downloads = tmpDir
+            .walk()
+            .filter { it.isFile }
+            .map { it.name }
+            .toSet()
+        assertTrue(
+            downloads.contains(realFile.fileName.toString()),
+            "realFile not in downloads after retry: $downloads",
+        )
+        assertTrue(
+            downloads.contains(realFile2.fileName.toString()),
+            "realFile2 not in downloads after retry: $downloads",
         )
 
         Files.deleteIfExists(realFile)
+        Files.deleteIfExists(realFile2)
     }
 
     @Test
-    fun `retry on peer with no terminal state reports nothing to retry`() {
+    fun `send returns Partial when one file fails mid-batch`() {
+        val file1 = Files.createTempFile("cli-partial-1", ".txt").also { it.writeBytes("data1".toByteArray()) }
+        val file2 = Files.createTempFile("cli-partial-2", ".txt").also { it.writeBytes("data2".toByteArray()) }
+
+        val callCount = AtomicInteger(0)
+        val (partialRegistry, _) = buildPartialRegistry(device, fileClient, callCount, failOnCall = 2)
+
+        val messages = mutableListOf<String>()
+        val result = runBlocking {
+            handleSend(
+                engineRegistry = partialRegistry,
+                peers = listOf(device),
+                peerName = device.name,
+                paths = listOf(file1, file2),
+                output = messages::add,
+            )
+        }
+
+        assertEquals(CliBatchResult.Partial, result, "Expected Partial but got: $result — $messages")
+        assertEquals(1, result.toExitCode(), "Partial exit code must be 1")
+
+        Files.deleteIfExists(file1)
+        Files.deleteIfExists(file2)
+    }
+
+    @Test
+    fun `send returns Cancelled when engine is cancelled mid-flight`() {
+        val file = Files.createTempFile("cli-cancel", ".txt").also { it.writeBytes("data".toByteArray()) }
+
+        var capturedEngine: PeerTransferEngine? = null
+        val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val cancelRegistry = PeerTransferEngineRegistry(
+            appScope = appScope,
+            engineFactory = { peer, engineScope ->
+                PeerTransferEngine(
+                    peer = peer,
+                    batchSenderFactory = {
+                        BatchSender(
+                            sendOne = { _, _ -> awaitCancellation() },
+                            connectionMonitor = NoOpConnectionMonitor,
+                        )
+                    },
+                    scope = engineScope,
+                    peerPreferencesStore = FakePeerPreferencesStore(),
+                )
+            },
+        )
+
+        val messages = mutableListOf<String>()
+        val result = runBlocking {
+            var sendResult: CliBatchResult? = null
+            val sendJob = launch {
+                sendResult = handleSend(
+                    engineRegistry = cancelRegistry,
+                    peers = listOf(device),
+                    peerName = device.name,
+                    paths = listOf(file),
+                    output = messages::add,
+                    onActiveEngine = { capturedEngine = it },
+                )
+            }
+            while (capturedEngine == null) delay(10)
+            delay(50)
+            capturedEngine!!.onCancel()
+            sendJob.join()
+            sendResult
+        }
+
+        assertEquals(CliBatchResult.Cancelled, result, "Expected Cancelled result")
+        assertEquals(130, CliBatchResult.Cancelled.toExitCode(), "Cancelled exit code must be 130")
+        assertTrue(
+            messages.any { it.contains("cancelled") },
+            "Expected cancelled message but got: $messages",
+        )
+
+        Files.deleteIfExists(file)
+    }
+
+    @Test
+    fun `collectUntilTerminal does not return prematurely on Reconnecting state`() {
+        val file = Files.createTempFile("cli-reconnect", ".txt").also { it.writeBytes("data".toByteArray()) }
+
+        // sendOne blocks on sendStarted until the test emits a drop; after reconnect it succeeds.
+        val sendStarted = CompletableDeferred<Unit>()
+        val dropFlow = kotlinx.coroutines.flow.MutableSharedFlow<com.tubetoast.tether.transfer.ConnectionDrop>(
+            extraBufferCapacity = 1,
+        )
+        val reconnectMonitor = object : com.tubetoast.tether.transfer.ConnectionMonitor {
+            override val drops = dropFlow
+
+            override suspend fun awaitReconnect(timeout: kotlin.time.Duration): Boolean = true
+        }
+
+        var sendCallCount = 0
+        val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val reconnectRegistry = PeerTransferEngineRegistry(
+            appScope = appScope,
+            engineFactory = { peer, engineScope ->
+                PeerTransferEngine(
+                    peer = peer,
+                    batchSenderFactory = {
+                        BatchSender(
+                            sendOne = { source, onProgress ->
+                                sendCallCount++
+                                if (sendCallCount == 1) {
+                                    // Signal that send is in flight, then block until drop cancels us
+                                    sendStarted.complete(Unit)
+                                    awaitCancellation()
+                                }
+                                try {
+                                    when (
+                                        val r = fileClient.send(
+                                            device,
+                                            source.openReadChannel(),
+                                            source.name,
+                                            source.sizeBytes,
+                                            onProgress,
+                                        )
+                                    ) {
+                                        is SendResult.Success -> Unit
+                                        is SendResult.Failure -> throw PeerUnreachableException(
+                                            RuntimeException(r.reason),
+                                        )
+                                    }
+                                } finally {
+                                    source.close()
+                                }
+                            },
+                            connectionMonitor = reconnectMonitor,
+                        )
+                    },
+                    scope = engineScope,
+                    peerPreferencesStore = FakePeerPreferencesStore(),
+                )
+            },
+        )
+
+        val messages = mutableListOf<String>()
+        runBlocking {
+            val sendJob = launch {
+                handleSend(
+                    engineRegistry = reconnectRegistry,
+                    peers = listOf(device),
+                    peerName = device.name,
+                    paths = listOf(file),
+                    output = messages::add,
+                )
+            }
+            // Wait until the first sendOne is blocking, then emit a drop
+            sendStarted.await()
+            dropFlow.emit(com.tubetoast.tether.transfer.ConnectionDrop)
+            sendJob.join()
+        }
+
+        // Reconnecting message must appear (non-terminal state was rendered, not skipped)
+        assertTrue(
+            messages.any { it.contains("reconnecting") },
+            "Expected reconnecting message but got: $messages",
+        )
+        // Terminal done message must also appear (collectUntilTerminal didn't return prematurely)
+        assertTrue(
+            messages.any { it.contains("done") },
+            "Expected done message after reconnect but got: $messages",
+        )
+
+        Files.deleteIfExists(file)
+    }
+
+    @Test
+    fun `retry on peer with no terminal state reports has no terminal state to retry from`() {
         val messages = mutableListOf<String>()
         val result = runBlocking {
             handleRetry(
@@ -314,22 +496,22 @@ class CliSendTest {
             )
         }
 
-        // Engine starts in Idle (non-terminal), so onRetryOutbound is a no-op and we report nothing
         assertTrue(
-            messages.any { it.contains("nothing to retry") || it.contains("no terminal state") },
-            "Expected nothing-to-retry but got: $messages",
+            messages.any { it.contains("has no terminal state to retry from") },
+            "Expected 'has no terminal state to retry from' but got: $messages",
         )
         assertEquals(CliBatchResult.AllSent, result)
     }
 
+    /** Returns a registry and the external call counter. `failOnCall` = which call number to throw on (1-based). */
     private fun buildPartialRegistry(
         target: Device,
         client: FileClient,
-        failSecond: Boolean,
-    ): PeerTransferEngineRegistry {
+        callCount: AtomicInteger,
+        failOnCall: Int,
+    ): Pair<PeerTransferEngineRegistry, AtomicInteger> {
         val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-        var callCount = 0
-        return PeerTransferEngineRegistry(
+        val registry = PeerTransferEngineRegistry(
             appScope = appScope,
             engineFactory = { peer, engineScope ->
                 PeerTransferEngine(
@@ -337,21 +519,27 @@ class CliSendTest {
                     batchSenderFactory = {
                         BatchSender(
                             sendOne = { source, onProgress ->
-                                callCount++
-                                if (failSecond && callCount % 2 == 0) {
-                                    throw PeerUnreachableException(RuntimeException("forced failure"))
+                                val n = callCount.incrementAndGet()
+                                if (n == failOnCall) {
+                                    throw PeerUnreachableException(RuntimeException("forced failure on call $n"))
                                 }
-                                when (
-                                    val r = client.send(
-                                        target,
-                                        source.openReadChannel(),
-                                        source.name,
-                                        source.sizeBytes,
-                                        onProgress,
-                                    )
-                                ) {
-                                    is SendResult.Success -> Unit
-                                    is SendResult.Failure -> throw PeerUnreachableException(RuntimeException(r.reason))
+                                try {
+                                    when (
+                                        val r = client.send(
+                                            target,
+                                            source.openReadChannel(),
+                                            source.name,
+                                            source.sizeBytes,
+                                            onProgress,
+                                        )
+                                    ) {
+                                        is SendResult.Success -> Unit
+                                        is SendResult.Failure -> throw PeerUnreachableException(
+                                            RuntimeException(r.reason),
+                                        )
+                                    }
+                                } finally {
+                                    source.close()
                                 }
                             },
                             connectionMonitor = NoOpConnectionMonitor,
@@ -362,5 +550,6 @@ class CliSendTest {
                 )
             },
         )
+        return registry to callCount
     }
 }

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/CliSendTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/CliSendTest.kt
@@ -166,6 +166,32 @@ class CliSendTest {
     }
 
     @Test
+    fun `consecutive sends on the same engine both transfer`() {
+        val first = Files.createTempFile("cli-seq-1", ".txt").also { it.writeBytes("first".toByteArray()) }
+        val second = Files.createTempFile("cli-seq-2", ".txt").also { it.writeBytes("second".toByteArray()) }
+
+        val firstResult = runBlocking {
+            handleSend(engineRegistry, listOf(device), device.name, listOf(first))
+        }
+        val secondResult = runBlocking {
+            handleSend(engineRegistry, listOf(device), device.name, listOf(second))
+        }
+
+        assertEquals(CliBatchResult.AllSent, firstResult)
+        assertEquals(CliBatchResult.AllSent, secondResult)
+        val landed = tmpDir
+            .walk()
+            .filter { it.isFile }
+            .map { it.name }
+            .toSet()
+        assertTrue(landed.contains(first.fileName.toString()), "first missing: $landed")
+        assertTrue(landed.contains(second.fileName.toString()), "second missing: $landed")
+
+        Files.deleteIfExists(first)
+        Files.deleteIfExists(second)
+    }
+
+    @Test
     fun `send reports Failed when peer not found`() {
         val file = Files.createTempFile("cli-no-peer", ".txt")
         file.writeBytes("data".toByteArray())

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/CliSendTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/CliSendTest.kt
@@ -496,12 +496,16 @@ class CliSendTest {
             sendJob.join()
         }
 
-        // Reconnecting message must appear (non-terminal state was rendered, not skipped)
-        assertTrue(
-            messages.any { it.contains("reconnecting") },
-            "Expected reconnecting message but got: $messages",
+        // Two sendOne invocations prove the engine traversed Reconnecting on its way back to
+        // Sending — directly evidences the reconnect path without depending on whether the
+        // renderer's StateFlow collector observed the transient Reconnecting emission (it may
+        // race past it on a busy scheduler).
+        assertEquals(
+            2,
+            sendCallCount,
+            "Expected 2 sendOne calls (first cancelled by drop, second after reconnect): $sendCallCount",
         )
-        // Terminal done message must also appear (collectUntilTerminal didn't return prematurely)
+        // Terminal done message must appear — collectUntilTerminal didn't return prematurely.
         assertTrue(
             messages.any { it.contains("done") },
             "Expected done message after reconnect but got: $messages",

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/CliSendTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/CliSendTest.kt
@@ -2,10 +2,20 @@ package com.tubetoast.tether
 
 import com.tubetoast.tether.network.FileClient
 import com.tubetoast.tether.network.FileServer
+import com.tubetoast.tether.preferences.FakePeerPreferencesStore
 import com.tubetoast.tether.preferences.TempDataStore
 import com.tubetoast.tether.protocol.Device
+import com.tubetoast.tether.protocol.SendResult
 import com.tubetoast.tether.security.DefaultTrustedDeviceStore
 import com.tubetoast.tether.security.DeviceKeyPair
+import com.tubetoast.tether.transfer.BatchSender
+import com.tubetoast.tether.transfer.NoOpConnectionMonitor
+import com.tubetoast.tether.transfer.PeerTransferEngine
+import com.tubetoast.tether.transfer.PeerTransferEngineRegistry
+import com.tubetoast.tether.transfer.PeerUnreachableException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.runBlocking
 import java.io.File
 import java.nio.file.Files
@@ -24,8 +34,9 @@ class CliSendTest {
     private lateinit var configDir: File
     private lateinit var tempStore: TempDataStore
     private lateinit var server: FileServer
-    private lateinit var client: FileClient
+    private lateinit var fileClient: FileClient
     private lateinit var device: Device
+    private lateinit var engineRegistry: PeerTransferEngineRegistry
 
     @BeforeTest
     fun setup() {
@@ -40,60 +51,126 @@ class CliSendTest {
         )
         val port = server.start()
         device = Device(name = "cli-test", host = "127.0.0.1", port = port)
-        client = FileClient.default()
+        fileClient = FileClient.default()
+        engineRegistry = buildRegistry(device, fileClient)
     }
 
     @AfterTest
     fun teardown() {
-        client.close()
+        fileClient.close()
         server.stop()
         tempStore.tearDown()
         tmpDir.deleteRecursively()
         configDir.deleteRecursively()
     }
 
+    private fun buildRegistry(target: Device, client: FileClient): PeerTransferEngineRegistry {
+        val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        return PeerTransferEngineRegistry(
+            appScope = appScope,
+            engineFactory = { peer, engineScope ->
+                PeerTransferEngine(
+                    peer = peer,
+                    batchSenderFactory = {
+                        BatchSender(
+                            sendOne = { source, onProgress ->
+                                when (
+                                    val r = client.send(
+                                        target,
+                                        source.openReadChannel(),
+                                        source.name,
+                                        source.sizeBytes,
+                                        onProgress,
+                                    )
+                                ) {
+                                    is SendResult.Success -> Unit
+                                    is SendResult.Failure -> throw PeerUnreachableException(RuntimeException(r.reason))
+                                }
+                            },
+                            connectionMonitor = NoOpConnectionMonitor,
+                        )
+                    },
+                    scope = engineScope,
+                    peerPreferencesStore = FakePeerPreferencesStore(),
+                )
+            },
+        )
+    }
+
     @Test
-    fun `send happy path transfers file and reports OK`() {
+    fun `send happy path transfers single file and reports AllSent`() {
         val content = "hello from cli test".toByteArray()
         val file = Files.createTempFile("cli-send", ".txt")
         file.writeBytes(content)
 
         val messages = mutableListOf<String>()
-        runBlocking {
+        val result = runBlocking {
             handleSend(
-                client = client,
+                engineRegistry = engineRegistry,
                 peers = listOf(device),
                 peerName = device.name,
-                file = file,
+                paths = listOf(file),
                 output = messages::add,
             )
         }
 
-        val ok = messages.firstOrNull { it.startsWith("[send] OK") }
-        assertTrue(ok != null, "Expected [send] OK but got: $messages")
-
-        val savedPath = ok.substringAfter("→").trim()
-        assertEquals(String(content), File(savedPath).readText())
+        assertEquals(CliBatchResult.AllSent, result)
+        val doneMsg = messages.firstOrNull { it.contains("done") }
+        assertTrue(doneMsg != null, "Expected done message but got: $messages")
 
         Files.deleteIfExists(file)
     }
 
     @Test
-    fun `send reports error when peer not found`() {
-        val file = Files.createTempFile("cli-no-peer", ".txt")
-        file.writeBytes("data".toByteArray())
+    fun `send happy path transfers multiple files and reports AllSent`() {
+        val file1 = Files.createTempFile("cli-batch-1", ".txt").also { it.writeBytes("file1 data".toByteArray()) }
+        val file2 = Files.createTempFile("cli-batch-2", ".txt").also { it.writeBytes("file2 data".toByteArray()) }
 
         val messages = mutableListOf<String>()
-        runBlocking {
+        val result = runBlocking {
             handleSend(
-                client = client,
-                peers = emptyList(),
-                peerName = "nonexistent",
-                file = file,
+                engineRegistry = engineRegistry,
+                peers = listOf(device),
+                peerName = device.name,
+                paths = listOf(file1, file2),
                 output = messages::add,
             )
         }
 
+        assertEquals(CliBatchResult.AllSent, result)
+        val done = messages.firstOrNull { it.contains("2/2") }
+        assertTrue(done != null, "Expected 2/2 done message but got: $messages")
+
+        // Verify both files landed in downloads dir
+        val downloads = tmpDir
+            .walk()
+            .filter { it.isFile }
+            .map { it.name }
+            .toSet()
+        assertTrue(downloads.contains(file1.fileName.toString()), "file1 not in downloads: $downloads")
+        assertTrue(downloads.contains(file2.fileName.toString()), "file2 not in downloads: $downloads")
+
+        Files.deleteIfExists(file1)
+        Files.deleteIfExists(file2)
+    }
+
+    @Test
+    fun `send reports Failed when peer not found`() {
+        val file = Files.createTempFile("cli-no-peer", ".txt")
+        file.writeBytes("data".toByteArray())
+
+        val messages = mutableListOf<String>()
+        val result = runBlocking {
+            handleSend(
+                engineRegistry = engineRegistry,
+                peers = emptyList(),
+                peerName = "nonexistent",
+                paths = listOf(file),
+                output = messages::add,
+            )
+        }
+
+        assertEquals(CliBatchResult.Failed, result)
         assertTrue(
             messages.any { it.contains("peer 'nonexistent' not found") },
             "Expected peer-not-found error but got: $messages",
@@ -103,49 +180,187 @@ class CliSendTest {
     }
 
     @Test
+    fun `send reports Failed when file does not exist`() {
+        val nonExistent = Files.createTempDirectory("cli-missing").resolve("no-such-file.bin")
+        val messages = mutableListOf<String>()
+        val result = runBlocking {
+            handleSend(
+                engineRegistry = engineRegistry,
+                peers = listOf(device),
+                peerName = device.name,
+                paths = listOf(nonExistent),
+                output = messages::add,
+            )
+        }
+
+        assertEquals(CliBatchResult.Failed, result)
+        assertTrue(
+            messages.any { it.contains("file not found") },
+            "Expected file-not-found error but got: $messages",
+        )
+    }
+
+    @Test
+    fun `send reports Failed when all paths are missing`() {
+        val missing1 = Files.createTempDirectory("cli-m1").resolve("nope1.bin")
+        val missing2 = Files.createTempDirectory("cli-m2").resolve("nope2.bin")
+
+        val messages = mutableListOf<String>()
+        val result = runBlocking {
+            handleSend(
+                engineRegistry = engineRegistry,
+                peers = listOf(device),
+                peerName = device.name,
+                paths = listOf(missing1, missing2),
+                output = messages::add,
+            )
+        }
+
+        assertEquals(CliBatchResult.Failed, result)
+        assertEquals(2, messages.count { it.contains("file not found") }, "Expected two not-found errors: $messages")
+    }
+
+    @Test
     fun `send warns and uses first when multiple peers share name`() {
-        val content = "dup-peer test".toByteArray()
         val file = Files.createTempFile("cli-dup", ".txt")
-        file.writeBytes(content)
+        file.writeBytes("dup-peer test".toByteArray())
 
         val duplicate = device.copy(host = "127.0.0.2")
         val errors = mutableListOf<String>()
         val messages = mutableListOf<String>()
-        runBlocking {
+        val result = runBlocking {
             handleSend(
-                client = client,
+                engineRegistry = engineRegistry,
                 peers = listOf(device, duplicate),
                 peerName = device.name,
-                file = file,
+                paths = listOf(file),
                 output = messages::add,
                 errorOutput = errors::add,
             )
         }
 
         assertTrue(errors.any { it.contains("multiple peers") }, "Expected WARN but got: $errors")
-        assertTrue(messages.any { it.startsWith("[send] OK") }, "Expected OK but got: $messages")
-        assertFalse(messages.any { it.startsWith("[send] FAIL") }, "Unexpected FAIL: $messages")
+        assertEquals(CliBatchResult.AllSent, result)
+        assertFalse(messages.any { it.contains("error") }, "Unexpected error: $messages")
 
         Files.deleteIfExists(file)
     }
 
     @Test
-    fun `send reports error when file does not exist`() {
-        val nonExistent = Files.createTempDirectory("cli-missing").resolve("no-such-file.bin")
+    fun `retry after partial sends only the failed file`() {
+        // Use one real file and one path that won't exist to force partial on first send.
+        val realFile = Files.createTempFile("cli-retry-real", ".txt")
+        realFile.writeBytes("real content".toByteArray())
+        val missingPath = Files.createTempDirectory("cli-retry-missing").resolve("missing.bin")
+
         val messages = mutableListOf<String>()
-        runBlocking {
+
+        // First send — partial because missingPath doesn't exist
+        val firstResult = runBlocking {
             handleSend(
-                client = client,
+                engineRegistry = engineRegistry,
                 peers = listOf(device),
                 peerName = device.name,
-                file = nonExistent,
+                paths = listOf(realFile, missingPath),
                 output = messages::add,
             )
         }
 
+        // The real file exists and the missing one is caught pre-engine — returns Failed (both paths validated up-front)
+        // Alternatively: partial only happens when the engine detects a missing file mid-flight.
+        // Since our handleSend validates all paths up-front and returns Failed early, we test retry
+        // from an Error terminal state: build a registry that fails one file inside the engine.
+        val partialMessages = mutableListOf<String>()
+        val partialRegistry = buildPartialRegistry(device, fileClient, failSecond = true)
+        val partialResult = runBlocking {
+            handleSend(
+                engineRegistry = partialRegistry,
+                peers = listOf(device),
+                peerName = device.name,
+                paths = listOf(realFile, realFile), // second will fail inside engine
+                output = partialMessages::add,
+            )
+        }
+
+        // After partial, retry
+        val retryMessages = mutableListOf<String>()
+        val retryResult = runBlocking {
+            handleRetry(
+                engineRegistry = partialRegistry,
+                peers = listOf(device),
+                peerName = device.name,
+                output = retryMessages::add,
+            )
+        }
+
+        // Retry should have attempted — result may vary, but must not be a pre-flight error
+        assertFalse(
+            retryMessages.any { it.contains("nothing to retry") && retryMessages.size == 1 },
+            "Retry should attempt something: $retryMessages",
+        )
+
+        Files.deleteIfExists(realFile)
+    }
+
+    @Test
+    fun `retry on peer with no terminal state reports nothing to retry`() {
+        val messages = mutableListOf<String>()
+        val result = runBlocking {
+            handleRetry(
+                engineRegistry = engineRegistry,
+                peers = listOf(device),
+                peerName = device.name,
+                output = messages::add,
+            )
+        }
+
+        // Engine starts in Idle (non-terminal), so onRetryOutbound is a no-op and we report nothing
         assertTrue(
-            messages.any { it.contains("file not found") },
-            "Expected file-not-found error but got: $messages",
+            messages.any { it.contains("nothing to retry") || it.contains("no terminal state") },
+            "Expected nothing-to-retry but got: $messages",
+        )
+        assertEquals(CliBatchResult.AllSent, result)
+    }
+
+    private fun buildPartialRegistry(
+        target: Device,
+        client: FileClient,
+        failSecond: Boolean,
+    ): PeerTransferEngineRegistry {
+        val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        var callCount = 0
+        return PeerTransferEngineRegistry(
+            appScope = appScope,
+            engineFactory = { peer, engineScope ->
+                PeerTransferEngine(
+                    peer = peer,
+                    batchSenderFactory = {
+                        BatchSender(
+                            sendOne = { source, onProgress ->
+                                callCount++
+                                if (failSecond && callCount % 2 == 0) {
+                                    throw PeerUnreachableException(RuntimeException("forced failure"))
+                                }
+                                when (
+                                    val r = client.send(
+                                        target,
+                                        source.openReadChannel(),
+                                        source.name,
+                                        source.sizeBytes,
+                                        onProgress,
+                                    )
+                                ) {
+                                    is SendResult.Success -> Unit
+                                    is SendResult.Failure -> throw PeerUnreachableException(RuntimeException(r.reason))
+                                }
+                            },
+                            connectionMonitor = NoOpConnectionMonitor,
+                        )
+                    },
+                    scope = engineScope,
+                    peerPreferencesStore = FakePeerPreferencesStore(),
+                )
+            },
         )
     }
 }

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/transfer/JvmPathFileSource.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/transfer/JvmPathFileSource.kt
@@ -1,6 +1,7 @@
 package com.tubetoast.tether.transfer
 
 import io.ktor.utils.io.jvm.javaio.toByteReadChannel
+import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.exists
@@ -13,11 +14,18 @@ class JvmPathFileSource(
     override val relativePath: String = name
     override val sizeBytes: Long? = if (path.exists()) Files.size(path) else null
 
+    private var openStream: InputStream? = null
+
     override suspend fun openReadChannel() = if (!path.exists()) {
         throw UnreadableSourceException(name)
     } else {
-        path.inputStream().toByteReadChannel()
+        val stream = path.inputStream()
+        openStream = stream
+        stream.toByteReadChannel()
     }
 
-    override fun close() = Unit
+    override fun close() {
+        openStream?.close()
+        openStream = null
+    }
 }

--- a/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/transfer/JvmPathFileSource.kt
+++ b/composeApp/src/jvmMain/kotlin/com/tubetoast/tether/transfer/JvmPathFileSource.kt
@@ -1,0 +1,23 @@
+package com.tubetoast.tether.transfer
+
+import io.ktor.utils.io.jvm.javaio.toByteReadChannel
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.inputStream
+
+class JvmPathFileSource(
+    private val path: Path,
+) : FileSource {
+    override val name: String = path.fileName.toString()
+    override val relativePath: String = name
+    override val sizeBytes: Long? = if (path.exists()) Files.size(path) else null
+
+    override suspend fun openReadChannel() = if (!path.exists()) {
+        throw UnreadableSourceException(name)
+    } else {
+        path.inputStream().toByteReadChannel()
+    }
+
+    override fun close() = Unit
+}

--- a/docs/engineering/dependency-injection.md
+++ b/docs/engineering/dependency-injection.md
@@ -15,6 +15,7 @@ AppContainer            (commonMain)
 ├── JvmAppContainer     (jvmMain)
 │   ├── AndroidAppContainer  (androidMain)
 │   └── DesktopAppContainer  (desktopMain — ships on Windows / Linux / macOS)
+│       └── CliAppContainer  (desktopCli — CLI runner, overrides batchSenderFactory)
 └── AppleAppContainer   (appleMain)
     └── IosAppContainer     (iosMain)
 ```
@@ -27,9 +28,9 @@ Concrete `*AppConfig` implementations are **named classes in their own files** (
 
 Each platform builds its container in its entry point and passes components down:
 
-- **Desktop** — two entry points, both build `DesktopAppContainer` via the shared helpers in `DesktopBackend.kt`:
-  - [`Main.kt`](../../composeApp/src/desktopCli/kotlin/com/tubetoast/tether/Main.kt) — CLI runner (`desktopCli` source set), launched via `./gradlew :composeApp:runDesktopCli` or `installCli` + `tether` wrapper. Clikt is only on this compilation's classpath.
-  - [`MainUi.kt`](../../composeApp/src/desktopMain/kotlin/com/tubetoast/tether/MainUi.kt) — Compose UI runner (`desktopMain` source set, default for `nativeDistributions` packaging), launched via `./gradlew :composeApp:run`.
+- **Desktop** — two entry points, each building its own container leaf:
+  - [`Main.kt`](../../composeApp/src/desktopCli/kotlin/com/tubetoast/tether/Main.kt) — CLI runner (`desktopCli` source set), builds `CliAppContainer`. Launched via `./gradlew :composeApp:runDesktopCli` or `installCli` + `tether` wrapper. Clikt is only on this compilation's classpath.
+  - [`MainUi.kt`](../../composeApp/src/desktopMain/kotlin/com/tubetoast/tether/MainUi.kt) — Compose UI runner (`desktopMain` source set, default for `nativeDistributions` packaging), builds `DesktopAppContainer`. Launched via `./gradlew :composeApp:run`.
 - **Android** ([`TetherApp`](../../composeApp/src/androidMain/kotlin/com/tubetoast/tether/TetherApp.kt)): builds `AndroidAppContainer` lazily in the `Application` subclass and exposes it via the [`AppContainerProvider`](../../composeApp/src/androidMain/kotlin/com/tubetoast/tether/di/AppContainerProvider.kt) interface. [`TetherForegroundService`](../../composeApp/src/androidMain/kotlin/com/tubetoast/tether/network/TetherForegroundService.kt) reads it via `(application as AppContainerProvider).container`.
 - **iOS** ([`MainViewController`](../../composeApp/src/iosMain/kotlin/com/tubetoast/tether/MainViewController.kt)): builds `IosAppContainer` outside the `ComposeUIViewController { ... }` lambda so the composable does not act as a composition root (see rule 5 below).
 - **macOS**: ships via Desktop JVM (see [`adr-macos-native-vs-jvm.md`](adr/adr-macos-native-vs-jvm.md)) — no separate entry point; uses the Desktop `MainUi.kt` runner.

--- a/docs/interview-prep-checklist.md
+++ b/docs/interview-prep-checklist.md
@@ -74,7 +74,7 @@
 ### Flow
 - [ ] Cold flow vs Hot flow — новый поток на каждого collector vs один общий
 - [x] `StateFlow` vs `SharedFlow` — replay, conflation, начальное значение
-- [ ] `StateFlow` под нагрузкой — механизм conflation, 100 collectors + 120 updates/sec
+- [x] `StateFlow` под нагрузкой — механизм conflation, 100 collectors + 120 updates/sec
 - [ ] `flatMapLatest` vs `flatMapMerge` vs `flatMapConcat` — параллелизм
 - [ ] `combine` vs `zip` — эмит при любом изменении vs ждёт пару
 - [ ] `debounce`, `throttleFirst` — поиск с задержкой


### PR DESCRIPTION
**What / why.** CLI now consumes the same `PeerTransferEngine` as the UI instead of orchestrating `FileClient.send` directly — bugfixes on one side propagate to the other. CLI gains per-file state visibility, retry, partial-outcome classification, and exit-code mapping (0/1/2/130) for free.

**👀 Sanity-check.**
- CLI exit-code mode is REPL-only by design (user decision): `lastExit` accumulates across `send`/`retry`; `quit` exits with it. One-shot subcommand mode deferred.
- `AppContainer.batchSenderFactory` widened to `(PeerIdentity) -> BatchSender`; engine still receives `() -> BatchSender` via partial application at the wiring site. Asymmetry deliberate — engine stays peer-agnostic.
- `DesktopAppContainer.batchSenderFactoryOverride` is CLI-only; UI default stays the throwing stub until sender-wiring for UI lands in sprint-11.
- `retry` "skip already-confirmed receipts" filter exists in the engine but the inbound `ReceiveEvent` source is empty until #195 lands; retry currently replays every failed file. Acceptable per issue scope, no CLI changes required when #195 wires real receipts.
- `FileClient.send` swallows exceptions into `SendResult.Failure`; the CLI's `sendOne` maps all failures to `PeerUnreachableException`. Loses distinction between receiver-write-failed and peer-unreachable; both lead to engine `Failed` outcome.
- Smoke not run on this branch — manual gate required before merge.

**Scope.**
- 📎 affected: `.claude/skills/smoke-test/SKILL.md` — updated for new `[send] done|partial|error` format, receiver-side file verification, multi-file + retry + exit-code rows.

Closes #328