### PR TITLE
retro from #343: doc invariants + bug-reproducer regression sweep

### DIFF
--- a/.claude/agents/bug-reproducer.md
+++ b/.claude/agents/bug-reproducer.md
@@ -24,6 +24,10 @@ Identify:
 
 ## Procedure
 
+### 0. Read recent history of the suspected area first
+
+Before reproducing and before any hypothesis work — `git log --oneline -20 -- <suspected-path>` for each file in the suspected area. Often one of the recent diffs is the cause, or rules out a whole branch of hypotheses by showing the code was untouched. After a rebase / merge main, narrow the range: `git log --oneline <prev-merge-base>..HEAD -- <path>`. The cost is one git command; the upside is short-circuiting hypothesis enumeration.
+
 ### 1. Reproduce
 
 Run the user's steps locally. Use `/smoke-test` blocks if the bug is in a smoke-covered path, or the manual scenario otherwise. Decide:

--- a/docs/engineering/testing.md
+++ b/docs/engineering/testing.md
@@ -14,6 +14,7 @@ A test lives in the most general source set across whose targets every reference
 - **One behaviour per test.** The test name describes the behaviour, not the implementation. Multiple asserts are fine when they describe the same behaviour from different angles; multiple behaviours in one test hide which one broke.
 - **Mental inversion.** Before submitting, invert the production code under test in your head — would the test fail? If not, the test is a tautology. A test that passes regardless of production logic is worse than no test: it manufactures false confidence.
 - **Isolation.** No shared mutable static state between tests. Each test sets up its own fixtures and runs independently under CI parallelism.
+- **State-machine units — exercise consecutive operations.** Classes that hold state between public calls (engine, registry, lifecycle-aware store) need at least one test that drives the main flow twice on the same instance. Per-test fresh fixtures cover only first-use; state-leakage bugs — terminal-state stuck, ack flags not reset, cached errors replayed — slip through unless a consecutive-operation test exists.
 
 ## Style
 


### PR DESCRIPTION
**What / why.** Retro on #328/#343 surfaced systemic gaps in the test discipline and the bug-investigation procedure. Both fixes are present-tense rules added to canonical docs.

- **`docs/engineering/testing.md`** — state-machine units (engine, registry, lifecycle-aware store) require a consecutive-operations test. The #328 stuck-engine bug (`PeerTransferEngine.startOutbound` silently no-ops on non-Idle state) escaped unit coverage because every test built a fresh registry; smoke caught it on the second send to the same peer.
- **`.claude/agents/bug-reproducer.md`** — step 0: `git log` on the suspected path is the first action in any root-cause investigation, not only after rebase. Often the recent diff is the cause, or rules out an entire branch of hypotheses by showing the code was untouched.

**👀 Sanity-check.** Two other gaps from the retro deliberately did not land here:
- DI hierarchy invariant (new \`AppContainer\` subclass must update the doc) — dropped as too pointwise.
- Sub-agents silently writing into parent checkout instead of active worktree — landed as #354 (PreToolUse hook), the right defense layer; soft prompts wouldn't reliably enforce.

Closes nothing.