### PR TITLE
#17: graceful mDNS deregister before CLI kill in smoke cleanup

### DIFF
--- a/.claude/skills/smoke-test/block-7-cleanup.sh
+++ b/.claude/skills/smoke-test/block-7-cleanup.sh
@@ -7,6 +7,11 @@ DOWNLOADS_B="${DOWNLOADS_B:-$HOME/Downloads/Tether}"
 
 set +e
 
+echo "quit" > /tmp/smoke-cliA-in 2>/dev/null || true
+echo "quit" > /tmp/smoke-cliB-in 2>/dev/null || true
+echo "quit" > /tmp/smoke-cliC-in 2>/dev/null || true
+sleep 2
+
 kill "$(cat /tmp/smoke-cliA.pid /tmp/smoke-cliB.pid /tmp/smoke-cliC.pid \
   /tmp/smoke-cliA-keeper.pid /tmp/smoke-cliB-keeper.pid /tmp/smoke-cliC-keeper.pid 2>/dev/null)" 2>/dev/null
 


### PR DESCRIPTION
## Summary

- Send `quit` to each CLI FIFO (`smoke-cliA-in`, `smoke-cliB-in`, `smoke-cliC-in`) before `kill`/`pkill` in `block-7-cleanup.sh`
- Add a 2-second sleep to let each CLI instance deregister its mDNS service cleanly
- `|| true` guards handle missing FIFOs safely

## Problem fixed

When the smoke cleanup killed CLI processes with SIGTERM without first sending `quit`, `mDNSResponder` retained the stale service record. On the next smoke run, the new instance detected a name conflict and renamed itself (`SmokeMacB → SmokeMacB (2)`), breaking the `send SmokeMacB` command in block-2.1.

## Test plan

- [ ] Run smoke test twice back-to-back — second run should not see `SmokeMacB (2)` or equivalent renamed peers
- [ ] Verify cleanup completes without errors when FIFOs don't exist (first-ever run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)