### PR TITLE
retro from #416: fix dead merge/squash skip in commit-msg hook

### DIFF
--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -190,9 +190,12 @@ cat > "$MSG_HOOK_FILE" << 'EOF'
 
 COMMIT_MSG_FILE="$1"
 
-# Skip auto-generated merge / squash messages.
-COMMIT_SOURCE="$2"
-[ "$COMMIT_SOURCE" = "merge" ] || [ "$COMMIT_SOURCE" = "squash" ] && exit 0
+# Skip auto-generated merge / squash commits. git passes no source argument to
+# commit-msg (only prepare-commit-msg gets it), so detect them from repo state.
+GIT_DIR=$(git rev-parse --git-dir)
+if git rev-parse -q --verify MERGE_HEAD >/dev/null 2>&1 || [ -f "$GIT_DIR/SQUASH_MSG" ]; then
+  exit 0
+fi
 
 # Strip git template comments ("# " or bare "#") and blank lines, take the subject.
 SUBJECT=$(grep -vE '^#([[:space:]]|$)' "$COMMIT_MSG_FILE" | grep -v '^[[:space:]]*$' | head -1)


### PR DESCRIPTION
## What

The `commit-msg` hook intends to exempt auto-generated merge / squash commits, but did so by reading `$2` as the commit source. git passes the source argument only to `prepare-commit-msg`; `commit-msg` receives a single argument (the message-file path). So the exemption was dead code that never ran, and every non-fast-forward `git merge` (notably from `/pull-main`) was rejected for not starting with `#<N>:`, forcing a manual `-m "#<N>: merge…"` recovery.

## Fix

Detect the in-progress operation from repo state instead of the missing source arg:
- merge → `git rev-parse -q --verify MERGE_HEAD`
- squash → `$GIT_DIR/SQUASH_MSG`

Auto-merge commits are now genuinely exempt (the hook author's original intent). Harmless for `main` history: PRs land via squash-merge, so branch-local merge commits never reach `main`.

## Verification

- Bad subject, no merge in progress → still rejected (safety net intact).
- Same bad subject with `MERGE_HEAD` present → passes.
- Normal `#194:` subject → passes.

Run `bash scripts/install-hooks.sh` to pick up the fixed hook locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
