### PR TITLE
retro from #368: fork-then-verify gate before the review pipeline

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -92,6 +92,8 @@ Stop and wait for answers. Do NOT proceed to Step 4 with unanswered questions or
 
 After answers arrive, pick the option that satisfies the answered constraints. Re-verify any factual claim the user relied on. The converged design now exists as: **one chosen mechanism + the trade-offs it accepts + the alternatives it rejects with one-line reasons each**.
 
+If the chosen mechanism's correctness rests on an unverified assumption about platform or third-party-library runtime behaviour (callback timing, sync-vs-async delivery, ordering guarantees), do not pass it down as a tension for the coder to discover — flag it as a **verify-before-building** item. Validate it now via the authoritative source or a cheap throwaway probe, or hand it to the orchestrator's approach-fork empirical gate, so a full implementation cycle is never spent on an assumption a quick check would have falsified.
+
 If during convergence you realise the palette was incomplete or the answers reveal a constraint nobody saw at Step 1 — go back to Step 2 with the new constraint. Don't paper over.
 
 ### Step 5 — Decide artifact scope

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -173,6 +173,8 @@ Use the built-in `Plan` agent (or `general-purpose` if plan unavailable) to prod
 
 **Plan conflicts with guides.** If the plan conflicts with loaded engineering guides → present to user, stop. Otherwise, accept and continue.
 
+**Approach-fork empirical gate.** When the task forks into more than one viable implementation — bugfix fix-hypotheses, or any design choice with several candidate mechanisms — first weigh the options and converge on the most suitable one (via `architect` when the choice is non-trivial), then implement *that* candidate and **verify it at runtime under the conditions that distinguish the candidates** — notably each affected OS / platform — before spending the review → simplify → full-review pipeline on it. Only an empirically-confirmed approach earns that investment. Static review, including the adversarial pass, reasons about code in the abstract; an approach whose correctness rests on platform or third-party-library runtime behaviour must be *run* to be trusted, and running it early turns a wrong approach into a cheap pivot instead of a full implement-and-revert cycle. This pulls the runtime check (Step 7) forward for fork tasks; single-implementation tasks keep the default order — review first, runtime verification at Step 7.
+
 ## Step 4 — Inner loop: coder ↔ fast reviewers
 
 Per track (or sequentially if single track):


### PR DESCRIPTION
**What / why.** Retro on #368 (PR #379). That task spent a full implement → review → revert cycle on an approach whose load-bearing assumption — JmDNS surfaces its conflict-resolved name synchronously after `registerService` — was only disproven later, by empirical cross-platform (Windows) testing. The whole static-review pipeline (incl. adversarial) reasoned about it in the abstract; only running it on the affected OS settled it.

**Change.** Make "verify the chosen approach in practice before investing the review pipeline" an explicit workflow rule:
- `.claude/skills/implement/SKILL.md` — new **approach-fork empirical gate** in Step 3: when a task forks into several candidate implementations (bugfix hypotheses or any design fork), weigh the options, implement the most suitable, then verify it at runtime under the conditions that distinguish the candidates (esp. each affected OS/platform) **before** the review → simplify → full-review pipeline. Single-implementation tasks keep the default order.
- `.claude/agents/architect.md` — on convergence, a mechanism resting on an unverified platform/3rd-party runtime assumption is flagged **verify-before-building**, not passed down as a coder-discovered tension.

**👀 Sanity-check.**
- Minor canon divergence noticed (not fixed here): CLAUDE.md says retro PRs use `retro from #<issue>`, the `retro` skill says `retro from #<PR>`. Followed CLAUDE.md. Worth reconciling separately if it matters.

Closes #368 — no (already closed); this is a follow-up process change.
