### PR TITLE
#354: block cross-worktree writes via PreToolUse hook

### DIFF
--- a/.claude/hooks/block-cross-worktree-writes.sh
+++ b/.claude/hooks/block-cross-worktree-writes.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# PreToolUse hook: reads tool input JSON from stdin; emits a deny hookSpecificOutput to stdout on violation.
+
+set -euo pipefail
+
+[ "${TETHER_SKIP_WORKTREE_HOOK:-}" = "1" ] && exit 0
+
+input=$(cat)
+
+# Cheap short-circuit: skip full JSON parse when no worktree path is present.
+case "$input" in
+  *'/.claude/worktrees/'*) ;;
+  *) exit 0 ;;
+esac
+
+printf '%s' "$input" | python3 -c '
+import json, os, sys
+
+try:
+    data = json.loads(sys.stdin.read())
+except json.JSONDecodeError:
+    sys.exit(0)
+
+tool = data.get("tool_name", "")
+if tool not in ("Edit", "Write"):
+    sys.exit(0)
+
+cwd = data.get("cwd", "")
+fp = (data.get("tool_input") or {}).get("file_path", "")
+if not cwd or not fp:
+    sys.exit(0)
+
+marker = "/.claude/worktrees/"  # worktree layout convention: <repo-root>/.claude/worktrees/<name>/
+if marker not in cwd:
+    sys.exit(0)
+
+repo_root = cwd.rsplit(marker, 1)[0]
+wt_name = cwd.rsplit(marker, 1)[1].split("/")[0]
+worktree_root = repo_root + marker + wt_name
+
+abs_fp = os.path.normpath(fp if os.path.isabs(fp) else os.path.join(cwd, fp))
+
+def under(p, root):
+    root = root.rstrip("/")
+    return p == root or p.startswith(root + "/")
+
+if not under(abs_fp, repo_root):
+    sys.exit(0)
+
+if under(abs_fp, worktree_root):
+    sys.exit(0)
+
+reason = (
+    f"Blocked write outside the active worktree.\n"
+    f"file_path: {abs_fp}\n"
+    f"expected root: {worktree_root}\n"
+    f"Edit files only inside this worktree. "
+    f"For a deliberate cross-worktree write, set TETHER_SKIP_WORKTREE_HOOK=1."
+)
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": reason,
+    }
+}))
+'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,15 @@
             "command": "bash .claude/hooks/pre-git-checklist.sh"
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/block-cross-worktree-writes.sh"
+          }
+        ]
       }
     ],
     "Stop": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,8 @@ Before committing, make sure the issue exists. If it does not — ask the user t
 
 To pull main into the branch — `/pull-main` (merges fresh main and shows what came in). It runs from both `/close-issue` and mid-flight.
 
+Writes to files inside the repo but outside the active worktree are blocked by a PreToolUse hook (`.claude/hooks/block-cross-worktree-writes.sh`); for a deliberate cross-worktree write set `TETHER_SKIP_WORKTREE_HOOK=1`.
+
 ## Common commands
 
 Run all Gradle commands with `-q`. Do not run KtLint manually — the git hook does it automatically on commit; do not fix style errors by hand either. Do not clean up unused imports by hand either — KtLint removes them on commit.

--- a/docs/engineering/adr/adr-logging-kydra.md
+++ b/docs/engineering/adr/adr-logging-kydra.md
@@ -117,7 +117,7 @@ The full present-tense rules are in [logging.md](../logging.md) §Desktop stream
 
 - [logging.md](../logging.md) — the living doc this ADR underpins.
 - [KydraLog README & skill](https://github.com/PocketByte/kotlin-kydra-log/blob/master/.claude/skills/kydra-log/SKILL.md) — initialisation API, writer list, decorator chain.
-- [SLF4J 2.0 provider mechanism](https://www.slf4j.org/manual.html#swapping) — context for the `slf4j-simple` choice.
+- SLF4J 2.0 provider mechanism — context for the `slf4j-simple` choice.
 - Related ADRs: [adr-network-stack.md](adr-network-stack.md) (Ktor framework that owns the SLF4J slot we fill), [adr-presentation-and-navigation.md](adr-presentation-and-navigation.md) (future Decompose components inherit this façade).
 - Issue [#74](https://github.com/khmelevartem/tether/issues/74) — full call-site inventory and DoD.
 

--- a/docs/interview-prep-checklist.md
+++ b/docs/interview-prep-checklist.md
@@ -44,7 +44,7 @@
 ## Блок 2 — Coroutines
 
 ### Механика
-- [ ] `suspend` под капотом — CPS, state machine, что компилятор делает с функцией
+- [x] `suspend` под капотом — CPS, state machine, что компилятор делает с функцией
 - [ ] `Continuation<T>` — интерфейс, как реализуется возобновление
 - [ ] Корутины vs потоки — почему «легковесные», как маппируются на потоки
 - [ ] `CoroutineContext` — `Job`, `Dispatcher`, `CoroutineName`, `CoroutineExceptionHandler`, наследование


### PR DESCRIPTION
**What / why.** Adds a `PreToolUse` hook that denies `Edit`/`Write` whose `file_path` lands inside the repo but outside the active `.claude/worktrees/<name>/` worktree (the parent checkout or a sibling worktree), naming the expected root. Turns the recurring "agent silently edits the parent checkout" slip (#328, and the `MEMORY.md` «Worktree cwd discipline» note) from a soft prompt into a hard, harness-level block. Reads and out-of-repo paths are untouched; `TETHER_SKIP_WORKTREE_HOOK=1` is the deliberate-cross-write escape hatch. Documented in CLAUDE.md §Git conventions.

**👀 Sanity-check.**
- **Matcher is `Edit|Write`, not the DoD's `Edit, Write, MultiEdit`.** `MultiEdit` is not a real Claude Code tool — wiring it would be dead config. Confirmed with the user; `NotebookEdit` stays out of scope (genuinely unused in this Kotlin/KMP repo). The DoD's tool list rested on a factual error.
- **Latency: ~24 ms per Edit/Write in worktree sessions** (python startup), ~3 ms in main-checkout sessions where the bash short-circuit skips python entirely. This is marginally over the issue's ~20 ms estimate; kept python3 over a measured ~6 ms jq alternative for portable, robust JSON parsing (the project standardized hooks on python3). Absolute cost is imperceptible vs LLM/build latency.
- **Worktree detection is a string-split on `/.claude/worktrees/`**, chosen over `git rev-parse` for latency. If the worktree layout ever moves, the guard fails *open* (stops firing) rather than mis-blocking — a comment on the `marker` line names the convention.
- **Fails open on internal error by design** (malformed JSON / `tool_input: null` / a python crash → allow). This is accident-prevention, not adversarial security: failing open on a rare internal error beats bricking every edit if python ever breaks. The one *common-path* fail-open (>1 MB writes hitting `ARG_MAX` via argv) is closed — input is piped via stdin.
- **Symlink escape is not guarded** (`normpath` is lexical, not `realpath`) — out of the accident-prevention threat model.

**Verification.** Live enforcement probe through the harness: a `Write` to the parent checkout was blocked with the expected message; an in-worktree edit was allowed; escape hatch and `tool_input:null`/malformed-JSON/large-write/injection/prefix-collision cases verified.

Closes #354