### PR TITLE
retro from #406: pre-merge defer gate, smoke teardown self-check, exit-code SKIP

### DIFF
--- a/.claude/skills/close-issue/SKILL.md
+++ b/.claude/skills/close-issue/SKILL.md
@@ -70,7 +70,7 @@ One question to the user to check understanding of principles actually applied i
 **After the user's answer:**
 - Assess correctness: what is right, what is missing, what is imprecise or wrong. Without leniency and without aggression — like a technical interviewer giving honest feedback.
 - If the answer was based on an item from the checklist — mark it as completed (`- [ ]` → `- [x]`) directly in `docs/interview-prep-checklist.md` via Edit. If the question was your own (not from the checklist) — add it to the "Additional questions from tasks" section at the end of the checklist as `- [x] <question>` via Edit.
-- **Commit the checklist edit into the current PR branch and push, before the Step 7 merge.**
+- **Commit the checklist edit into the current PR branch and push, before the Step 8 merge.**
 
 **This is not a stop-point based on the content of the answer** — a weak answer does not block the merge. The user decides themselves whether to proceed or explore the topic further. The stop-point is only the fact that the question was asked and an answer was received.
 
@@ -153,22 +153,27 @@ Don't treat this as "a poor estimate" — scope often grows along the way due to
 
 ---
 
-## Step 7 — Merge
+## Step 7 — Known issues & next tasks (pre-merge gate)
+
+Before merging — while the PR can still absorb a fix — surface every loose end. Sources: the issue's "Consequences" / "Out of scope", TODO/FIXME in the diff, anything deferred or scoped out during the work, and any cheap fix you spotted in a file you already touched.
+
+State **each** item as: **"\<known problem / unfinished item\>. Can do now because … / Can't do now because …"** — your honest read of whether it belongs in this PR (cheap and in files already touched → lean do-now; a separate surface / new target / large change → defer). Then ask the user **"What do you disagree with?"** and **stop**.
+
+Hard stop-point: the user redirects do-now-vs-defer here, while the merge is still reversible — not after, when a cheap in-file fix can no longer ride along.
+
+- "Do now" items → implement in this PR (back through the inner loop if non-trivial), re-run the relevant review/runtime checks, then merge.
+- Confirmed defers → file via the `create-issue` skill (here, or right after merge).
+- No loose ends — say so explicitly and proceed.
+
+---
+
+## Step 8 — Merge
 
 ```bash
 gh pr merge <PR> --squash --delete-branch
 ```
 
-Use squash unless otherwise specified. After merging, verify that the PR is closed and the branch is deleted.
-
----
-
-## Step 8 — Next tasks
-
-Look in the issue for a "Consequences" section and in the PR — are there TODOs, unresolved questions, things moved out of scope.
-
-If there are explicit next steps — offer to create issues (use the `create-issue` skill).
-If there is nothing — say so explicitly.
+Use squash unless otherwise specified. After merging, confirm the PR actually merged: `gh pr merge` can print a local-sync error (e.g. "Could not read from remote", "not possible to fast-forward") even when the server-side merge succeeded — leaving the worktree switched to `main` with pre-PR file content, which looks like a failed merge or lost work. Verify via `gh pr view <PR> --json state,mergedAt` (`state == MERGED`) before treating any local CLI error as failure; then confirm the branch is deleted.
 
 ---
 

--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -172,7 +172,7 @@ Runs after the Android and iOS blocks — both need instance A alive for cross-d
 
 Sends `quit` to A, waits up to 8 s, checks exit. PASS if the process exited.
 
-Checks exit code = 0 (last send was AllSent after the retry scenario). If the process had to be force-killed — exit-code check SKIP.
+Checks exit code = 0 (last send was AllSent after the retry scenario). The exit-code check SKIPs when the code is unobtainable: a force-killed process, or — the usual case — CLI A being a non-child of this block's shell (launched in Block 1), where `wait` returns 127. Graceful exit itself still PASS/FAILs normally.
 
 ### Block 7: Cleanup
 
@@ -215,7 +215,7 @@ At the end of the run print a markdown report:
 | Desktop↔Desktop | single-file send | ✓ PASS | file lands in receiver downloads, diff empty |
 | Desktop↔Desktop | multi-file send (3 files) | ✓ PASS | `[send] done — 3/3 sent`, all 3 diff empty |
 | Desktop↔Desktop | retry after error | ✓ PASS | file lands after `retry`, diff empty |
-| Desktop CLI A | exit code on `quit` | ✓ PASS | exit=0 (last send AllSent) |
+| Desktop CLI A | exit code on `quit` | ⊘ SKIP | unobtainable cross-shell (wait=127); graceful exit passed |
 | Same-name discovery | A/B/C convergence | ✓ PASS | each sees 2 SmokeMac peers in 3s |
 | Peer dedup (#346) | no host:port collisions | ✓ PASS | A=0 B=0 C=0 duplicate (host,port) entries |
 | Device name | rename via stdin | ✓ PASS | peer sees new name in <15s |
@@ -236,6 +236,7 @@ At the end of the run print a markdown report:
 | iOS | /health (real bundle) | ✓ PASS | port=55171, "Tether OK" |
 | iOS | /pair X.509 EC P-256 | ✓ PASS | 91 bytes via real Keychain |
 | iOS | Keychain persistence | ✓ PASS | publicKey identical across cold launches |
+| Cleanup | teardown self-check | ✓ PASS | no CLI processes or `$SMOKE_DIR` left after block-7 |
 
 ## Failures
 

--- a/.claude/skills/smoke-test/block-6-graceful-quit.sh
+++ b/.claude/skills/smoke-test/block-6-graceful-quit.sh
@@ -28,5 +28,11 @@ if [ $EXITED -eq 0 ]; then
 else
   set +e; wait "$JPID_A" 2>/dev/null; EXIT_A=$?; set -e
   echo "PASS: graceful quit — exited"
-  [ "$EXIT_A" = "0" ] && echo "PASS: exit code — exit=$EXIT_A (last send AllSent)" || echo "FAIL: exit code — exit=$EXIT_A"
+  if [ "$EXIT_A" = "0" ]; then
+    echo "PASS: exit code — exit=0 (last send AllSent)"
+  else
+    # CLI A was launched by block-1 in a separate shell, so it is not a child of this one;
+    # `wait` returns 127 ("not a child") and the real exit code is unobtainable cross-shell.
+    echo "SKIP: exit-code check — unobtainable cross-shell (wait=$EXIT_A); graceful exit passed"
+  fi
 fi

--- a/.claude/skills/smoke-test/run-all.sh
+++ b/.claude/skills/smoke-test/run-all.sh
@@ -19,6 +19,7 @@ run() { log "===== $1 ====="; shift; "$@" 2>&1 | tee -a "$RESULTS"; }
 # fds detached so the (possibly orphaned) sleep child never holds this script's stdout open.
 ( sleep "${SMOKE_DEADLINE:-540}"; kill -TERM "$$" ) >/dev/null 2>&1 &
 WATCHDOG=$!
+disown 2>/dev/null   # so reaping it in finish() prints no job-control "Terminated" line
 
 cleaned=0
 finish() {
@@ -27,6 +28,13 @@ finish() {
     cleaned=1
     kill "$WATCHDOG" 2>/dev/null; pkill -P "$WATCHDOG" 2>/dev/null
     run BLOCK7 ./block-7-cleanup.sh
+    # Teardown self-check — the harness must leave no instances or scratch behind for this
+    # worktree; without this assertion a silently-broken cleanup leaks every run unseen.
+    local leak=0
+    { [ -n "$SMOKE_JAR" ] && pgrep -f "$SMOKE_JAR" >/dev/null 2>&1; } && leak=1
+    [ -d "$SMOKE_DIR" ] && leak=1
+    [ "$leak" = 0 ] && log "PASS: teardown — no instances or scratch left" \
+      || log "FAIL: teardown — LEAK (CLI processes or $SMOKE_DIR remain after cleanup)"
     log "ALLDONE"
   fi
   exit 0

--- a/.claude/skills/smoke-test/run-all.sh
+++ b/.claude/skills/smoke-test/run-all.sh
@@ -13,6 +13,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 RESULTS="/tmp/smoke-results-$SMOKE_ID.log"
 : > "$RESULTS"
+SECONDS=0   # bash builtin — wall-clock of the whole run, reported in finish()
 log() { echo "$@" | tee -a "$RESULTS"; }
 run() { log "===== $1 ====="; shift; "$@" 2>&1 | tee -a "$RESULTS"; }
 
@@ -35,6 +36,7 @@ finish() {
     [ -d "$SMOKE_DIR" ] && leak=1
     [ "$leak" = 0 ] && log "PASS: teardown — no instances or scratch left" \
       || log "FAIL: teardown — LEAK (CLI processes or $SMOKE_DIR remain after cleanup)"
+    log "TOTAL: $((SECONDS / 60))m$((SECONDS % 60))s (${SECONDS}s)"
     log "ALLDONE"
   fi
   exit 0


### PR DESCRIPTION
Retro on #404 / PR #406.

## Signals addressed

1. **`/close-issue` surfaced defer-vs-do-now *after* the irreversible merge.** The decision point sat on the wrong side of the merge — this task's Block 6 `FAIL→SKIP` fix (3 lines, in a file already touched) was identified only at the post-merge "Next tasks" step, too late to ride along.
2. **The smoke harness never verified its own teardown.** The original #404 cleanup was broken (the `pkill` pattern never matched) yet smoke "passed" every run while leaking orphans — nothing asserted "no processes/scratch left behind".
3. **`gh pr merge` local-sync flake read as failure.** The server-side merge succeeded, but gh's post-merge local fetch errored and switched the worktree to `main` with pre-PR file content — looked like lost work, cost a long diagnostic.

## Changes

- **close-issue**: the known-issues / next-tasks block moves **before** merge as a hard stop-point — each loose end stated as *"can do now because… / can't because…"* + *"what do you disagree with?"*; user redirects do-now-vs-defer while the PR can still absorb a fix. Plus a merge-success verify (confirm `state=MERGED` before trusting a local CLI error).
- **smoke-test**: `run-all.sh`'s `finish` asserts teardown — no `$SMOKE_JAR` processes and `$SMOKE_DIR` gone after block-7, surfaced as PASS / `LEAK` in the report. Watchdog `disown`ed for quiet reaping.
- **block-6** (the bug, approved to fix in this retro): the cross-shell exit-code check is now SKIP, not FAIL — CLI A isn't a child of block-6's shell, so `wait` returns 127 and the code is unobtainable; graceful exit still PASS/FAILs.

## Verification

Live `run-all.sh` (iOS skipped): Block 6 → `SKIP: exit-code check — unobtainable cross-shell (wait=127)`; cleanup → `PASS: teardown — no instances or scratch left`; `ALLDONE`, task exits, `java=0`, `SMOKE_DIR removed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
