### PR TITLE
retro from #450: make allTests the coder's done-gate

### DIFF
--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -66,7 +66,7 @@ When in doubt whether a finding is pointwise or structural — assume structural
 2. **Simplify pass.** Re-read your own diff. For each block ask: can this be shorter without losing clarity? Specifically: dead branches, premature abstractions, helpers used once, `when` with single branch, `if (x) true else false`, redundant null checks after `requireNotNull`, exception handlers that just re-throw, comments that restate code. Cut them. Better to ship 30 lines than 60.
 
    **Prose differs from code.** For comments, KDoc, and any Markdown / doc / skill text in the diff: the goal is not fewer words but fewer non-load-bearing facts. Cut whole sentences that (a) narrate the history of how the artifact got its current shape, (b) restate something already said nearby, or (c) describe something that does NOT exist in the artifact — a feature considered and dropped, a control we chose not to render — unless its absence is a non-obvious invariant the reader would otherwise assume. Do **not** reword load-bearing sentences just to shorten them; word-count reduction on well-formed sentences is not a goal.
-3. Run `./gradlew allTests -q` (or scope to the affected source set).
+3. Run `./gradlew allTests -q` before reporting done — a single source set is for the inner edit-rerun loop only, since `expect/actual` code can pass on one target and fail on another.
 4. Do NOT commit. The orchestrator decides when to commit, after review passes.
 
 ## Output to caller


### PR DESCRIPTION
## What / why

Retro on #425 / #450. The test-fix re-entry reported "done" after running only `:composeApp:desktopTest`; the chooser flag is `expect/actual` (Desktop `false`, Android/Apple `true`), so Android failed while Desktop passed. The pre-push hook (allTests) caught it before anything reached the remote — the correctness gate worked. What did not work was the agent's *report*: a single green target was treated as the result.

[coder.md:69](.claude/agents/coder.md) actively licensed this with `(or scope to the affected source set)`. This drops that escape: `allTests` is the done-gate; a single source set is for the inner edit-rerun loop only.

## 👀 Sanity-check

- Single edit, one line in the coder brief. No runtime code, no behavior change.
- Considered and **dropped**: a paragraph in `testing.md` — it would duplicate what the pre-push hook already enforces (`testing.md:101`), against long-lived-artifacts discipline.
- Considered and **dropped (no action)**: code-symbol leak into docs (sheet named by its composable class in the ux-brief). The rule already lives in five places and the human caught it pre-merge — system working; a sixth restatement or a CamelCase lint (false-positives on the template's own good examples) is net-negative.
