### PR TITLE
retro from #192: no silently-throwing DI defaults, close-issue applies long-lived-artifacts

### DIFF
--- a/.claude/skills/close-issue/SKILL.md
+++ b/.claude/skills/close-issue/SKILL.md
@@ -108,6 +108,8 @@ Files to check:
 
 If the documentation is out of date — update it. Small edits do immediately, large ones — create a separate issue.
 
+**Apply the writing discipline.** Before writing or editing any long-lived artifact here, re-read [`long-lived-artifacts.md`](../../../docs/engineering/long-lived-artifacts.md) and apply it — do not write from memory.
+
 **Doc-as-spec on first implementation of an architectural sketch.** If the PR is the first real implementation of a pattern that was a sketch in `docs/engineering/` (marker: "skeleton lands in #N" or code examples without a working implementation) — the doc must be updated in the same PR. Otherwise, the next implementor will follow an outdated example.
 
 **New runtime flag — the entry-point doc must mention it.** If the PR introduces a new runtime flag (env var, JVM system property, CLI option, build flag) that affects observable application behavior — the README or the corresponding entry-point section must mention it with at least one line and a link to the engineering doc. Engineering doc as the only documentation location does not count as coverage: a contributor / user looks in the README, not in `docs/engineering/`.
@@ -129,6 +131,8 @@ Examples of such decisions:
 If such a decision exists and is not recorded anywhere — **before merging**, record it. A small decision — as a short entry in an existing doc. A large one — as a separate ADR or a new DOCS issue if the volume doesn't fit in the current PR.
 
 Do not let a decision live only in the chat: sessions are lost, and the next contributor (or yourself a month later) won't see the history and will reopen the same question.
+
+**Apply the writing discipline.** Before writing or editing any long-lived artifact while recording a decision (doc, ADR, KDoc, `.claude/**`), re-read [`long-lived-artifacts.md`](../../../docs/engineering/long-lived-artifacts.md) and apply it — do not write from memory.
 
 ---
 

--- a/docs/engineering/dependency-injection.md
+++ b/docs/engineering/dependency-injection.md
@@ -186,6 +186,10 @@ When you do need to test a class that depends on a collaborator, prefer a hand-r
 
 A container field is a named object that owns or manages something — a store, a server, a client, a scope, a factory. It is not a primitive, a string, a number, a collection, or any other plain data shape. Values like an identity, an alias, a port, a device-type tag belong to the component that owns them; consumers receive the owning component and ask it for the value at the moment they need it, including across an asynchronous boundary if the value is only known after I/O. Putting plain data on the container forces materialisation at construction time, hides who is responsible for the value, and turns the container into a property bag instead of a wiring graph.
 
+### 8. No silently-throwing common defaults
+
+When a container field needs a per-platform implementation, the common contract states that explicitly: the field is `abstract` on the common container so every platform leaf is forced to declare a value, or the leaves declare explicit stubs that throw with `TODO(#<tracking-issue>)` referencing the issue that implements the real value. A concrete common default that throws unconditionally and works only because one platform happens to override it is the worst of both shapes: it compiles, satisfies fake-based tests, and surfaces only at runtime on the platforms that forgot to override. The `abstract` form makes the gap a compile error; the explicit-stub form makes the gap a discoverable `TODO` with an owner.
+
 ## Testability
 
 The container is also the seam tests use to substitute fakes. Three levels of tests, three patterns:


### PR DESCRIPTION
Closes none — retro fixes from #383 / issue #192.

## Signals

**Signal 1 — silently-throwing common default surfaced as a runtime bug on GUI/Android.**
During #192 the common `AppContainer.batchSenderFactory` was a concrete default whose `sendOne` lambda threw `PeerUnreachableException` unconditionally, and only the CLI container overrode it. The codebase compiled, unit tests on fakes were green, smoke (CLI-only) was green — but every GUI/Android send threw "пир больше не доступен" because the GUI never overrode the default. Caught only by the user's on-device test mid-PR. This is a class of bug: a common contract that *looks* implemented but exists only on one platform.

**Signal 2 — `/close-issue` wrote a long-lived artifact without re-reading the discipline.**
During `/close-issue 192`, a doc edit on `file-transfer-wire.md` introduced a class name and platform API field names into prose — a direct §"Code does not belong in long-lived artifacts" violation. The skill's Step 4.2 (Update documentation) and Step 5 (Record decisions) never instructed the writer to apply `long-lived-artifacts.md` before writing.

## Changes

**`docs/engineering/dependency-injection.md`** — new Rule 8 "No silently-throwing common defaults": when a container field needs a per-platform implementation, the common contract states that explicitly — either the field is `abstract` in commonMain so every platform leaf must declare a value, or platform leaves carry explicit stubs that throw with `TODO(#<tracking-issue>)`. A concrete common default that throws unconditionally and works only because one platform happens to override it compiles, satisfies fake-based tests, and surfaces only at runtime.

**`.claude/skills/close-issue/SKILL.md`** — Steps 4.2 and 5 now carry a one-line directive: re-read `long-lived-artifacts.md` and apply it before writing any long-lived artifact. Link only, no rule-summary next to the link.

## What did NOT land here (deferred to existing tracker)

The folder-nesting test gap (sender violated documented wire contract; no automated test ever sent a source where `relativePath ≠ name`) — already covered by #347's "Tests" + "Smoke" DoD bullets. Posted a comment there sharpening the test expectations so the implementer of #347 doesn't have to re-derive the lesson.

## 👀 Sanity-check

- Doc + skill edits only; no runtime code touched.
- Considered a commit-time lint hook for the "code symbols in doc prose" rule but rejected it as false-positive-heavy on the existing corpus (legit backticked symbols in glossary / DI docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)