### PR TITLE
plan sprint 13: close sprint-12 by actuals, compose sprint-13

### DIFF
--- a/.claude/sizing-bands.json
+++ b/.claude/sizing-bands.json
@@ -3,7 +3,7 @@
   "generated_by": ".claude/scripts/review-burden.py --write",
   "bands": {
     "S": 0.6,
-    "M": 3.3,
-    "L": 11.7
+    "M": 3.2,
+    "L": 11.6
   }
 }

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -13,6 +13,7 @@ The minimum that makes Tether worth installing. **All four platforms ship togeth
 - Device list screen + transfer/progress screen on every platform.
 - Settable device name (implicit in pairing/discovery; full settings screen comes in Post-MVP).
 - Channel encryption decision made and implemented (see [security.md](../security/README.md)).
+- Installable and published on all four platforms — signed builds from a legitimate channel (Play, App Store, signed desktop installers) plus a public landing page (epic [#430](https://github.com/khmelevartem/tether/issues/430)).
 
 Done = a non-technical user can install Tether on their phone (Android/iOS) and macOS/Windows laptop, pair them once, and reliably move files between them on home Wi-Fi.
 

--- a/docs/sprints/sprint-12.md
+++ b/docs/sprints/sprint-12.md
@@ -4,15 +4,29 @@
 
 ## Состав
 
-| # | Issue | Название | Тип | Размер |
-| - | ----- | -------- | --- | ------ |
-| 1 | [#10](https://github.com/khmelevartem/tether/issues/10) | Паринг — handshake, вычисление PIN-кода, CLI-флоу | feature | M |
-| 2 | [#378](https://github.com/khmelevartem/tether/issues/378) | Independent threat model and attack-surface analysis for pairing and transfer | docs | L |
-| 3 | [#361](https://github.com/khmelevartem/tether/issues/361) | Pairing mutual confirmation before trust is stored | feature | M |
-| 4 | [#193](https://github.com/khmelevartem/tether/issues/193) | Desktop sender wiring: AWT file picker на EDT и drag-and-drop по окну | feature | M |
-| 5 | [#194](https://github.com/khmelevartem/tether/issues/194) | iOS sender wiring: UIDocumentPickerViewController и bookmark-based FileSource | feature | M |
-| 6 | [#198](https://github.com/khmelevartem/tether/issues/198) | Structured findings + synthesis pass в /code-review | infra | M |
-| 7 | [#354](https://github.com/khmelevartem/tether/issues/354) | Block writes outside the current worktree via PreToolUse hook | infra | S |
+**Итог:** 5/7 закрыто. #10 переехал (новый блокер [#429](https://github.com/khmelevartem/tether/issues/429)), #361 снят со скоупа — поглощён в переопределённый #10.
+
+| # | Issue | Название | Тип | Размер | Итог |
+| - | ----- | -------- | --- | ------ | ---- |
+| 1 | [#10](https://github.com/khmelevartem/tether/issues/10) | Паринг — handshake, вычисление PIN-кода, CLI-флоу | feature | M | ❌ не сделано (блокер [#429](https://github.com/khmelevartem/tether/issues/429); попытка [#362](https://github.com/khmelevartem/tether/pull/362) закрыта без мерджа) |
+| 2 | [#378](https://github.com/khmelevartem/tether/issues/378) | Independent threat model and attack-surface analysis for pairing and transfer | docs | L | ✅ закрыто ([PR #394](https://github.com/khmelevartem/tether/pull/394)) |
+| 3 | [#361](https://github.com/khmelevartem/tether/issues/361) | Pairing mutual confirmation before trust is stored | feature | M | ❌ снят (NOT_PLANNED — confirm-before-trust поглощён в переопределённый #10) |
+| 4 | [#193](https://github.com/khmelevartem/tether/issues/193) | Desktop sender wiring: AWT file picker на EDT и drag-and-drop по окну | feature | M | ✅ закрыто ([PR #401](https://github.com/khmelevartem/tether/pull/401)) |
+| 5 | [#194](https://github.com/khmelevartem/tether/issues/194) | iOS sender wiring: UIDocumentPickerViewController и bookmark-based FileSource | feature | M | ✅ закрыто ([PR #416](https://github.com/khmelevartem/tether/pull/416)) |
+| 6 | [#198](https://github.com/khmelevartem/tether/issues/198) | Structured findings + synthesis pass в /code-review | infra | M | ✅ закрыто ([PR #396](https://github.com/khmelevartem/tether/pull/396)) |
+| 7 | [#354](https://github.com/khmelevartem/tether/issues/354) | Block writes outside the current worktree via PreToolUse hook | infra | S | ✅ закрыто ([PR #400](https://github.com/khmelevartem/tether/pull/400)) |
+
+## Дополнительные результаты
+
+Закрыты в окне спринта вне исходного состава:
+
+- [#194 → #416](https://github.com/khmelevartem/tether/pull/416) учтён в составе; ниже — внеплановое.
+- [#148](https://github.com/khmelevartem/tether/issues/148) ([PR #402](https://github.com/khmelevartem/tether/pull/402)) — «This device» на device list с inline-rename: закрывает UI-хвост device-name-bootstrapping.
+- [#367](https://github.com/khmelevartem/tether/issues/367) ([PR #414](https://github.com/khmelevartem/tether/pull/414)) — opt-in persistent CLI identity + fingerprint-keyed PeerIdentity: стабильная идентичность пира между рестартами, фундамент под паринг.
+- [#418](https://github.com/khmelevartem/tether/issues/418) ([PR #423](https://github.com/khmelevartem/tether/pull/423)) — packaged desktop installers запускаются (bundled JDK, Windows icon): первый задел под эпик #430.
+- [#214](https://github.com/khmelevartem/tether/issues/214) ([PR #420](https://github.com/khmelevartem/tether/pull/420)) — review-ux-brief: UX-доменный ревьюер для ux-brief.md.
+- [#404](https://github.com/khmelevartem/tether/issues/404) ([PR #406](https://github.com/khmelevartem/tether/pull/406), [PR #415](https://github.com/khmelevartem/tether/pull/415)) — smoke-test изолируется по воркт­ри и надёжно гасит свои CLI-инстансы.
+- [#397](https://github.com/khmelevartem/tether/issues/397) ([PR #398](https://github.com/khmelevartem/tether/pull/398)) — sizing по review-усилию в create-issue/close-issue + cost в /progress.
 
 ## Что разблокирует
 

--- a/docs/sprints/sprint-12.md
+++ b/docs/sprints/sprint-12.md
@@ -20,7 +20,6 @@
 
 Закрыты в окне спринта вне исходного состава:
 
-- [#194 → #416](https://github.com/khmelevartem/tether/pull/416) учтён в составе; ниже — внеплановое.
 - [#148](https://github.com/khmelevartem/tether/issues/148) ([PR #402](https://github.com/khmelevartem/tether/pull/402)) — «This device» на device list с inline-rename: закрывает UI-хвост device-name-bootstrapping.
 - [#367](https://github.com/khmelevartem/tether/issues/367) ([PR #414](https://github.com/khmelevartem/tether/pull/414)) — opt-in persistent CLI identity + fingerprint-keyed PeerIdentity: стабильная идентичность пира между рестартами, фундамент под паринг.
 - [#418](https://github.com/khmelevartem/tether/issues/418) ([PR #423](https://github.com/khmelevartem/tether/pull/423)) — packaged desktop installers запускаются (bundled JDK, Windows icon): первый задел под эпик #430.

--- a/docs/sprints/sprint-13.md
+++ b/docs/sprints/sprint-13.md
@@ -1,0 +1,25 @@
+# Sprint 13 · Острог на Берегу
+
+**Направления:** iOS · transfer · UI · identity
+
+## Состав
+
+| # | Issue | Название | Тип | Размер |
+| - | ----- | -------- | --- | ------ |
+| 1 | [#224](https://github.com/khmelevartem/tether/issues/224) | iOS Share Sheet → Tether: отправка файлов из Photos / Files / других приложений | feature | L |
+| 2 | [#417](https://github.com/khmelevartem/tether/issues/417) | Received files reachable by the user on iOS | feature | M |
+| 3 | [#426](https://github.com/khmelevartem/tether/issues/426) | Mobile screens have unwanted edge padding | bugfix | S |
+| 4 | [#429](https://github.com/khmelevartem/tether/issues/429) | Derive device fingerprint from EC P-256 public key | feature | S |
+| 5 | [#425](https://github.com/khmelevartem/tether/issues/425) | Reactive peer snapshot in PeerTransferComponent — fix stale isOnline | refactor | S |
+| 6 | [#389](https://github.com/khmelevartem/tether/issues/389) | CLI: restore live byte/speed progress line during send | bugfix | S |
+
+## Что разблокирует
+
+- После #224 + #417 iOS получает полный round-trip: отправка через системный share-sheet и доступ к принятым файлам — закрывается iOS-хвост эпика #8.
+- После #429 снимается блокер #10 (паринг переходит на fingerprint от настоящего EC-ключа вместо interim random hex) — #10 встаёт в Sprint 14 без переезда.
+
+## Порядок мерджа
+
+#224 → #417 ; #426 || #429 || #425 || #389
+
+`||` — параллельные ветки. #224 и #417 делят iosMain file-handling (Share Extension target / app group и receive-path destination) — мержить последовательно. #426 (common-UI `safeContentPadding`), #429 (commonMain crypto/identity), #425 (presentation `PeerTransferComponent`) и #389 (jvmMain/CLI) изолированы друг от друга и от iOS-пары.


### PR DESCRIPTION
## Sprint 12 — closed by actuals

**5/7 closed.** #10 slipped (new blocker #429), #361 scoped out (NOT_PLANNED — `confirm-before-trust` folded into the redefined #10).

Outcome column + **Дополнительные результаты** section added to `sprint-12.md`. 6 in-window results outside the original composition: #148, #367, #418, #214, #404, #397.

## Cost bands recalibrated

`review-burden.py --write` → `S 0.6 · M 3.2 · L 11.6` (M eased from prior run).

## Sprint 13 · Острог на Берегу — composed

iOS-focused, small-leaning. One heavy anchor + five small, across five isolated layers.

| # | Issue | Size | Layer |
|---|-------|------|-------|
| #224 | iOS Share Sheet → Tether | L | iosMain (sender) |
| #417 | Received files reachable on iOS | M | iosMain (receiver) |
| #426 | Mobile edge padding | S | common UI root |
| #429 | Fingerprint from EC P-256 pubkey | S | common crypto |
| #425 | Reactive peer snapshot | S | presentation |
| #389 | CLI live progress line | S | jvmMain/CLI |

- #224 + #417 close the iOS file round-trip (epic #8 iOS tail).
- #429 clears the blocker that keeps bouncing #10 → #10 lands in Sprint 14 without slipping.

All candidates verified unblocked (closed ancestors only).

## Roadmap

8th MVP bar recorded — installable & published on all four platforms (epic #430) — formalizing the existing `Done =` clause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)