### PR TITLE
retro from #470: reviewers verify each enumerated input class, not a representative

### DIFF
--- a/.claude/agents/review-dod.md
+++ b/.claude/agents/review-dod.md
@@ -26,8 +26,9 @@ If the issue references a feature spec in `docs/product/features/` — read it; 
    - `DONE` — the diff visibly implements it (point to file:line)
    - `MISSING` — no trace in the diff
    - `UNVERIFIABLE` — requires runtime / manual check; record as an explicit question
-3. **Scope creep:** flag files in the diff that don't map to any criterion. Out-of-scope changes are findings, not virtues.
-4. **PR body — dependency disclosure:** if the diff adds production dependencies, the PR body must call them out (any phrasing). Missing disclosure → REQUIRED finding. Smoke verdict in the body is optional — orchestrators gate on green smoke pre-push, so absence is not a finding.
+3. **Enumerated-class criteria — check each class, not a representative.** When a criterion names several input classes (media types, file kinds, peer states) routed through separate branches, check each one. Proving a single case is not `DONE` for its siblings — a class whose outcome the diff cannot show, because it rests on runtime platform behaviour, is `UNVERIFIABLE` with an explicit question, never `DONE` by association.
+4. **Scope creep:** flag files in the diff that don't map to any criterion. Out-of-scope changes are findings, not virtues.
+5. **PR body — dependency disclosure:** if the diff adds production dependencies, the PR body must call them out (any phrasing). Missing disclosure → REQUIRED finding. Smoke verdict in the body is optional — orchestrators gate on green smoke pre-push, so absence is not a finding.
 
 ## What you do NOT check
 

--- a/.claude/agents/review-tests.md
+++ b/.claude/agents/review-tests.md
@@ -85,6 +85,15 @@ Per `testing.md §Real time vs virtual time`, flag as `[REQUIRED]`:
 - a real-thread integration test that synchronizes by a fixed delay ("wait long enough") instead of awaiting an observable condition (completion signal / state transition);
 - an assertion on a side-effect produced by another thread (a file the peer writes, a log line) where the operation's contract already implies it, or that polls for the side-effect to appear.
 
+### 12. Unit-untestable platform branches relocate coverage; they don't excuse it
+
+When the unit runner cannot exercise a feature's divergent platform branches — a headless
+test process resolves a platform API differently than a real device — the coverage
+obligation moves to the runtime/smoke layer; it does not vanish. Require a guard that drives
+**each** input class to its observable outcome, not one representative assumed to vouch for
+its siblings. A branch that looks correct but is never run, in any test layer, is
+`[REQUIRED]`: name the class that lacks a guard.
+
 ## What you do NOT check
 
 - AC coverage → review-dod


### PR DESCRIPTION
**Retro on [#470](https://github.com/khmelevartem/tether/pull/470).** A received video shipped misclassified as an image and was caught only by manual device testing — past the full review wave + smoke. The bug itself is fixed in #470; this PR closes the **escape** path so the next such case is caught in review.

**Why it escaped.** The DoD enumerated two media classes (photo + video) routed through divergent platform branches. Smoke proved the image route and the video route was assumed identical — but its branch was dead, and being unit-untestable in the headless runner, smoke was the only possible guard. One passing sibling case hid an unrun branch.

**Fix — two reviewers, two angles:**
- **review-dod:** an enumerated-class criterion is checked per class; a class whose outcome the diff cannot show is `UNVERIFIABLE`, not `DONE` by association with a proven sibling.
- **review-tests:** unit-untestability relocates the coverage obligation to the runtime/smoke layer per class — it does not excuse a missing guard.

Generalized wording (no incident reference, no code symbols), per `long-lived-artifacts.md`.

No backing issue — retro fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
