### PR TITLE
#346: fix smoke-test script bugs introduced by SKILL.md extraction

### DIFF
--- a/.claude/skills/smoke-test/block-0-preparation.sh
+++ b/.claude/skills/smoke-test/block-0-preparation.sh
@@ -11,7 +11,7 @@ cd "$(git rev-parse --show-toplevel)"
 
 ./gradlew :composeApp:cliJar -q
 
-JAR=$(ls composeApp/build/libs/tether-cli-*.jar composeApp/build/libs/tether-cli.jar 2>/dev/null | head -1)
+JAR=$(ls composeApp/build/libs/tether-cli-*.jar composeApp/build/libs/tether-cli.jar 2>/dev/null | head -1 || true)
 [ -z "$JAR" ] && { echo "FAIL: cli jar not found after build"; exit 1; }
 
 echo "JAR=$JAR"

--- a/.claude/skills/smoke-test/block-1-desktop-cli-a.sh
+++ b/.claude/skills/smoke-test/block-1-desktop-cli-a.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
-JAR="${JAR:-$(ls composeApp/build/libs/tether-cli-*.jar composeApp/build/libs/tether-cli.jar 2>/dev/null | head -1)}"
+JAR="${JAR:-$(ls composeApp/build/libs/tether-cli-*.jar composeApp/build/libs/tether-cli.jar 2>/dev/null | head -1 || true)}"
 [ -z "$JAR" ] && { echo "FAIL: cli jar not found — run block-0 first"; exit 1; }
 
 LOG_A=/tmp/smoke-cliA.log

--- a/.claude/skills/smoke-test/block-2.1-single-file-send.sh
+++ b/.claude/skills/smoke-test/block-2.1-single-file-send.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 LOG_A="${LOG_A:-/tmp/smoke-cliA.log}"
 DOWNLOADS_B="${DOWNLOADS_B:-$HOME/Downloads/Tether}"
 JAR="${JAR:-$(ls "$(git rev-parse --show-toplevel)"/composeApp/build/libs/tether-cli-*.jar \
-  "$(git rev-parse --show-toplevel)"/composeApp/build/libs/tether-cli.jar 2>/dev/null | head -1)}"
+  "$(git rev-parse --show-toplevel)"/composeApp/build/libs/tether-cli.jar 2>/dev/null | head -1 || true)}"
 
 LOG_B=/tmp/smoke-cliB.log
 rm -f /tmp/smoke-cliB-in

--- a/.claude/skills/smoke-test/block-2.2-multi-file-send.sh
+++ b/.claude/skills/smoke-test/block-2.2-multi-file-send.sh
@@ -12,14 +12,14 @@ M1="/tmp/smoke-multi-${TS}-1.txt"; echo "m1-$TS" > "$M1"
 M2="/tmp/smoke-multi-${TS}-2.txt"; echo "m2-$TS" > "$M2"
 M3="/tmp/smoke-multi-${TS}-3.txt"; echo "m3-$TS" > "$M3"
 
-set +e
-PREV_DONE=$(grep -cE "^\[send\] done" "$LOG_A" 2>/dev/null || echo 0)
-set -e
+PREV_DONE=$(grep -cE "^\[send\] done" "$LOG_A" 2>/dev/null || true)
+PREV_DONE=${PREV_DONE:-0}
 
 echo "send SmokeMacB $M1 $M2 $M3" > /tmp/smoke-cliA-in &
 
 for i in $(seq 1 20); do
-  set +e; NOW_DONE=$(grep -cE "^\[send\] done" "$LOG_A" 2>/dev/null || echo 0); set -e
+  NOW_DONE=$(grep -cE "^\[send\] done" "$LOG_A" 2>/dev/null || true)
+  NOW_DONE=${NOW_DONE:-0}
   [ "$NOW_DONE" -gt "$PREV_DONE" ] && break
   sleep 1
 done

--- a/.claude/skills/smoke-test/block-2.3-retry.sh
+++ b/.claude/skills/smoke-test/block-2.3-retry.sh
@@ -10,22 +10,34 @@ DOWNLOADS_B="${DOWNLOADS_B:-$HOME/Downloads/Tether}"
 JAR="${JAR:-$(ls "$(git rev-parse --show-toplevel)"/composeApp/build/libs/tether-cli-*.jar \
   "$(git rev-parse --show-toplevel)"/composeApp/build/libs/tether-cli.jar 2>/dev/null | head -1)}"
 
-# Stop B to trigger an error on send.
+# Stop B and immediately send — A's registry still holds the stale peer entry, so the
+# engine begins a transfer that fails mid-flight (connection refused) instead of erroring
+# synchronously with "peer not found". The latter is unretryable: no engine state was created.
 set +e; kill "$(cat /tmp/smoke-cliB.pid 2>/dev/null)" 2>/dev/null; set -e
-sleep 2
 
 RETRY_NAME="smoke-retry-$(date +%s).txt"
 RETRY_SRC="/tmp/$RETRY_NAME"
 echo "retry-payload-$(date +%s)" > "$RETRY_SRC"
 
-set +e; PREV_ERR=$(grep -cE "^\[send\] error" "$LOG_A" 2>/dev/null || echo 0); set -e
+# CLI emits two error formats: `[send] error — <reason>` for transfer failures and
+# `[send] ERROR: peer 'X' not found.` for unknown peers (registry purge after mDNS evicts B).
+# Match both case-insensitively.
+PREV_ERR=$(grep -ciE "^\[send\] (error|ERROR)" "$LOG_A" 2>/dev/null || true)
+PREV_ERR=${PREV_ERR:-0}
 echo "send SmokeMacB $RETRY_SRC" > /tmp/smoke-cliA-in &
 
 for i in $(seq 1 15); do
-  set +e; NOW_ERR=$(grep -cE "^\[send\] error" "$LOG_A" 2>/dev/null || echo 0); set -e
+  NOW_ERR=$(grep -ciE "^\[send\] (error|ERROR)" "$LOG_A" 2>/dev/null || true)
+  NOW_ERR=${NOW_ERR:-0}
   [ "$NOW_ERR" -gt "$PREV_ERR" ] && break
   sleep 1
 done
+
+# Sample "hello from SmokeMacB" count BEFORE restart — any old [peers]/SmokeMacB line in
+# the log would falsely satisfy a static grep. Restart B, then wait for the count to grow,
+# which only happens once A's FileClient has actually shaken hands with the new B.
+PREV_HELLO=$(grep -cE "hello from SmokeMacB@" "$LOG_A" 2>/dev/null || true)
+PREV_HELLO=${PREV_HELLO:-0}
 
 # Restart B with the same name so the engine's PeerIdentity resolves again.
 nohup java -jar "$JAR" --name SmokeMacB --port 0 < /tmp/smoke-cliB-in > "$LOG_B" 2>&1 &
@@ -33,16 +45,19 @@ JPID_B=$!; disown $JPID_B
 echo $JPID_B > /tmp/smoke-cliB.pid
 
 for i in $(seq 1 30); do
-  set +e; grep -q 'SmokeMacB' "$LOG_A" 2>/dev/null; RC=$?; set -e
-  [ $RC -eq 0 ] && break
+  NOW_HELLO=$(grep -cE "hello from SmokeMacB@" "$LOG_A" 2>/dev/null || true)
+  NOW_HELLO=${NOW_HELLO:-0}
+  [ "$NOW_HELLO" -gt "$PREV_HELLO" ] && break
   sleep 1
 done
 
-set +e; PREV_DONE=$(grep -cE "^\[send\] done" "$LOG_A" 2>/dev/null || echo 0); set -e
+PREV_DONE=$(grep -cE "^\[send\] done" "$LOG_A" 2>/dev/null || true)
+PREV_DONE=${PREV_DONE:-0}
 echo "retry SmokeMacB" > /tmp/smoke-cliA-in &
 
 for i in $(seq 1 15); do
-  set +e; NOW_DONE=$(grep -cE "^\[send\] done" "$LOG_A" 2>/dev/null || echo 0); set -e
+  NOW_DONE=$(grep -cE "^\[send\] done" "$LOG_A" 2>/dev/null || true)
+  NOW_DONE=${NOW_DONE:-0}
   [ "$NOW_DONE" -gt "$PREV_DONE" ] && break
   sleep 1
 done

--- a/.claude/skills/smoke-test/block-2.3-retry.sh
+++ b/.claude/skills/smoke-test/block-2.3-retry.sh
@@ -8,7 +8,7 @@ LOG_A="${LOG_A:-/tmp/smoke-cliA.log}"
 LOG_B="${LOG_B:-/tmp/smoke-cliB.log}"
 DOWNLOADS_B="${DOWNLOADS_B:-$HOME/Downloads/Tether}"
 JAR="${JAR:-$(ls "$(git rev-parse --show-toplevel)"/composeApp/build/libs/tether-cli-*.jar \
-  "$(git rev-parse --show-toplevel)"/composeApp/build/libs/tether-cli.jar 2>/dev/null | head -1)}"
+  "$(git rev-parse --show-toplevel)"/composeApp/build/libs/tether-cli.jar 2>/dev/null | head -1 || true)}"
 
 # Stop B and immediately send — A's registry still holds the stale peer entry, so the
 # engine begins a transfer that fails mid-flight (connection refused) instead of erroring

--- a/.claude/skills/smoke-test/block-3-same-name-discovery.sh
+++ b/.claude/skills/smoke-test/block-3-same-name-discovery.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 LOG_A="${LOG_A:-/tmp/smoke-cliA.log}"
 LOG_B="${LOG_B:-/tmp/smoke-cliB.log}"
 JAR="${JAR:-$(ls "$(git rev-parse --show-toplevel)"/composeApp/build/libs/tether-cli-*.jar \
-  "$(git rev-parse --show-toplevel)"/composeApp/build/libs/tether-cli.jar 2>/dev/null | head -1)}"
+  "$(git rev-parse --show-toplevel)"/composeApp/build/libs/tether-cli.jar 2>/dev/null | head -1 || true)}"
 
 LOG_C=/tmp/smoke-cliC.log
 rm -f /tmp/smoke-cliC-in

--- a/.claude/skills/smoke-test/block-5-android.sh
+++ b/.claude/skills/smoke-test/block-5-android.sh
@@ -29,7 +29,7 @@ while [ "$(date +%s)" -lt "$DEADLINE" ]; do
 done
 NSD_READY_MS=$(python3 -c "import time; print(int(time.time() * 1000))")
 
-ANDROID_PORT=$(adb logcat -d 2>/dev/null | grep "FileServer started on port" | grep -oE '[0-9]+$' | tail -1)
+ANDROID_PORT=$(adb logcat -d 2>/dev/null | grep "FileServer started on port" | grep -oE 'port [0-9]+' | awk '{print $2}' | tail -1)
 echo "Android port: $ANDROID_PORT"
 
 ANDROID_IP=$(adb shell ip addr show wlan0 2>&1 | grep "inet " | awk '{print $2}' | cut -d/ -f1 | head -1)
@@ -71,10 +71,12 @@ else
   ANDROID_NAME_FILE="smoke-android-$(date +%s).txt"
   ANDROID_SRC="/tmp/$ANDROID_NAME_FILE"
   echo "send-to-android-$(date +%s)" > "$ANDROID_SRC"
-  set +e; PREV_DONE=$(grep -cE "^\[send\] done" "$LOG_A" 2>/dev/null || echo 0); set -e
+  PREV_DONE=$(grep -cE "^\[send\] done" "$LOG_A" 2>/dev/null || true)
+  PREV_DONE=${PREV_DONE:-0}
   echo "send $ANDROID_NAME $ANDROID_SRC" > /tmp/smoke-cliA-in &
   for i in $(seq 1 15); do
-    set +e; NOW_DONE=$(grep -cE "^\[send\] done" "$LOG_A" 2>/dev/null || echo 0); set -e
+    NOW_DONE=$(grep -cE "^\[send\] done" "$LOG_A" 2>/dev/null || true)
+    NOW_DONE=${NOW_DONE:-0}
     [ "$NOW_DONE" -gt "$PREV_DONE" ] && break
     sleep 1
   done


### PR DESCRIPTION
## Summary

Three classes of bugs introduced when 337c78e extracted the smoke logic from `SKILL.md` prose into separate `block-*.sh` files. Surfaced while running `/smoke-test` on the #346 branch — pulling out of #346 into its own PR since the fixes are independent of the fingerprint work.

- **`grep -c "pat" || echo 0` → "0\n0"**: `grep -c` on a readable file with zero matches prints `"0"` AND exits 1, so `|| echo 0` fires too. The resulting `"0\n0"` breaks every `[ -gt ]` arithmetic compare. Replaced with `|| true` plus `VAR=${VAR:-0}` in blocks 2.2 / 2.3 / 5. Same defect class as 92d9fa7's block-5.5 fix.

- **Block 5 Android port parse**: `grep -oE '[0-9]+$'` assumed the port was at end-of-line, but the FGService log line ends with `... downloads → /storage/.../Tether`. Switched to `grep -oE 'port [0-9]+' | awk '{print $2}'`.

- **Block 2.3 retry flow** (three fixes):
  - Dropped `sleep 2` after killing B — the sleep let A's mDNS evict B before the send fires, so the engine errored synchronously with `peer not found` instead of starting a retry-able transfer.
  - `grep -cE "^\[send\] error"` was case-sensitive; CLI emits `[send] ERROR:` (uppercase) for the unknown-peer path. Switched to `-iE`.
  - `grep -q 'SmokeMacB' "$LOG_A"` for rediscovery matched the stale `peer 'SmokeMacB' not found.` error line as a false positive. Replaced with a `hello from SmokeMacB@` count delta that only grows when A's FileClient actually shakes hands with the new B.

## Test plan

- [x] Block 5 Android (physical OPPO device): port parsed (42261), `/health` OK, cross-discovery 20 s (peer=CPH2653), send Desktop→Android byte-identical, force-stop OK
- [x] Block 2.1 single-file send: PASS
- [x] Block 2.2 multi-file send: PASS
- [ ] Block 2.3 retry: script-bug paths fixed; remaining FAIL is a product-level race in the user-issued `retry` command vs the engine's own Reconnecting→Sending auto-retry (covered by `CliSendTest`). Out of scope here — worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)