### PR TITLE
retro from #423: correct smoke-test packaged-installer coverage claim

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -14,7 +14,7 @@ Runs basic smoke scenarios across Tether targets and produces a human-readable r
 At the start of the run **tell the user** — coverage boundaries:
 
 - **Physical iPhone** — no, requires manual signing and certificate trust.
-- **macOS** — ships through the Desktop JVM target; smoke is covered by the Desktop block (the same jar is packaged into `.app`/`.dmg` via `packageReleaseDistributionForCurrentOS`).
+- **Packaged desktop installers** (jpackage `.dmg` / `.msi` / `.deb` and the `.app` image) — not covered. The Desktop block runs the CLI fat-jar on the full system JDK; the installer instead bundles a jlinked, stripped runtime and launches the Compose UI, a path that surfaces failures the jar never hits. Build and launch the installer manually — see [docs/knowledge/jpackage-jlink-modules.md](../../../docs/knowledge/jpackage-jlink-modules.md).
 - **iOS Local Network Privacy prompt** — on the first app launch on the simulator iOS may show "Allow Local Network access". Without Allow, `NSNetService.publish()` silently fails. If the iOS block fails on publish — check the prompt manually, grant Allow, restart the smoke.
 - **Android-initiated send (Android → Desktop)** — Android has no programmatic send trigger (intent / UI button / broadcast). The skill checks the reverse direction: Desktop → Android via CLI `send`.
 - **Tapping the Notification "Stop" button** — replaced by `am force-stop` or broadcast. That the *button is rendered and works* — verify manually.


### PR DESCRIPTION
**What / why.** The smoke-test skill listed macOS under "what it does NOT check" yet simultaneously claimed the packaged `.app`/`.dmg` was "covered by the Desktop block." It isn't — the Desktop block runs the CLI fat-jar on the full system JDK, while the installer bundles a jlinked, stripped runtime and launches the Compose UI. That false equivalence left the packaging path unverified and is the systemic root of #418 (packaging crash) and the cover for #421 (startup exception). This corrects the claim and links the knowledge note.

**👀 Sanity-check.**
- Retro decided (with the user) **not** to add an automated packaged-startup smoke check: the package build takes minutes and the path only breaks under narrow triggers (new/reflective deps, version bumps, desktop-startup or `nativeDistributions` changes), so a per-task or always-on gate would be mostly waste. Accurate expectation-setting (this doc fix) was preferred over a heavy gate.

Closes #418 (retro)