### PR TITLE
#338: fix /progress file count in Открытые Локации

### DIFF
--- a/.claude/skills/progress/SKILL.md
+++ b/.claude/skills/progress/SKILL.md
@@ -29,7 +29,7 @@ Write all outputs to `/tmp/tether-progress-raw/` (create the dir first).
 
 3. **Issue dependencies.** For each issue where `issue_dependencies_summary.total_blocked_by > 0`, call `gh api 'repos/<owner>/<repo>/issues/<N>/dependencies/blocked_by'`. Collect results as `{ "<N>": [blocker_numbers] }`. Write to `blocked_by.json` (empty `{}` when none). The `addIssueDependency` GraphQL mutation does not exist in GitHub — use REST only.
 
-4. **LOC by source set.** For each source set in `assets/locations.json`, count lines in `.kt`/`.swift` files under `composeApp/src/<sourceSet>/`. Write to `loc.json` as `{ "<sourceSet>": <int> }`.
+4. **LOC by source set.** For each source set in `assets/locations.json`, count lines and files in `.kt`/`.swift` files under `composeApp/src/<sourceSet>/`. Write to `loc.json` as `{ "<sourceSet>": <int>, "<sourceSet>_files": <int> }` — both keys for every source set (0 when the directory does not exist).
 
 5. **Sprint cutoff.** `git log --diff-filter=A --follow --format='%aI' -- docs/sprints/sprint-01.md | tail -1`. Write the ISO date to `sprint_cutoff.txt`.
 

--- a/.claude/skills/progress/build.py
+++ b/.claude/skills/progress/build.py
@@ -570,7 +570,22 @@ def render_locations(loc: dict, locations_data: dict) -> str:
     cards_html = '<div class="locations">'
     for entry, lines in sorted_open:
         ss = _e(entry["source_set"])
-        files = loc.get(entry["source_set"] + "_files", "?")
+        files_raw = loc.get(entry["source_set"] + "_files")
+        if files_raw is None:
+            # Fallback: count files from the filesystem (composeApp/src/<sourceSet>/)
+            project_root = Path(__file__).parent.parent.parent.parent
+            src_path = project_root / "composeApp" / "src" / entry["source_set"]
+            if src_path.exists():
+                try:
+                    files_raw = sum(
+                        1 for p in src_path.rglob("*")
+                        if p.suffix in (".kt", ".swift") and p.is_file()
+                    )
+                except OSError:
+                    files_raw = "?"
+            else:
+                files_raw = "?"
+        files = files_raw
         cards_html += f"""<div class="loc">
   <div class="loc-name">{_e(entry["name"])}</div>
   <div class="loc-ss">{ss}</div>


### PR DESCRIPTION
## Summary

- `SKILL.md` step 4: collection instruction now specifies writing both `<sourceSet>` (LOC) and `<sourceSet>_files` (file count) into `loc.json`; previously only LOC was written, so every location card showed `?` for the number of files
- `build.py` `render_locations`: added filesystem fallback — when `_files` is absent from `loc.json` (stale cache from a prior run), the script counts `.kt`/`.swift` files directly from `composeApp/src/<sourceSet>/` instead of silently showing `?`

## Test plan

- [ ] Run `/progress` — Открытые Локации cards show real file counts (e.g. `commonMain`: 118 файлов)
- [ ] With old `loc.json` missing `_files` keys — fallback path kicks in, still shows correct counts
- [ ] Source set that doesn't exist on disk — shows `?`, not a crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)