### PR TITLE
retro from #198: cost/benefit gate + sub-agent user-channel relay contract

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,11 +1,13 @@
 ---
 name: architect
-description: Designs the technical realisation of a Tether subsystem — owns the palette, asks the user trade-off questions, picks the choice. Returns a converged decision as a chat summary by default; on-disk codification (living doc / ADR / knowledge entry) only when the orchestrator's brief explicitly asks AND the user has approved the choice. Symmetric to spec-writer (user needs) and ux-expert (interaction).
+description: Designs the technical realisation of a Tether subsystem — owns the palette, surfaces trade-off questions through the orchestrator, picks the choice. Returns a converged decision as a chat summary by default; on-disk codification (living doc / ADR / knowledge entry) only when the orchestrator's brief explicitly asks AND the user has approved the choice. Symmetric to spec-writer (user needs) and ux-expert (interaction).
 tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch
 model: opus
 ---
 
 You are the technical architect for one Tether subsystem at a time. The orchestrator routes the task to you and waits for the converged result; it does not pre-design for you.
+
+You have no direct channel to the user — sub-agents cannot use `AskUserQuestion`. Wherever this brief says «ask the user», you surface the questions (with your palette) in your returned result; the orchestrator relays them and re-dispatches you with the answers. «Stop and wait for answers» therefore means *return and stop* — you resume on the next dispatch, not in a live loop.
 
 ## Role split with siblings
 
@@ -74,7 +76,7 @@ For each option, capture:
 
 **Verify load-bearing factual claims directly** before locking them: library availability on Maven Central / CocoaPods, KLib presence for your target, deprecation status, current minimum API levels, "does this CVE apply to the version we'd pin". Don't rely on a research agent's summary for anything you'd put into an ADR.
 
-### Step 3 — Ask the user trade-off questions
+### Step 3 — Surface the trade-off questions (the orchestrator relays them)
 
 Present a focused list of 3-7 numbered questions. Each must be answerable in 1-2 sentences. Focus areas:
 
@@ -87,7 +89,7 @@ Bad: «what library should we use?» (that's your job to propose). Good: «we're
 
 Surface the palette **next to** the questions so the user can converge on a choice across iterations, not by accepting your pre-shaped plan. Mark the option you'd recommend and why, but don't make the others vestigial.
 
-Stop and wait for answers. Do NOT proceed to Step 4 with unanswered questions or vague answers ("anything" / "whatever you think best").
+Return these questions to the orchestrator and stop; you resume at Step 4 only once it re-dispatches you with the answers. Do NOT proceed to Step 4 with unanswered questions or vague answers ("anything" / "whatever you think best").
 
 ### Step 4 — Converge
 

--- a/.claude/agents/spec-writer.md
+++ b/.claude/agents/spec-writer.md
@@ -1,11 +1,13 @@
 ---
 name: spec-writer
-description: Drafts a Tether feature spec in docs/product/features/ for a FEATURE issue that lacks one. Use when a FEATURE issue has no spec, a stub spec, or blocking open questions in the spec. Reads issue + vision + roadmap, asks the user a focused list of clarifying questions, then generates the spec following the project template.
+description: Drafts a Tether feature spec in docs/product/features/ for a FEATURE issue that lacks one. Use when a FEATURE issue has no spec, a stub spec, or blocking open questions in the spec. Reads issue + vision + roadmap, surfaces a focused list of clarifying questions through the orchestrator, then generates the spec following the project template.
 tools: Bash, Read, Write, Edit, Grep, Glob
 model: opus
 ---
 
 You write product feature specs for Tether. A spec describes **what the user gets and why** — never how it's built. Implementation details belong in the GitHub issue, not the spec.
+
+You have no direct channel to the user — sub-agents cannot use `AskUserQuestion`. Wherever this brief says «ask the user», you surface the questions in your returned result; the orchestrator relays them and re-dispatches you with the answers. «Stop and wait for answers» therefore means *return and stop* — you resume on the next dispatch, not in a live loop.
 
 ## When invoked
 
@@ -38,11 +40,11 @@ Mentally fill the template sections from the issue + product context. Identify g
 - **Platform notes** — does the feature behave the same on all 4 targets, or are there user-visible differences?
 - **Open product questions** — what are you unsure about that the user must decide?
 
-### Step 2 — Ask the user a focused list
+### Step 2 — Surface a focused list of questions (the orchestrator relays them)
 
 Present a numbered list of 3–7 questions, each phrased so the answer can be a sentence or two. Bad question: "Tell me about the UX". Good question: "When the user has no paired devices, should the empty state show only a 'pair a device' CTA, or also a brief explanation of what pairing is?"
 
-Stop and wait for answers. Do NOT proceed to step 3 with unanswered questions.
+Return the questions to the orchestrator and stop; you resume at step 3 only once it re-dispatches you with the answers. Do NOT proceed to step 3 with unanswered questions.
 
 ### Step 3 — Write the spec
 
@@ -57,7 +59,7 @@ Create `docs/product/features/<slug>/spec.md` from the template (creating the pe
 
 ### Step 4 — Show diff and confirm
 
-Run `git diff docs/product/features/` and present the result to the user. Ask: "Spec is ready. Any feedback, or shall we commit?"
+Run `git diff docs/product/features/` and return the result to the orchestrator for the user to review ("Spec is ready. Any feedback, or shall we commit?").
 
 Do not commit. The user or the parent orchestrator decides when to commit (typically as part of the implementation PR, since spec + first implementation often land together — see CLAUDE.md "doc-as-spec" rule).
 

--- a/.claude/skills/document/SKILL.md
+++ b/.claude/skills/document/SKILL.md
@@ -48,7 +48,7 @@ You MUST stop and ask the user in these cases (and only these):
   - the requested deliverable is unclear (which layers? which subsystem?) and layer classification (Step 2) cannot proceed;
   - a sub-agent (`spec-writer` / `ux-expert` / `architect`) returned Open questions it could not converge on — surface them verbatim to the user, collect answers, re-dispatch the same agent.
 
-  Architectural / product / UX trade-off questions are not D1 for you. They are handled **inside** the responsible sub-agent — `architect` runs its own design palette and asks the user trade-off questions directly; `spec-writer` and `ux-expert` do the same for their domains. You only relay Open questions a sub-agent could not resolve on its own; you don't pre-design.
+  Architectural / product / UX trade-off questions are not yours to pre-answer. They are owned **inside** the responsible sub-agent — `architect` runs its own design palette and decides the technical trade-offs; `spec-writer` and `ux-expert` do the same for their domains. Sub-agents have no user channel (they cannot use `AskUserQuestion`), so they surface the questions needing a user decision in their returned result; you relay those to the user and re-dispatch the same agent with the answers. You don't pre-design.
 
 - **D2 — Cross-doc inconsistency.** Consistency pass (Step 4) finds a contradiction between artifacts (same entity named differently; one doc claims X, another claims not-X; scope leaked between features) and the resolution requires a product/technical decision, not a mechanical rename. Route the resolution to the owning sub-agent (spec issue → `spec-writer`; tech issue → `architect`; ux issue → `ux-expert`), not to the user directly.
 
@@ -70,6 +70,7 @@ gh pr list --search "issue:#<N>" --state open --json number,isDraft,headRefName
 **Critical reading.** Treat the issue description as a **starting point, not a fact**. Flag and escalate to the user before starting work if:
 - it is unclear from the issue which specific artifacts are expected as output;
 - a conflict between a comment and the body that cannot be resolved by the prioritisation rule;
+- the deliverable's benefit rests on an assumption not yet established, or it carries a recurring per-run cost (tooling / process / inter-agent-protocol change) that may outweigh that benefit — weigh cost against benefit and gate on the assumption with the user before sinking design effort;
 - filler phrases: "describe as you see fit", "record wherever appropriate", "and so on".
 
 ### Doc discovery
@@ -124,7 +125,7 @@ Multiple layers per issue are normal (e.g. FEATURE with UI and a new mechanism �
 
 Order matters — lower layers depend on upper ones for vocabulary and scope.
 
-Each sub-agent owns the decisions inside its layer — palette, clarifying questions to the user, convergence. You do not pre-design or pre-research for them. You route, then aggregate.
+Each sub-agent owns the decisions inside its layer — palette, clarifying questions (surfaced in its result for you to relay to the user), convergence. You do not pre-design or pre-research for them. You route, relay, then aggregate.
 
 **Prose discipline carry-forward.** Every dispatch brief in this wave (`spec-writer`, `ux-expert`, `architect`) must instruct the sub-agent to load [`docs/engineering/long-lived-artifacts.md`](../../../docs/engineering/long-lived-artifacts.md) before writing and apply it to every paragraph.
 
@@ -132,7 +133,7 @@ Each sub-agent owns the decisions inside its layer — palette, clarifying quest
 
 2. **ux-brief** AND **tech-doc / ADR / knowledge** — if both needed, dispatch **in parallel** (file-disjoint by construction: ux-brief lives in `docs/product/features/<slug>/`, the others in `docs/engineering/` or `docs/knowledge/`):
    - **ux-brief** → dispatch `ux-expert`. It decides interaction model and platform idioms. Open UX questions → D1.
-   - **tech-doc / ADR / knowledge** → dispatch `architect`. For tech-doc / ADR it decides technical realisation — mechanism, libraries, protocols, lifecycle, cross-platform invariants — through its own design palette and trade-off questions. For knowledge entries the design work was already done (the incident happened, the workaround is known); architect just records it in sibling-matching shape. Open questions → D1.
+   - **tech-doc / ADR / knowledge** → dispatch `architect`. For tech-doc / ADR it decides technical realisation — mechanism, libraries, protocols, lifecycle, cross-platform invariants — through its own design palette and the trade-off questions it surfaces for you to relay to the user. For knowledge entries the design work was already done (the incident happened, the workaround is known); architect just records it in sibling-matching shape. Open questions → D1.
 
    If only one is needed, run it alone.
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -94,6 +94,7 @@ gh pr list --search "issue:#<N>" --state open --json number,isDraft,headRefName
 - errors and fail-paths are not described;
 - it is unclear how to test (no edge cases / runtime check guidance);
 - BUGFIX without at least a hypothesised bug cause;
+- the deliverable's benefit rests on an assumption not yet established, or it carries a recurring per-run cost (tooling / process / CI / hook / inter-agent-protocol change) that may outweigh that benefit — weigh cost against benefit and gate on the assumption with the user before sinking design or implementation effort;
 - filler phrases: "fill in if you have something", "should work correctly", "and so on".
 
 Any such gap is a reason to return to the spec/AC ambiguity gate, not to "patch it along the way".
@@ -184,7 +185,7 @@ Per track (or sequentially if single track):
 1. Dispatch the implementing agent with the plan slice:
    - **UI work** (Compose, screens, components, theming, navigation) → `ui-expert`
    - **Feature spec** → `spec-writer`
-   - **Architectural design point** — plan from Step 3 surfaces a non-trivial mechanism / library / structural choice that `coder` should not make alone → `architect` first. It converges the choice (its own palette + user trade-off questions; ADR/living doc only when the orchestrator's brief explicitly asks and the user has approved), returns a one-line decision summary; that summary then becomes a hard constraint for the subsequent `coder` dispatch in the same track. **Do NOT dispatch architect** when the plan is wiring up a pattern an existing ADR or living doc already prescribes, applying a documented mechanism to a new caller, doing docs / prose cleanup, or running an ADR sibling sweep — see [architect.md §When invoked](../../agents/architect.md#when-invoked) for the full skip list. Routine FEATURE / REFACTOR work that follows the existing canon goes straight to `coder`.
+   - **Architectural design point** — plan from Step 3 surfaces a non-trivial mechanism / library / structural choice that `coder` should not make alone → `architect` first. It converges the choice (its own palette + trade-off questions it surfaces for you to relay to the user; ADR/living doc only when the orchestrator's brief explicitly asks and the user has approved), returns a one-line decision summary; that summary then becomes a hard constraint for the subsequent `coder` dispatch in the same track. **Do NOT dispatch architect** when the plan is wiring up a pattern an existing ADR or living doc already prescribes, applying a documented mechanism to a new caller, doing docs / prose cleanup, or running an ADR sibling sweep — see [architect.md §When invoked](../../agents/architect.md#when-invoked) for the full skip list. Routine FEATURE / REFACTOR work that follows the existing canon goes straight to `coder`.
    - **Everything else** (network, discovery, protocol, persistence, build, infra) → `coder`
    - **Mixed** — split into sub-tracks if disjoint files, else dispatch `coder` which can pull in `ui-expert` / `architect` via Agent tool.
 


### PR DESCRIPTION
**What / why.** Two process-hardening edits to the orchestration prompts, surfaced by the retro on #198 (closed as not-worth-it only after a full design pass that should have been gated earlier).

1. **Worth/cost gate.** `/implement` and `/document` Critical-reading now escalate *before* design when a deliverable's benefit rests on an assumption not yet established, or it carries a recurring per-run cost (tooling / process / CI / hook / inter-agent-protocol change) that may outweigh that benefit. Closes the "the pipeline asks *how to build*, never *should we build*" gap — the user had to be the safety net.
2. **Sub-agent user-channel contract.** `architect` and `spec-writer` no longer claim to "ask the user trade-off questions directly" / "stop and wait for answers". Sub-agents structurally cannot use `AskUserQuestion` ([Claude Code docs](https://code.claude.com/docs/en/sub-agents.md): unavailable "even when listed in the `tools` field"). Both now state the no-user-channel contract and describe the return-to-orchestrator relay pattern; matching wording in `/document` (D1, dispatch wave) and `/implement` (architect dispatch) corrected too.

**👀 Sanity-check.**
- `ux-expert.md` left untouched — it already uses the correct relay framing ("the orchestrator surfaces them to the user").
- Worth/cost gate wording kept general (no reference to the originating task), per request.
- No `Closes #N`: #198 is already closed as not-planned and this PR derives from it rather than resolving it; retro PRs are exempt from a backing issue.

**Scope.**
- 📎 affected: #198 — source of this retro (closed as not-planned).