### PR TITLE
#392: /progress — hide completed quest-map tasks + extract collect.py

### DIFF
--- a/.claude/skills/progress/SKILL.md
+++ b/.claude/skills/progress/SKILL.md
@@ -19,19 +19,21 @@ Fixed dictionaries and palette are in `assets/`. No names, keywords, or colours 
 
 ## What to collect (raw data)
 
-Write all outputs to `/tmp/tether-progress-raw/` (create the dir first).
+Run `collect.py` — it resolves `owner/repo` from `gh repo view` and writes every input `build.py` consumes:
 
-1. **PR statistics via GraphQL.** One paginated `gh api graphql` request over `repository.pullRequests`. Required fields per node: `number, title, state, createdAt, mergedAt, additions, deletions, changedFiles, commits { totalCount nodes { commit { committedDate } } }, comments { totalCount }, reviews { totalCount }, reviewThreads { totalCount }`. Nodes must be sorted ascending by date; only the first node is used for cycleHours. Write to `prs.json`.
+```
+python3 .claude/skills/progress/collect.py --raw-data /tmp/tether-progress-raw --repo-root .
+```
 
-   The REST list endpoint (`/pulls`) does not return commits/comments/review_threads — GraphQL is required.
+Outputs into `--raw-data`: `prs.json`, `issues.json`, `blocked_by.json`, `loc.json`, `sprint_cutoff.txt`. Do not hand-roll these in chat — edit `collect.py` if collection needs to change.
 
-2. **Issues.** `gh api 'repos/<owner>/<repo>/issues?state=all&per_page=100' --paginate` — needed for `parent_issue_url` and `issue_dependencies_summary`. Filter out objects that contain a `pull_request` key. Write to `issues.json`.
+What it gathers, and the quirks baked into the script:
 
-3. **Issue dependencies.** For each issue where `issue_dependencies_summary.total_blocked_by > 0`, call `gh api 'repos/<owner>/<repo>/issues/<N>/dependencies/blocked_by'`. Collect results as `{ "<N>": [blocker_numbers] }`. Write to `blocked_by.json` (empty `{}` when none). The `addIssueDependency` GraphQL mutation does not exist in GitHub — use REST only.
-
-4. **LOC by source set.** For each source set in `assets/locations.json`, count lines and files in `.kt`/`.swift` files under `composeApp/src/<sourceSet>/`. Write to `loc.json` as `{ "<sourceSet>": <int>, "<sourceSet>_files": <int> }` — both keys for every source set (0 when the directory does not exist).
-
-5. **Sprint cutoff.** `git log --diff-filter=A --follow --format='%aI' -- docs/sprints/sprint-01.md | tail -1`. Write the ISO date to `sprint_cutoff.txt`.
+1. **PR statistics via GraphQL** → `prs.json`. Paginated over `repository.pullRequests`, sorted ascending by date (only the first commit node feeds cycleHours). Fields: `number, title, state, createdAt, mergedAt, additions, deletions, changedFiles, commits { totalCount nodes { commit { committedDate } } }, comments { totalCount }, reviews { totalCount }, reviewThreads { totalCount }`. The REST `/pulls` list endpoint omits commits/comments/review_threads — GraphQL is required.
+2. **Issues** → `issues.json`. `--paginate --slurp` over `repos/<owner>/<repo>/issues?state=all`, objects with a `pull_request` key filtered out. Carries `parent_issue_url` and `issue_dependencies_summary`.
+3. **Issue dependencies** → `blocked_by.json`. For each issue with `total_blocked_by > 0`, REST `…/dependencies/blocked_by`, collected as `{ "<N>": [blockers] }` (`{}` when none). The `addIssueDependency` GraphQL mutation does not exist — REST only.
+4. **LOC by source set** → `loc.json`. Lines and files in `.kt`/`.swift` under `composeApp/src/<source_set>/` for each entry in `assets/locations.json`; emits `<sourceSet>` and `<sourceSet>_files` (0 when the dir is absent).
+5. **Sprint cutoff** → `sprint_cutoff.txt`. Last `git log --diff-filter=A --follow` date for `docs/sprints/sprint-01.md`.
 
 ## MVP chapters — compose in chat
 

--- a/.claude/skills/progress/build.py
+++ b/.claude/skills/progress/build.py
@@ -810,7 +810,10 @@ def render_quest_map(graph: dict, schools_data: dict) -> str:
       <div class="duty-pct muted">без связей</div>
     </div>
   </div>
-  <div id="graph-box" class="chart-box" style="height:620px; margin-top:14px;">
+  <label class="show-closed" style="display:inline-flex; align-items:center; gap:6px; margin-top:14px; font-size:13px; cursor:pointer; color:var(--text-muted);">
+    <input type="checkbox" id="show-closed-toggle"> показать закрытые задачи
+  </label>
+  <div id="graph-box" class="chart-box" style="height:620px; margin-top:8px;">
     <div class="graph-tooltip" id="graph-tooltip"></div>
     <div class="graph-controls">
       <button onclick="window.__graphZoom('in')">+</button>
@@ -870,58 +873,78 @@ def render_quest_map(graph: dict, schools_data: dict) -> str:
     .attr('x', d => d.lx).attr('y', d => d.ly)
     .text(d => d.name);
 
-  const link = root.append('g').selectAll('line').data(rawEdges).join('line')
-    .attr('class', d => 'ge-' + (d.type === 'block' ? 'block' : 'parent'))
-    .attr('marker-end', d => d.type === 'block' ? 'url(#arrow-block)' : 'url(#arrow-parent)');
-
-  const node = root.append('g').selectAll('g').data(rawNodes).join('g').attr('class','gn');
-  node.append('circle')
-    .attr('r', d => d.state === 'closed' ? 4 : (d.orphan ? 4 : 6))
-    .attr('class', d => d.state === 'closed' ? 'gn-closed' : (d.blocked ? 'gn-blocked' : (d.orphan ? 'gn-orphan' : 'gn-free')));
-
-  const labelLayer = root.append('g').attr('class','labels');
-  const label = labelLayer.selectAll('text').data(rawNodes).join('text')
-    .attr('class','gn-label').attr('dx', 8).attr('dy', 3)
-    .text(d => '#' + d.id);
-
   const tip = document.getElementById('graph-tooltip');
   const stateRu = {{open:'открыт', closed:'закрыт'}};
-  node.on('mouseenter', (e, d) => {{
-    const status = (stateRu[d.state] || d.state)
-      + (d.blocked ? ' · в цепях' : '') + (d.orphan ? ' · сирый' : '');
-    tip.innerHTML = `<div><span class="tt-num">#${{d.id}}</span>${{esc(d.title)}}</div><div class="tt-meta">${{d.school}} · ${{status}}</div>`;
-    const r = box.getBoundingClientRect();
-    tip.style.left = (e.clientX - r.left) + 'px';
-    tip.style.top  = (e.clientY - r.top - 12) + 'px';
-    tip.classList.add('show');
-  }}).on('mousemove', (e) => {{
-    const r = box.getBoundingClientRect();
-    tip.style.left = (e.clientX - r.left) + 'px';
-    tip.style.top  = (e.clientY - r.top - 12) + 'px';
-  }}).on('mouseleave', () => tip.classList.remove('show'));
+  const layer = root.append('g').attr('class','dynamic');
+  let sim = null;
 
-  const sim = d3.forceSimulation(rawNodes)
-    .force('link', d3.forceLink(rawEdges).id(d => d.id).distance(38).strength(.7))
-    .force('charge', d3.forceManyBody().strength(-50))
-    .force('x', d3.forceX(d => (clusterMap[d.school]||{{x:cx}}).x).strength(.14))
-    .force('y', d3.forceY(d => (clusterMap[d.school]||{{y:cy}}).y).strength(.14))
-    .force('collide', d3.forceCollide(13))
-    .alphaDecay(.025)
-    .on('tick', () => {{
-      rawNodes.forEach(d => {{
-        d.x = Math.max(PAD, Math.min(W - PAD, d.x));
-        d.y = Math.max(PAD, Math.min(H - PAD, d.y));
-      }});
-      link.attr('x1', d=>d.source.x).attr('y1', d=>d.source.y)
-          .attr('x2', d=>d.target.x).attr('y2', d=>d.target.y);
-      node.attr('transform', d => `translate(${{d.x}},${{d.y}})`);
-      label.attr('x', d => d.x).attr('y', d => d.y);
+  function draw(showClosed) {{
+    const nodes = showClosed ? rawNodes : rawNodes.filter(n => n.state !== 'closed');
+    const visible = new Set(nodes.map(n => n.id));
+    const edges = rawEdges.filter(e => {{
+      const s = (e.source && typeof e.source === 'object') ? e.source.id : e.source;
+      const t = (e.target && typeof e.target === 'object') ? e.target.id : e.target;
+      return visible.has(s) && visible.has(t);
     }});
 
-  node.call(d3.drag()
-    .on('start', (e,d) => {{ if (!e.active) sim.alphaTarget(.3).restart(); d.fx=d.x; d.fy=d.y; }})
-    .on('drag',  (e,d) => {{ d.fx=e.x; d.fy=e.y; }})
-    .on('end',   (e,d) => {{ if (!e.active) sim.alphaTarget(0); d.fx=null; d.fy=null; }}));
+    if (sim) sim.stop();
+    layer.selectAll('*').remove();
+
+    const link = layer.append('g').selectAll('line').data(edges).join('line')
+      .attr('class', d => 'ge-' + (d.type === 'block' ? 'block' : 'parent'))
+      .attr('marker-end', d => d.type === 'block' ? 'url(#arrow-block)' : 'url(#arrow-parent)');
+
+    const node = layer.append('g').selectAll('g').data(nodes).join('g').attr('class','gn');
+    node.append('circle')
+      .attr('r', d => d.state === 'closed' ? 4 : (d.orphan ? 4 : 6))
+      .attr('class', d => d.state === 'closed' ? 'gn-closed' : (d.blocked ? 'gn-blocked' : (d.orphan ? 'gn-orphan' : 'gn-free')));
+
+    const labelLayer = layer.append('g').attr('class','labels');
+    const label = labelLayer.selectAll('text').data(nodes).join('text')
+      .attr('class','gn-label').attr('dx', 8).attr('dy', 3)
+      .text(d => '#' + d.id);
+
+    node.on('mouseenter', (e, d) => {{
+      const status = (stateRu[d.state] || d.state)
+        + (d.blocked ? ' · в цепях' : '') + (d.orphan ? ' · сирый' : '');
+      tip.innerHTML = `<div><span class="tt-num">#${{d.id}}</span>${{esc(d.title)}}</div><div class="tt-meta">${{d.school}} · ${{status}}</div>`;
+      const r = box.getBoundingClientRect();
+      tip.style.left = (e.clientX - r.left) + 'px';
+      tip.style.top  = (e.clientY - r.top - 12) + 'px';
+      tip.classList.add('show');
+    }}).on('mousemove', (e) => {{
+      const r = box.getBoundingClientRect();
+      tip.style.left = (e.clientX - r.left) + 'px';
+      tip.style.top  = (e.clientY - r.top - 12) + 'px';
+    }}).on('mouseleave', () => tip.classList.remove('show'));
+
+    sim = d3.forceSimulation(nodes)
+      .force('link', d3.forceLink(edges).id(d => d.id).distance(38).strength(.7))
+      .force('charge', d3.forceManyBody().strength(-50))
+      .force('x', d3.forceX(d => (clusterMap[d.school]||{{x:cx}}).x).strength(.14))
+      .force('y', d3.forceY(d => (clusterMap[d.school]||{{y:cy}}).y).strength(.14))
+      .force('collide', d3.forceCollide(13))
+      .alphaDecay(.025)
+      .on('tick', () => {{
+        nodes.forEach(d => {{
+          d.x = Math.max(PAD, Math.min(W - PAD, d.x));
+          d.y = Math.max(PAD, Math.min(H - PAD, d.y));
+        }});
+        link.attr('x1', d=>d.source.x).attr('y1', d=>d.source.y)
+            .attr('x2', d=>d.target.x).attr('y2', d=>d.target.y);
+        node.attr('transform', d => `translate(${{d.x}},${{d.y}})`);
+        label.attr('x', d => d.x).attr('y', d => d.y);
+      }});
+
+    node.call(d3.drag()
+      .on('start', (e,d) => {{ if (!e.active) sim.alphaTarget(.3).restart(); d.fx=d.x; d.fy=d.y; }})
+      .on('drag',  (e,d) => {{ d.fx=e.x; d.fy=e.y; }})
+      .on('end',   (e,d) => {{ if (!e.active) sim.alphaTarget(0); d.fx=null; d.fy=null; }}));
+  }}
+
+  draw(false);
+  const showClosedCb = document.getElementById('show-closed-toggle');
+  if (showClosedCb) showClosedCb.addEventListener('change', () => draw(showClosedCb.checked));
 
   const zoom = d3.zoom().scaleExtent([0.3, 4])
     .filter(e => !e.target.closest('.gn'))

--- a/.claude/skills/progress/collect.py
+++ b/.claude/skills/progress/collect.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Collect raw data for the /progress snapshot.
+
+Gathers everything build.py consumes into one directory:
+
+  prs.json          all PRs (paginated GraphQL — REST /pulls omits commits/comments/threads)
+  issues.json       all issues, PRs filtered out
+  blocked_by.json   { "<issue>": [<blocker>, ...] } via REST dependencies (no GraphQL mutation exists)
+  loc.json          lines + files per source set from assets/locations.json
+  sprint_cutoff.txt ISO date sprint-01.md first landed in git
+
+owner/repo is resolved from `gh repo view`; LOC/git read --repo-root (default cwd).
+MVP chapters and the diary are judged in chat — this script does not touch them.
+
+  python3 collect.py [--raw-data DIR] [--repo-root PATH]
+"""
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SKILL_DIR = Path(__file__).resolve().parent
+
+PR_FIELDS = """
+            number title state createdAt mergedAt additions deletions changedFiles
+            commits(first:100){ totalCount nodes{ commit{ committedDate } } }
+            comments{ totalCount } reviews{ totalCount } reviewThreads{ totalCount }
+"""
+
+PR_QUERY = """
+query($owner:String!,$repo:String!,$cursor:String){
+  repository(owner:$owner,name:$repo){
+    pullRequests(first:50, after:$cursor, orderBy:{field:CREATED_AT, direction:ASC}){
+      pageInfo{ hasNextPage endCursor }
+      nodes{ %s }
+    }
+  }
+}""" % PR_FIELDS
+
+
+def gh(args: list[str]) -> str:
+    res = subprocess.run(["gh", *args], capture_output=True, text=True)
+    if res.returncode != 0:
+        sys.exit(f"gh {' '.join(args)} failed:\n{res.stderr}")
+    return res.stdout
+
+
+def resolve_repo() -> tuple[str, str]:
+    full = gh(["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]).strip()
+    owner, repo = full.split("/", 1)
+    return owner, repo
+
+
+def fetch_prs(owner: str, repo: str) -> list:
+    nodes, cursor = [], ""
+    while True:
+        cmd = ["api", "graphql", "-f", f"query={PR_QUERY}", "-F", f"owner={owner}", "-F", f"repo={repo}"]
+        # GraphQL String! cursor: pass null on the first page via -F (gh maps absent -F to null).
+        if cursor:
+            cmd += ["-F", f"cursor={cursor}"]
+        else:
+            cmd += ["-f", "cursor="]  # empty string -> treated as no cursor by the API for the first page
+        page = json.loads(gh(cmd))["data"]["repository"]["pullRequests"]
+        nodes += page["nodes"]
+        if not page["pageInfo"]["hasNextPage"]:
+            break
+        cursor = page["pageInfo"]["endCursor"]
+    return nodes
+
+
+def fetch_issues(owner: str, repo: str) -> list:
+    raw = gh(["api", f"repos/{owner}/{repo}/issues?state=all&per_page=100", "--paginate",
+              "--slurp"])
+    pages = json.loads(raw)
+    flat = [item for page in pages for item in page]
+    return [i for i in flat if "pull_request" not in i]
+
+
+def fetch_blocked_by(owner: str, repo: str, issues: list) -> dict:
+    out = {}
+    for iss in issues:
+        summ = iss.get("issue_dependencies_summary") or {}
+        if summ.get("total_blocked_by", 0) > 0:
+            n = iss["number"]
+            deps = json.loads(gh(["api", f"repos/{owner}/{repo}/issues/{n}/dependencies/blocked_by"]))
+            out[str(n)] = [b["number"] for b in deps]
+    return out
+
+
+def count_loc(repo_root: Path) -> dict:
+    locations = json.loads((SKILL_DIR / "assets" / "locations.json").read_text())["locations"]
+    out = {}
+    for entry in locations:
+        ss = entry["source_set"]
+        base = repo_root / "composeApp" / "src" / ss
+        total = files = 0
+        if base.is_dir():
+            for path in base.rglob("*"):
+                if path.suffix in (".kt", ".swift") and path.is_file():
+                    files += 1
+                    total += sum(1 for _ in path.open(encoding="utf-8", errors="ignore"))
+        out[ss] = total
+        out[f"{ss}_files"] = files
+    return out
+
+
+def sprint_cutoff(repo_root: Path) -> str:
+    res = subprocess.run(
+        ["git", "-C", str(repo_root), "log", "--diff-filter=A", "--follow",
+         "--format=%aI", "--", "docs/sprints/sprint-01.md"],
+        capture_output=True, text=True)
+    lines = [ln for ln in res.stdout.splitlines() if ln.strip()]
+    return lines[-1] if lines else ""
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Collect raw data for /progress")
+    ap.add_argument("--raw-data", default="/tmp/tether-progress-raw")
+    ap.add_argument("--repo-root", default=".")
+    args = ap.parse_args()
+
+    raw = Path(args.raw_data)
+    raw.mkdir(parents=True, exist_ok=True)
+    repo_root = Path(args.repo_root).resolve()
+
+    owner, repo = resolve_repo()
+    print(f"repo: {owner}/{repo}")
+
+    prs = fetch_prs(owner, repo)
+    (raw / "prs.json").write_text(json.dumps(prs, indent=2))
+    print(f"prs.json: {len(prs)}")
+
+    issues = fetch_issues(owner, repo)
+    (raw / "issues.json").write_text(json.dumps(issues, indent=2))
+    print(f"issues.json: {len(issues)}")
+
+    blocked = fetch_blocked_by(owner, repo, issues)
+    (raw / "blocked_by.json").write_text(json.dumps(blocked, indent=2))
+    print(f"blocked_by.json: {len(blocked)}")
+
+    loc = count_loc(repo_root)
+    (raw / "loc.json").write_text(json.dumps(loc, indent=2))
+    print(f"loc.json: {sum(v for k, v in loc.items() if not k.endswith('_files'))} LOC")
+
+    cutoff = sprint_cutoff(repo_root)
+    (raw / "sprint_cutoff.txt").write_text(cutoff + "\n")
+    print(f"sprint_cutoff.txt: {cutoff}")
+
+    print(f"\nwritten to {raw}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #392.

Two improvements to the `/progress` skill.

## Quest map — hide completed tasks by default
- Graph opens with closed issues hidden; a **показать закрытые задачи** checkbox brings them back.
- `render_quest_map` now redraws through a `draw(showClosed)` function that filters nodes/edges (drops edges with a hidden endpoint), stops the prior simulation, and rebuilds it. Node positions persist across toggles, so the graph doesn't jump. Cluster labels, zoom and pan are built once, outside `draw`.

## Extract data collection into `collect.py`
- One `python3 collect.py --raw-data … --repo-root …` writes every input `build.py` consumes: `prs.json`, `issues.json`, `blocked_by.json`, `loc.json`, `sprint_cutoff.txt`.
- Baked-in quirks that previously had to be rediscovered each run: GraphQL PR pagination (first-page cursor handling), `--paginate --slurp` issues with PRs filtered out, REST `blocked_by` dependencies (no GraphQL mutation exists), `source_set`-keyed LOC counting.
- `SKILL.md` §"What to collect" now directs the operator to run the script; field/quirk details kept as rationale.

## Verification
- `collect.py` output is byte-identical to the previously hand-rolled data (diffed all five files: 221 PRs, 170 issues, 36 blocked_by, same cutoff).
- `build.py` renders without error; generated quest-map JS passes `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
