### PR TITLE
plan sprint 12: close sprint-11 by actuals, compose sprint-12

### DIFF
--- a/docs/sprints/sprint-11.md
+++ b/docs/sprints/sprint-11.md
@@ -4,14 +4,23 @@
 
 ## Состав
 
-| # | Issue | Название | Тип | Размер |
-| - | ----- | -------- | --- | ------ |
-| 1 | [#345](https://github.com/khmelevartem/tether/issues/345) | CLI: два экземпляра на одном хосте не видят друг друга | bugfix | S |
-| 2 | [#368](https://github.com/khmelevartem/tether/issues/368) | Same-named peers stay distinguishable in the peer list | bugfix | S |
-| 3 | [#352](https://github.com/khmelevartem/tether/issues/352) | Spaces in filenames arrive as '+' on receiver | bugfix | S |
-| 4 | [#348](https://github.com/khmelevartem/tether/issues/348) | CLI: design and apply a convenient log format | refactor | M |
-| 5 | [#192](https://github.com/khmelevartem/tether/issues/192) | Android sender wiring: SAF picker, share-sheet и MediaStore receiver | feature | M |
-| 6 | [#10](https://github.com/khmelevartem/tether/issues/10) | Паринг — handshake, вычисление PIN-кода, CLI-флоу | feature | M |
+**Итог:** 5/6 задач закрыто. #10 — частично: реальная работа вынесена в #361 и #378, перенос в sprint-12.
+
+| # | Issue | Название | Тип | Размер | Итог |
+| - | ----- | -------- | --- | ------ | ---- |
+| 1 | [#345](https://github.com/khmelevartem/tether/issues/345) | CLI: два экземпляра на одном хосте не видят друг друга | bugfix | S | ✅ closed (дубль [#346](https://github.com/khmelevartem/tether/issues/346), PR #350) |
+| 2 | [#368](https://github.com/khmelevartem/tether/issues/368) | Same-named peers stay distinguishable in the peer list | bugfix | S | ✅ closed (PR #379) |
+| 3 | [#352](https://github.com/khmelevartem/tether/issues/352) | Spaces in filenames arrive as '+' on receiver | bugfix | S | ✅ closed (PR #373) |
+| 4 | [#348](https://github.com/khmelevartem/tether/issues/348) | CLI: design and apply a convenient log format | refactor | M | ✅ closed (PR #385) |
+| 5 | [#192](https://github.com/khmelevartem/tether/issues/192) | Android sender wiring: SAF picker, share-sheet и MediaStore receiver | feature | M | ✅ closed (PR #383, follow-up #391) |
+| 6 | [#10](https://github.com/khmelevartem/tether/issues/10) | Паринг — handshake, вычисление PIN-кода, CLI-флоу | feature | M | 🟡 partial — PR #362 открыт; части вынесены в #361/#378, перенос в sprint-12 |
+
+## Дополнительные результаты
+
+Закрыто в окне спринта вне исходного состава:
+
+- **#375** (PR #377) — стабилизация флэйки `CliSendTest` и `FileClientTest`: прогон тестов перестал падать на гонках, smoke и unit-проходы читаемы.
+- **#392** (PR #393) — `/progress`: карта заданий по умолчанию скрывает закрытые задачи (галочка возвращает), а сбор сырых данных вынесен в воспроизводимый `collect.py`.
 
 ## Что разблокирует
 

--- a/docs/sprints/sprint-12.md
+++ b/docs/sprints/sprint-12.md
@@ -1,0 +1,26 @@
+# Sprint 12 · Узы и Стражи
+
+**Направления:** pairing · sender wiring · security · tooling
+
+## Состав
+
+| # | Issue | Название | Тип | Размер |
+| - | ----- | -------- | --- | ------ |
+| 1 | [#10](https://github.com/khmelevartem/tether/issues/10) | Паринг — handshake, вычисление PIN-кода, CLI-флоу | feature | M |
+| 2 | [#378](https://github.com/khmelevartem/tether/issues/378) | Independent threat model and attack-surface analysis for pairing and transfer | docs | L |
+| 3 | [#361](https://github.com/khmelevartem/tether/issues/361) | Pairing mutual confirmation before trust is stored | feature | M |
+| 4 | [#193](https://github.com/khmelevartem/tether/issues/193) | Desktop sender wiring: AWT file picker на EDT и drag-and-drop по окну | feature | M |
+| 5 | [#194](https://github.com/khmelevartem/tether/issues/194) | iOS sender wiring: UIDocumentPickerViewController и bookmark-based FileSource | feature | M |
+| 6 | [#198](https://github.com/khmelevartem/tether/issues/198) | Structured findings + synthesis pass в /code-review | infra | M |
+| 7 | [#354](https://github.com/khmelevartem/tether/issues/354) | Block writes outside the current worktree via PreToolUse hook | infra | S |
+
+## Что разблокирует
+
+- После #10 + #378 + #361 паринг закрывает MVP-главу «Четырёхзначная Клятва»: trust устанавливается только после взаимного подтверждения, а #11 (PIN-диалоги Android/iOS/Desktop) получает готовый сквозной контракт.
+- После #193 + #194 sender есть на всех четырёх платформах — file-transfer перестаёт быть Android-only, и #224 (iOS Share Sheet) встаёт на готовый iOS FileSource.
+
+## Порядок мерджа
+
+#10 || #378 → #361 ; #193 → #194 ; #198 || #354
+
+`||` — параллельные ветки. #361 заблокирован #10 и #378 (взят в спринт по явному решению — мержить строго после обоих). #193 и #194 делят commonMain sender-seam от #192 — если кто-то из них его трогает, мержить последовательно. #198 и #354 — изолированный `.claude/`-тулинг (skill-файлы vs хук в settings), параллельны. #10 (pairing commonMain + jvmMain/CLI) и #378 (docs-only) друг от друга независимы.


### PR DESCRIPTION
## Sprint-11 closed by actuals

5/6 tasks shipped; #10 carried over as partial.

| # | Outcome |
|---|---------|
| #345 | ✅ via duplicate #346 (PR #350) |
| #368 | ✅ PR #379 |
| #352 | ✅ PR #373 |
| #348 | ✅ PR #385 |
| #192 | ✅ PR #383 (+#391) |
| #10 | 🟡 partial — split into #361/#378, carried to sprint-12 |

Additional in-window results: **#375** (test de-flake, PR #377), **#392** (`/progress` quest-map toggle + `collect.py`, PR #393).

## Sprint-12 · Узы и Стражи

Directions: **pairing · sender wiring · security · tooling**.

| # | Issue | Type | Size |
|---|-------|------|------|
| #10 | Pairing — handshake, PIN, CLI flow | feature | M |
| #378 | Threat model & attack-surface analysis | docs | L |
| #361 | Pairing mutual confirmation before trust stored | feature | M |
| #193 | Desktop sender wiring | feature | M |
| #194 | iOS sender wiring | feature | M |
| #198 | Structured findings + synthesis in /code-review | infra | M |
| #354 | Block writes outside worktree via PreToolUse hook | infra | S |

Merge order: `#10 || #378 → #361 ; #193 → #194 ; #198 || #354`.

**Note on the chain:** #361 is blocked_by both #10 and #378, which are in the same sprint — this breaks the usual "no chain within a sprint" rule. Kept together by explicit decision; merge order sequences #361 strictly after both blockers. #224 (blocked by #194) deferred to a later sprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
