### PR TITLE
retro from #377: document test-determinism rules and add review-tests check

### DIFF
--- a/.claude/agents/review-tests.md
+++ b/.claude/agents/review-tests.md
@@ -78,6 +78,13 @@ feature ran. Flag as `[REQUIRED]`.
 
 When a component subscribes to a repository or flow and derives state from each emit, the test suite must cover every variation the source can produce — not only the happy path used at construction time. That means: empty / single / multiple shapes; both polarities of every boolean the emitted model carries; transitions across successive emits (presence flips, flag flips, mixed combinations). Missing a variation the source can legally emit is `[REQUIRED]` — without it a future enrichment of the source ships an untested code path on the consumer side.
 
+### 11. Test determinism — no escape from virtual time, no timer synchronization
+
+Per `testing.md §Real time vs virtual time`, flag as `[REQUIRED]`:
+- a test under `runTest` whose input or dispatcher runs on a real dispatcher — a real-I/O-backed source, an un-pinned engine — escaping virtual time and making timing-sensitive assertions race;
+- a real-thread integration test that synchronizes by a fixed delay ("wait long enough") instead of awaiting an observable condition (completion signal / state transition);
+- an assertion on a side-effect produced by another thread (a file the peer writes, a log line) where the operation's contract already implies it, or that polls for the side-effect to appear.
+
 ## What you do NOT check
 
 - AC coverage → review-dod

--- a/docs/engineering/testing.md
+++ b/docs/engineering/testing.md
@@ -27,6 +27,12 @@ A test lives in the most general source set across whose targets every reference
 
 - `Thread.sleep` and `System.currentTimeMillis`-polling are permissible **only** when waiting for events from external native APIs (JmDNS, NsdManager, etc.) that run on real threads outside our `CoroutineScope`. Everything else inside the test body uses virtual time.
 - `withTimeout` inside `runTest` uses **virtual** clocks even on `Dispatchers.IO` — do not rely on it as a real-time timeout.
+- Under `runTest`, the **inputs** must also live on the test scheduler, not only the unit under test. A source backed by real I/O — a file stream adapted into a channel — pumps its bytes on a real dispatcher and escapes virtual time even when the engine dispatcher is pinned, making timing-sensitive assertions race. Feed the unit an in-memory source produced inside the test scope instead.
+
+A test that genuinely runs on real threads (an integration suite around a real server/client) cannot use virtual time. It stays deterministic by two rules:
+
+- **Synchronize on an observable condition, not a timer.** Await a completion signal or a state transition the unit exposes; never advance by a fixed delay chosen to be "long enough" for the work to reach some point.
+- **Assert the contract, not a racy side-effect.** Check the operation's result and emitted events. A side-effect that another thread produces (a file the peer writes, a log line) lands at a moment the test does not control — assert it only where the contract does not already imply it, and never by polling for it to appear.
 
 ## Apple targets
 


### PR DESCRIPTION
**What / why.** Retro on #377 (de-flaking CliSendTest/FileClientTest). The flakes recurred across many PRs because `testing.md` covered only the engine side of virtual time, and review had no explicit determinism check — so the anti-patterns were written and approved repeatedly.

- `testing.md` §Real time vs virtual time: inputs under `runTest` must also live on the test scheduler (a real-I/O-backed source escapes virtual time even with the engine dispatcher pinned); real-thread integration tests synchronize on an observable condition, not a fixed delay, and assert the contract rather than a racy cross-thread side-effect.
- `review-tests`: flags those three anti-patterns at review time.

**👀 Sanity-check.**
- CI-level flake detection (rerun/stress before merge) deliberately deferred to #380 — it has a real CI-cost tradeoff that's a design decision, not a doc edit.

Closes #375 is already merged; this is the retro follow-up.
