### PR TITLE
retro from #401: pattern code blocks use synthetic placeholders

### DIFF
--- a/docs/engineering/dependency-injection.md
+++ b/docs/engineering/dependency-injection.md
@@ -195,16 +195,16 @@ When a container field needs a per-platform implementation, the common contract 
 Within a platform that bundles several operating systems (Desktop = Windows / Linux / macOS), resolve the host OS exactly once and deliver every OS-specific dependency as a delegate. A sealed provider with one object per OS, selected at a single internal point, is the only place a `when (os)` lives; the container, config, and tests consume `provider.someDelegate(...)` and never re-read `os.name`.
 
 ```kotlin
-internal sealed interface DesktopPlatform {
-    fun mdnsDelegate(...): DeviceDiscovery
-    object MacOs : DesktopPlatform { /* Bonjour */ }
-    object Windows : DesktopPlatform { /* JmDNS */ }
-    object Linux : DesktopPlatform { /* JmDNS */ }
+internal sealed interface HostPlatform {
+    fun someDelegate(...): SomeCollaborator
+    object MacOs : HostPlatform { /* impl A */ }
+    object Windows : HostPlatform { /* impl B */ }
+    object Linux : HostPlatform { /* impl B */ }
 }
-internal val desktopPlatform = desktopPlatformFrom(System.getProperty("os.name").orEmpty())
+internal val hostPlatform = hostPlatformFrom(System.getProperty("os.name").orEmpty())
 ```
 
-A public `currentOs` enum that any call site can branch on is the anti-pattern: OS forks then scatter and drift. Keep the OS axis orthogonal to other axes (e.g. GUI-vs-CLI stays in the container hierarchy) so the provider doesn't multiply into a class-per-combination. Inject the provider into the container with a default (`platform: DesktopPlatform = desktopPlatform`) so a test can pass `DesktopPlatform.Linux` on any host.
+A public OS enum that any call site can branch on is the anti-pattern: OS forks then scatter and drift. Keep the OS axis orthogonal to other axes (e.g. GUI-vs-CLI stays in the container hierarchy) so the provider doesn't multiply into a class-per-combination. Inject the provider into the container with a default (`platform: HostPlatform = hostPlatform`) so a test can pass any OS on any host.
 
 ## Testability
 

--- a/docs/engineering/long-lived-artifacts.md
+++ b/docs/engineering/long-lived-artifacts.md
@@ -26,6 +26,8 @@ Either generalise the *shape* of the error (contrast «principle catches this, b
 
 An incident-rooted example (a string lifted from the task that birthed the rule) is matched literally by the next agent, which then skips structurally identical neighbouring cases. If the rule isn't readable without an example, rewrite the formulation; do not prop it up with a quote from the incident.
 
+A fenced code block that illustrates a pattern follows the same rule: name its participants with synthetic placeholders (`SomeService`, `XxxComponent`), never real project classes or methods. A real symbol in a teaching example is corrupted silently by a mechanical rename of that symbol, and it reads as concrete API a reader may import rather than as a shape to copy.
+
 ## Runtime claims are snapshots, not rules
 
 A long-lived artifact stating «component X currently does Y» is a snapshot — it may have drifted since written.


### PR DESCRIPTION
Retro on #193 / #401.

## Systemic gap
`long-lived-artifacts.md` forbade real code symbols in prose but never addressed **fenced code blocks that teach a pattern**. Two manifestations in #401:
- the ADR "The pattern" snippet named a real component class → a mechanical rename corrupted it → flagged twice in review;
- DI rule 9 (added while closing #193) named real project symbols, breaking its own doc's `SomeService` convention.

## Changes
- **long-lived-artifacts.md** §"Inline examples must be synthetic" — pattern code blocks use synthetic placeholders, never real project symbols (renames corrupt them silently; they read as importable API).
- **dependency-injection.md** rule 9 — code block rewritten to synthetic placeholders, matching sibling rules 1–8.

## 👀 Sanity-check
- Docs-only; no code touched.
- Observation, not actioned: #193's issue "Контракт" froze concrete signatures that drifted from #190/#191 — low ROI to codify since `/implement` already treats issue scope as a starting point.