### PR TITLE
plan sprint 11: close sprint-10, compose sprint-11, allow plan-sprint commits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,11 +28,11 @@ Read on demand. Match what you're touching to the corresponding canon:
 
 ## Git conventions
 
-All git naming in English. **All commit messages and PR titles must start with the issue number:** `#<issue>: <message>` (e.g., `#42: add mDNS discovery for Android`). Retro commits and PRs use `retro from #<issue>: <message>`.
+All git naming in English. **All commit messages and PR titles must start with the issue number:** `#<issue>: <message>` (e.g., `#42: add mDNS discovery for Android`). Two prefixes stand in for an issue number where no backing issue is warranted: retro commits and PRs use `retro from #<issue>: <message>`; sprint-planning commits and PRs (close the previous sprint, compose the next — see [`docs/sprints/`](docs/sprints/)) use `plan sprint <N>: <message>`.
 
 All issue titles, issue bodies, and PR descriptions must be written in English. Russian is only permitted in interactive chat.
 
-Before committing, make sure the issue exists. If it does not — ask the user to create it.
+Before committing, make sure the issue exists. If it does not — ask the user to create it. Sprint-planning commits under `plan sprint <N>` are the exception: planning needs no backing issue.
 
 To pull main into the branch — `/pull-main` (merges fresh main and shows what came in). It runs from both `/close-issue` and mid-flight.
 

--- a/docs/sprints/sprint-10.md
+++ b/docs/sprints/sprint-10.md
@@ -4,16 +4,23 @@
 
 ## Состав
 
-| # | Issue | Название | Тип | Размер |
-| - | ----- | -------- | --- | ------ |
-| 1 | [#333](https://github.com/khmelevartem/tether/issues/333) | UX of share-sheet tap during active transfer | docs | S |
-| 2 | [#327](https://github.com/khmelevartem/tether/issues/327) | PeerTransferComponent.onCardClick молча роняет share-sheet payload при активной передаче | bugfix | S |
-| 3 | [#336](https://github.com/khmelevartem/tether/issues/336) | Atomic clear in PendingFilesRepository against pending overwrite race | refactor | S |
-| 4 | [#317](https://github.com/khmelevartem/tether/issues/317) | Apply v0 visual references to transfer UI | refactor | M |
-| 5 | [#321](https://github.com/khmelevartem/tether/issues/321) | Codify the UI → Presentation → Domain → Data layering scheme | docs | M |
-| 6 | [#116](https://github.com/khmelevartem/tether/issues/116) | Apple: настоящая EC P-256 пара ключей через Security framework + Keychain | enhancement | S |
-| 7 | [#10](https://github.com/khmelevartem/tether/issues/10) | Pairing — handshake, вычисление PIN-кода, CLI-флоу | feature | M |
-| 8 | [#328](https://github.com/khmelevartem/tether/issues/328) | Batch send + retry in CLI via PeerTransferEngine | feature | M |
+**Итог: 7/8 задач закрыто. Pairing handshake (#10) перенесён в следующий спринт — не готов.**
+
+| # | Issue | Название | Тип | Размер | Итог |
+| - | ----- | -------- | --- | ------ | ---- |
+| 1 | [#333](https://github.com/khmelevartem/tether/issues/333) | UX of share-sheet tap during active transfer | docs | S | ✅ закрыт ([PR #334](https://github.com/khmelevartem/tether/pull/334)) |
+| 2 | [#327](https://github.com/khmelevartem/tether/issues/327) | PeerTransferComponent.onCardClick молча роняет share-sheet payload при активной передаче | bugfix | S | ✅ закрыт ([PR #349](https://github.com/khmelevartem/tether/pull/349)) |
+| 3 | [#336](https://github.com/khmelevartem/tether/issues/336) | Atomic clear in PendingFilesRepository against pending overwrite race | refactor | S | ✅ закрыт ([PR #337](https://github.com/khmelevartem/tether/pull/337)) |
+| 4 | [#317](https://github.com/khmelevartem/tether/issues/317) | Apply v0 visual references to transfer UI | refactor | M | ✅ закрыт ([PR #360](https://github.com/khmelevartem/tether/pull/360)) |
+| 5 | [#321](https://github.com/khmelevartem/tether/issues/321) | Codify the UI → Presentation → Domain → Data layering scheme | docs | M | ✅ закрыт ([PR #356](https://github.com/khmelevartem/tether/pull/356)) |
+| 6 | [#116](https://github.com/khmelevartem/tether/issues/116) | Apple: настоящая EC P-256 пара ключей через Security framework + Keychain | enhancement | S | ✅ закрыт ([PR #351](https://github.com/khmelevartem/tether/pull/351)) |
+| 7 | [#10](https://github.com/khmelevartem/tether/issues/10) | Pairing — handshake, вычисление PIN-кода, CLI-флоу | feature | M | ❌ не сделан, перенесён в sprint-12 |
+| 8 | [#328](https://github.com/khmelevartem/tether/issues/328) | Batch send + retry in CLI via PeerTransferEngine | feature | M | ✅ закрыт ([PR #343](https://github.com/khmelevartem/tether/pull/343)) |
+
+## Дополнительные результаты
+
+- [#346](https://github.com/khmelevartem/tether/issues/346) ([PR #350](https://github.com/khmelevartem/tether/pull/350), [PR #366](https://github.com/khmelevartem/tether/pull/366)) — Ephemeral fingerprint для CLI: два экземпляра на одном хосте перестали глушить друг друга; smoke Block 2 стал проходимым. Побочно исправлены баги smoke-test скрипта после экстракции SKILL.md.
+- [PR #365](https://github.com/khmelevartem/tether/pull/365) ([#17](https://github.com/khmelevartem/tether/issues/17)) — Graceful mDNS deregister перед kill CLI в smoke-cleanup: устранён flake, при котором повторный запуск smoke видел зомби-запись от предыдущего процесса.
 
 ## Что разблокирует
 

--- a/docs/sprints/sprint-10.md
+++ b/docs/sprints/sprint-10.md
@@ -14,7 +14,7 @@
 | 4 | [#317](https://github.com/khmelevartem/tether/issues/317) | Apply v0 visual references to transfer UI | refactor | M | ✅ закрыт ([PR #360](https://github.com/khmelevartem/tether/pull/360)) |
 | 5 | [#321](https://github.com/khmelevartem/tether/issues/321) | Codify the UI → Presentation → Domain → Data layering scheme | docs | M | ✅ закрыт ([PR #356](https://github.com/khmelevartem/tether/pull/356)) |
 | 6 | [#116](https://github.com/khmelevartem/tether/issues/116) | Apple: настоящая EC P-256 пара ключей через Security framework + Keychain | enhancement | S | ✅ закрыт ([PR #351](https://github.com/khmelevartem/tether/pull/351)) |
-| 7 | [#10](https://github.com/khmelevartem/tether/issues/10) | Pairing — handshake, вычисление PIN-кода, CLI-флоу | feature | M | ❌ не сделан, перенесён в sprint-12 |
+| 7 | [#10](https://github.com/khmelevartem/tether/issues/10) | Pairing — handshake, вычисление PIN-кода, CLI-флоу | feature | M | ❌ не сделан, перенесён в sprint-11 |
 | 8 | [#328](https://github.com/khmelevartem/tether/issues/328) | Batch send + retry in CLI via PeerTransferEngine | feature | M | ✅ закрыт ([PR #343](https://github.com/khmelevartem/tether/pull/343)) |
 
 ## Дополнительные результаты

--- a/docs/sprints/sprint-11.md
+++ b/docs/sprints/sprint-11.md
@@ -1,0 +1,24 @@
+# Sprint 11 · Пепел и Железо
+
+**Направления:** CLI · smoke · Android sender
+
+## Состав
+
+| # | Issue | Название | Тип | Размер |
+| - | ----- | -------- | --- | ------ |
+| 1 | [#345](https://github.com/khmelevartem/tether/issues/345) | CLI: два экземпляра на одном хосте не видят друг друга | bugfix | S |
+| 2 | [#368](https://github.com/khmelevartem/tether/issues/368) | Same-named peers stay distinguishable in the peer list | bugfix | S |
+| 3 | [#352](https://github.com/khmelevartem/tether/issues/352) | Spaces in filenames arrive as '+' on receiver | bugfix | S |
+| 4 | [#348](https://github.com/khmelevartem/tether/issues/348) | CLI: design and apply a convenient log format | refactor | M |
+| 5 | [#192](https://github.com/khmelevartem/tether/issues/192) | Android sender wiring: SAF picker, share-sheet и MediaStore receiver | feature | M |
+
+## Что разблокирует
+
+- После #345 smoke Block 2 (Desktop↔Desktop send) проходит без внешнего Android-устройства — CI-smoke становится полностью автономным.
+- После #352 + #368 + #348 wire-протокол, peer-list и CLI-вывод доведены до production-качества: Android sender (#192) и следующие платформенные sender'ы (#193/#194) не наследуют известные баги, а smoke читается без шума.
+
+## Порядок мерджа
+
+#345 || #368 || #352 → #348 || #192
+
+`||` — параллельные ветки. #352 и #348 оба правят `FileClient.kt` — мержить последовательно. #345 (desktopCli fingerprint), #368 (hello handler) и #192 (androidMain) полностью изолированы от остальных.

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -144,7 +144,8 @@ echo "✅ Pre-push hook installed at $PUSH_HOOK_FILE"
 # that truncates COMMIT_EDITMSG.
 #
 # Fix: when the first meaningful line of COMMIT_EDITMSG does not match our
-# commit convention `#<N>: ...`, restore from `$GIT_DIR/rebase-merge/message`,
+# commit convention (`#<N>: …`, `retro from #<N>: …`, `plan sprint <N>: …`),
+# restore from `$GIT_DIR/rebase-merge/message`,
 # which git populates with the original commit message before invoking the editor.
 # ---------------------------------------------------------------------------
 PREPARE_HOOK_FILE="$HOOK_DIR/prepare-commit-msg"
@@ -163,8 +164,9 @@ REBASE_MSG="$GIT_DIR/rebase-merge/message"
 # Our commit subjects start with "#<digits>:" and survive this filter.
 FIRST_LINE=$(grep -vE '^#([[:space:]]|$)' "$COMMIT_MSG_FILE" | grep -v '^[[:space:]]*$' | head -1)
 
-# Restore unless the first meaningful line already matches `#<N>: ...`.
-if ! echo "$FIRST_LINE" | grep -qE '^#[0-9]+:'; then
+# Restore unless the first meaningful line already matches a valid subject:
+# `#<N>: …`, `retro from #<N>: …`, or `plan sprint <N>: …` (see CLAUDE.md §Git conventions).
+if ! echo "$FIRST_LINE" | grep -qE '^(#[0-9]+|retro from #[0-9]+|plan sprint [0-9]+):'; then
   cp "$REBASE_MSG" "$COMMIT_MSG_FILE"
   echo "ℹ️  prepare-commit-msg: restored subject from rebase-merge/message" >&2
 fi
@@ -174,3 +176,35 @@ EOF
 
 chmod +x "$PREPARE_HOOK_FILE"
 echo "✅ prepare-commit-msg hook installed at $PREPARE_HOOK_FILE"
+
+# ---------------------------------------------------------------------------
+# commit-msg: enforce the subject convention after the editor closes.
+# Valid subjects (see CLAUDE.md §Git conventions):
+#   #<N>: …            retro from #<N>: …            plan sprint <N>: …
+# ---------------------------------------------------------------------------
+MSG_HOOK_FILE="$HOOK_DIR/commit-msg"
+
+cat > "$MSG_HOOK_FILE" << 'EOF'
+#!/bin/bash
+# commit-msg hook: enforce commit subject format
+
+COMMIT_MSG_FILE="$1"
+
+# Skip auto-generated merge / squash messages.
+COMMIT_SOURCE="$2"
+[ "$COMMIT_SOURCE" = "merge" ] || [ "$COMMIT_SOURCE" = "squash" ] && exit 0
+
+# Strip git template comments ("# " or bare "#") and blank lines, take the subject.
+SUBJECT=$(grep -vE '^#([[:space:]]|$)' "$COMMIT_MSG_FILE" | grep -v '^[[:space:]]*$' | head -1)
+
+if ! echo "$SUBJECT" | grep -qE '^(#[0-9]+:|retro from #[0-9]+:|plan sprint [0-9]+:)'; then
+  echo "❌  Commit subject must start with '#<N>: …', 'retro from #<N>: …', or 'plan sprint <N>: …'" >&2
+  echo "    Got: \"$SUBJECT\"" >&2
+  exit 1
+fi
+
+exit 0
+EOF
+
+chmod +x "$MSG_HOOK_FILE"
+echo "✅ commit-msg hook installed at $MSG_HOOK_FILE"


### PR DESCRIPTION
**What / why.** Closes sprint-10 by actuals and composes sprint-11 (CLI + smoke + Android sender). Sprint planning produces no backing issue, so this PR also adds a third commit/PR prefix — `plan sprint <N>:` — alongside `#<N>:` and `retro from #<N>:`. This PR itself is the first to use it.

**👀 Sanity-check.**
- No `Closes #N`: this is a planning PR by design — planning needs no backing issue (the rule this PR introduces). The template's `Closes #N` requirement does not apply to the `plan sprint <N>` track.
- The hard enforcer was an **untracked** `.git/hooks/commit-msg`, hand-installed long ago and never generated by `scripts/install-hooks.sh` (commit c0bcb19, despite its title, only added `prepare-commit-msg`). I brought the validator under the tracked installer so it's regenerable on a fresh clone — fixing drift, not just adding the prefix. `scripts/install-hooks.sh` was re-run locally so the live hook matches.
- sprint-11 composition mirrors the agreed focus: #345, #368, #352, #348 (CLI/smoke), #192 (Android sender). #10 deferred to a later sprint.

**Scope.**
- 📎 `CLAUDE.md` §Git conventions — new prefix documented
- 📎 `scripts/install-hooks.sh` — `commit-msg` validator now tracked; `commit-msg` + `prepare-commit-msg` regexes accept `plan sprint <N>:` (and `retro from`, which the restore regex previously missed)
- 📎 `docs/sprints/sprint-10.md` — closed by actuals; `docs/sprints/sprint-11.md` — new plan