### PR TITLE
#352: fix spaces in filenames arriving as '+' on receiver

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/tubetoast/tether/network/FileClient.kt
@@ -9,13 +9,13 @@ import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.HttpTimeoutConfig
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.content.OutgoingContent
 import io.ktor.http.contentType
+import io.ktor.http.encodeURLQueryComponent
 import io.ktor.http.isSuccess
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteChannel
@@ -142,7 +142,7 @@ open class FileClient(
         totalBytes: Long?,
     ): SendResult = try {
         val response = client.post("http://${device.host}:${device.port}/upload") {
-            parameter("name", fileName)
+            url.encodedParameters.append("name", fileName.encodeURLQueryComponent(encodeFull = true))
             setBody(channel.asOctetStreamContent(totalBytes))
         }
         log.debug { "response status ${response.status} for '$fileName' → ${device.host}:${device.port}" }

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/network/FilenameEncodingRoundTripTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/network/FilenameEncodingRoundTripTest.kt
@@ -1,0 +1,50 @@
+package com.tubetoast.tether.network
+
+import io.ktor.http.encodeURLQueryComponent
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FilenameEncodingRoundTripTest {
+    private fun roundTrip(filename: String): String? =
+        PathSanitization.sanitizeRelativePath(filename.encodeURLQueryComponent(encodeFull = true))
+
+    @Test
+    fun `space survives round-trip`() {
+        assertEquals("manual with space.txt", roundTrip("manual with space.txt"))
+    }
+
+    @Test
+    fun `hash survives round-trip`() {
+        assertEquals("file#name.txt", roundTrip("file#name.txt"))
+    }
+
+    @Test
+    fun `question mark survives round-trip`() {
+        assertEquals("file?name.txt", roundTrip("file?name.txt"))
+    }
+
+    @Test
+    fun `ampersand survives round-trip`() {
+        assertEquals("a&b.txt", roundTrip("a&b.txt"))
+    }
+
+    @Test
+    fun `equals sign survives round-trip`() {
+        assertEquals("k=v.txt", roundTrip("k=v.txt"))
+    }
+
+    @Test
+    fun `percent sign survives round-trip`() {
+        assertEquals("50%.txt", roundTrip("50%.txt"))
+    }
+
+    @Test
+    fun `mixed Latin and Cyrillic name survives round-trip`() {
+        assertEquals("report_Отчёт.pdf", roundTrip("report_Отчёт.pdf"))
+    }
+
+    @Test
+    fun `nested path with spaces survives round-trip`() {
+        assertEquals("My Folder/my file.txt", roundTrip("My Folder/my file.txt"))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/tubetoast/tether/network/PathSanitizationTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/tubetoast/tether/network/PathSanitizationTest.kt
@@ -129,4 +129,44 @@ class PathSanitizationTest {
         // %F0%9F%8F%96 → 🏖 (four-byte UTF-8 emoji)
         assertEquals("vacation/🏖.jpg", sanitize("vacation/%F0%9F%8F%96.jpg"))
     }
+
+    @Test
+    fun `percent-encoded space decodes to space`() {
+        assertEquals("manual with space.txt", sanitize("manual%20with%20space.txt"))
+    }
+
+    @Test
+    fun `percent-encoded hash decodes correctly`() {
+        assertEquals("file#name.txt", sanitize("file%23name.txt"))
+    }
+
+    @Test
+    fun `percent-encoded question mark decodes correctly`() {
+        assertEquals("file?name.txt", sanitize("file%3Fname.txt"))
+    }
+
+    @Test
+    fun `percent-encoded ampersand decodes correctly`() {
+        assertEquals("key&value.txt", sanitize("key%26value.txt"))
+    }
+
+    @Test
+    fun `percent-encoded equals decodes correctly`() {
+        assertEquals("key=value.txt", sanitize("key%3Dvalue.txt"))
+    }
+
+    @Test
+    fun `percent-encoded percent decodes correctly`() {
+        assertEquals("50%.txt", sanitize("50%25.txt"))
+    }
+
+    @Test
+    fun `plus literal in filename is preserved as-is`() {
+        assertEquals("a+b.txt", sanitize("a+b.txt"))
+    }
+
+    @Test
+    fun `mixed Latin and Cyrillic filename passes`() {
+        assertEquals("report_Отчёт.pdf", sanitize("report_%D0%9E%D1%82%D1%87%D1%91%D1%82.pdf"))
+    }
 }

--- a/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/network/FileClientTest.kt
+++ b/composeApp/src/desktopTest/kotlin/com/tubetoast/tether/network/FileClientTest.kt
@@ -220,6 +220,76 @@ class FileClientTest {
     }
 
     @Test
+    fun `send encodes spaces in filename as percent-20 not plus`() = runTest {
+        val capturedQuery = AtomicReference<String?>()
+        val client = mockClient { request ->
+            capturedQuery.set(request.url.encodedQuery)
+            val body = request.body as OutgoingContent.ReadChannelContent
+            val ch = body.readFrom()
+            val buf = ByteArray(8 * 1024)
+            while (!ch.isClosedForRead) ch.readAvailable(buf)
+            respond(
+                content = okResponse("/saved/manual with space.txt"),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val source = ByteChannel(autoFlush = true)
+        source.writeFully(ByteArray(4))
+        source.close()
+        try {
+            client.send(
+                device = device,
+                channel = source,
+                fileName = "manual with space.txt",
+                totalBytes = 4L,
+            )
+            val query = capturedQuery.get() ?: error("handler did not capture request")
+            assertTrue(
+                query.contains("name=manual%20with%20space") && !query.contains('+'),
+                "expected spaces encoded as %20 (not +) in query, got: $query",
+            )
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `send encodes hash in filename as percent-23`() = runTest {
+        val capturedQuery = AtomicReference<String?>()
+        val client = mockClient { request ->
+            capturedQuery.set(request.url.encodedQuery)
+            val body = request.body as OutgoingContent.ReadChannelContent
+            val ch = body.readFrom()
+            val buf = ByteArray(8 * 1024)
+            while (!ch.isClosedForRead) ch.readAvailable(buf)
+            respond(
+                content = okResponse("/saved/file#name.txt"),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val source = ByteChannel(autoFlush = true)
+        source.writeFully(ByteArray(4))
+        source.close()
+        try {
+            client.send(
+                device = device,
+                channel = source,
+                fileName = "file#name.txt",
+                totalBytes = 4L,
+            )
+            val query = capturedQuery.get() ?: error("handler did not capture request")
+            assertTrue(
+                query.contains("name=file%23name"),
+                "expected # encoded as %23 in query, got: $query",
+            )
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
     fun `send does not trip watchdog during cold-start before first byte is sent`() = runTest {
         val client = mockClient(noProgressTimeout = 500.milliseconds) {
             delay(Long.MAX_VALUE)

--- a/docs/engineering/file-transfer-wire.md
+++ b/docs/engineering/file-transfer-wire.md
@@ -10,7 +10,7 @@ A receiver, given a sequence of files belonging to one folder send, lands them o
 
 A single endpoint, `POST /upload`, carries every file transfer — flat or nested. Each file is one HTTP request. The sender supplies, per request:
 
-- The **relative POSIX path** of the file inside the send, in the `name` query parameter. For a flat single-file send this is the leaf name (`photo.jpg`); for a folder send it is the path within the chosen folder using `/` separators (`Vacation/2024/IMG_001.jpg`).
+- The **relative POSIX path** of the file inside the send, in the `name` query parameter. The value must be percent-encoded per RFC 3986. The receiver decodes `%XX` sequences before applying path safety checks; `+` is not treated as space on the receive path. For a flat single-file send this is the leaf name (`photo.jpg`); for a folder send it is the path within the chosen folder using `/` separators (`Vacation/2024/IMG_001.jpg`).
 - The **file bytes** as the raw request body (`application/octet-stream`), streamed — no buffering on either side.
 - `Content-Length` when the sender knows the size; absent for unbounded streams.
 
@@ -82,7 +82,7 @@ Responsibilities owned by the route handler, not the seam:
 For each, the reason it was rejected — short, because none was close.
 
 - **Dedicated `X-Tether-Relative-Path` HTTP header.** Adjacent in shape to the chosen design but introduces a parallel metadata channel for no gain — the existing `?name=` already carries filename metadata, widening its semantics to "relative path" is a one-word change in the contract description. Reduces wire-shape diversity to debug across four platforms.
-- **Path as URL segments (`POST /upload/{percent-encoded-path}`).** Forces every sender platform to percent-encode `/` inside the path, with per-platform encoding quirks (NSURLSession normalises path segments in ways that are hard to predict). Higher integration risk than query parameter for no expressive gain.
+- **Path as URL segments (`POST /upload/{percent-encoded-path}`).** Forces every sender platform to percent-encode `/` inside the path, with per-platform encoding quirks. Higher integration risk than query parameter for no expressive gain.
 - **`multipart/form-data` with a `relativePath` text part and a `file` binary part.** Standards-friendly but adds a multipart parser on the hot path of every file transfer, against the streaming-not-buffering invariant. Multipart parsing differences between the engines in play across `adr-network-stack.md` are exactly the kind of cross-platform surface this contract is trying to keep small.
 - **Custom framing inside the body (length-prefixed JSON header, then bytes).** Defeats curl- and Wireshark-level debuggability for no scope this doc covers. Listed for completeness — the rejection is the rule.
 

--- a/docs/interview-prep-checklist.md
+++ b/docs/interview-prep-checklist.md
@@ -191,7 +191,7 @@
 - [ ] `suspend` функции в iOS — Swift Export, `async/await` bridge
 
 ### Библиотеки
-- [ ] Ktor Client — multiplatform HTTP
+- [x] Ktor Client — multiplatform HTTP
 - [ ] SQLDelight — multiplatform database
 - [ ] Kotlinx.serialization — vs Gson/Moshi, почему KMP-friendly
 - [ ] Kotlinx.datetime, Kotlinx.coroutines multiplatform


### PR DESCRIPTION
**What / why.** `FileClient` was using Ktor's `parameter("name", fileName)` which encodes spaces as `+` (form-URL encoding). The server reads `rawQueryParameters["name"]` which does not decode `+` as space, so `manual with space.txt` landed as `manual+with+space.txt`. Fix: encode the query value with `encodeURLQueryComponent(encodeFull = true)` via `url.encodedParameters.append`, which uses `%XX` for all reserved characters.

**👀 Sanity-check.**
- Android runtime (Desktop → Android send with a space in the filename) — not verified in smoke; code path is identical to Desktop (same `commonMain` `FileClient`).
- Smoke 🟡: retry / same-name-discovery / rename blocks failed due to accumulated CLI state from rerunning block-2.3 — pre-existing flakiness, unrelated to this change. Single-file and multi-file send both passed byte-identical.

Closes #352