### PR TITLE
plan sprint 11: add #10 (pairing CLI flow) to sprint composition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ captures
 node_modules/
 .claude/scheduled_tasks.lock
 scripts/.run-all/
+.obsidian

--- a/docs/sprints/sprint-11.md
+++ b/docs/sprints/sprint-11.md
@@ -1,6 +1,6 @@
 # Sprint 11 · Пепел и Железо
 
-**Направления:** CLI · smoke · Android sender
+**Направления:** CLI · smoke · Android sender · pairing
 
 ## Состав
 
@@ -11,14 +11,16 @@
 | 3 | [#352](https://github.com/khmelevartem/tether/issues/352) | Spaces in filenames arrive as '+' on receiver | bugfix | S |
 | 4 | [#348](https://github.com/khmelevartem/tether/issues/348) | CLI: design and apply a convenient log format | refactor | M |
 | 5 | [#192](https://github.com/khmelevartem/tether/issues/192) | Android sender wiring: SAF picker, share-sheet и MediaStore receiver | feature | M |
+| 6 | [#10](https://github.com/khmelevartem/tether/issues/10) | Паринг — handshake, вычисление PIN-кода, CLI-флоу | feature | M |
 
 ## Что разблокирует
 
 - После #345 smoke Block 2 (Desktop↔Desktop send) проходит без внешнего Android-устройства — CI-smoke становится полностью автономным.
 - После #352 + #368 + #348 wire-протокол, peer-list и CLI-вывод доведены до production-качества: Android sender (#192) и следующие платформенные sender'ы (#193/#194) не наследуют известные баги, а smoke читается без шума.
+- После #10 паринг становится сквозным E2E-флоу на CLI: Android UI подтверждения (#6c) и мобильные платформы могут опираться на готовый commonMain-контракт.
 
 ## Порядок мерджа
 
-#345 || #368 || #352 → #348 || #192
+#345 || #368 || #352 → #348 || #192 || #10
 
-`||` — параллельные ветки. #352 и #348 оба правят `FileClient.kt` — мержить последовательно. #345 (desktopCli fingerprint), #368 (hello handler) и #192 (androidMain) полностью изолированы от остальных.
+`||` — параллельные ветки. #352 и #348 оба правят `FileClient.kt` — мержить последовательно. #345 (desktopCli fingerprint), #368 (hello handler), #192 (androidMain) и #10 (pairing commonMain + jvmMain) полностью изолированы от остальных.


### PR DESCRIPTION
Добавлена задача [#10](https://github.com/khmelevartem/tether/issues/10) «Паринг — handshake, вычисление PIN-кода, CLI-флоу» в состав спринта 11.

Блокеры #9 и #52 закрыты — задача готова к реализации.

- Добавлена строка в таблицу состава
- Добавлен bullet в «Что разблокирует»
- Обновлён порядок мерджа (#10 изолирован, параллельная ветка)
- Добавлено направление `pairing` в теги

🤖 Generated with [Claude Code](https://claude.com/claude-code)