### PR TITLE
plan sprint 14: close sprint-13, compose sprint-14

### DIFF
--- a/.claude/sizing-bands.json
+++ b/.claude/sizing-bands.json
@@ -2,8 +2,8 @@
   "metric": "mean ROOT review comments per closed sized issue with a merged PR",
   "generated_by": ".claude/scripts/review-burden.py --write",
   "bands": {
-    "S": 0.6,
-    "M": 3.2,
-    "L": 11.6
+    "S": 0.5,
+    "M": 3.1,
+    "L": 10.5
   }
 }

--- a/docs/sprints/sprint-13.md
+++ b/docs/sprints/sprint-13.md
@@ -4,14 +4,25 @@
 
 ## Состав
 
-| # | Issue | Название | Тип | Размер |
-| - | ----- | -------- | --- | ------ |
-| 1 | [#224](https://github.com/khmelevartem/tether/issues/224) | iOS Share Sheet → Tether: отправка файлов из Photos / Files / других приложений | feature | L |
-| 2 | [#417](https://github.com/khmelevartem/tether/issues/417) | Received files reachable by the user on iOS | feature | M |
-| 3 | [#426](https://github.com/khmelevartem/tether/issues/426) | Mobile screens have unwanted edge padding | bugfix | S |
-| 4 | [#429](https://github.com/khmelevartem/tether/issues/429) | Derive device fingerprint from EC P-256 public key | feature | S |
-| 5 | [#425](https://github.com/khmelevartem/tether/issues/425) | Reactive peer snapshot in PeerTransferComponent — fix stale isOnline | refactor | S |
-| 6 | [#389](https://github.com/khmelevartem/tether/issues/389) | CLI: restore live byte/speed progress line during send | bugfix | S |
+**Итог:** 6/6 закрыто. Все цели достигнуты — iOS round-trip и identity-фундамент под паринг закрыты.
+
+| # | Issue | Название | Тип | Размер | Итог |
+| - | ----- | -------- | --- | ------ | ---- |
+| 1 | [#224](https://github.com/khmelevartem/tether/issues/224) | iOS Share Sheet → Tether: отправка файлов из Photos / Files / других приложений | feature | L | ✅ закрыто ([PR #452](https://github.com/khmelevartem/tether/pull/452)) |
+| 2 | [#417](https://github.com/khmelevartem/tether/issues/417) | Received files reachable by the user on iOS | feature | M | ✅ закрыто ([PR #456](https://github.com/khmelevartem/tether/pull/456)) |
+| 3 | [#426](https://github.com/khmelevartem/tether/issues/426) | Mobile screens have unwanted edge padding | bugfix | S | ✅ закрыто ([PR #448](https://github.com/khmelevartem/tether/pull/448)) |
+| 4 | [#429](https://github.com/khmelevartem/tether/issues/429) | Derive device fingerprint from EC P-256 public key | feature | S | ✅ закрыто ([PR #451](https://github.com/khmelevartem/tether/pull/451)) |
+| 5 | [#425](https://github.com/khmelevartem/tether/issues/425) | Reactive peer snapshot in PeerTransferComponent — fix stale isOnline | refactor | S | ✅ закрыто ([PR #450](https://github.com/khmelevartem/tether/pull/450)) |
+| 6 | [#389](https://github.com/khmelevartem/tether/issues/389) | CLI: restore live byte/speed progress line during send | bugfix | S | ✅ закрыто ([PR #449](https://github.com/khmelevartem/tether/pull/449)) |
+
+## Дополнительные результаты
+
+Закрыты в окне спринта вне исходного состава:
+
+- [#461](https://github.com/khmelevartem/tether/issues/461) ([PR #470](https://github.com/khmelevartem/tether/pull/470)) — приём сохраняется в системную галерею (iOS Photos + Android MediaStore) после подтверждённой загрузки: принятые медиа видны в штатной галерее, а не только внутри приложения.
+- [#419](https://github.com/khmelevartem/tether/issues/419) ([PR #422](https://github.com/khmelevartem/tether/pull/422)) — spec + UX brief для clipboard-transfer: дизайн-фундамент под эпик #469.
+- [#462](https://github.com/khmelevartem/tether/issues/462) ([PR #463](https://github.com/khmelevartem/tether/pull/463)) — epic-aware /progress + актуализированный индекс фич.
+- [#443](https://github.com/khmelevartem/tether/issues/443) ([PR #444](https://github.com/khmelevartem/tether/pull/444)) — /implement-оркестратор работает экономнее по контексту и токенам.
 
 ## Что разблокирует
 

--- a/docs/sprints/sprint-14.md
+++ b/docs/sprints/sprint-14.md
@@ -1,6 +1,6 @@
 # Sprint 14 · Раскопки в Саартале
 
-**Направления:** .claude framework · publication · transport
+**Направления:** .claude framework · publication · receiver · discovery · UI
 
 ## Состав
 
@@ -8,8 +8,17 @@
 | - | ----- | -------- | --- | ------ |
 | 1 | [#465](https://github.com/khmelevartem/tether/issues/465) | Project-context adapter: decouple framework from repo-specific paths and conventions | infra | L |
 | 2 | [#479](https://github.com/khmelevartem/tether/issues/479) | Manual DI in KMP — article on Habr and Medium | docs | M |
-| 3 | [#386](https://github.com/khmelevartem/tether/issues/386) | Receiver detects truncation of unknown-size uploads | bugfix | M |
+| 3 | [#195](https://github.com/khmelevartem/tether/issues/195) | Receiver UI: FileServer events, PeerCard inbound states, платформенные уведомления | feature | M |
+| 4 | [#326](https://github.com/khmelevartem/tether/issues/326) | Discovery: idle-expiry for /hello and fallback-channel peers | feature | S |
+| 5 | [#222](https://github.com/khmelevartem/tether/issues/222) | Settings navigation surface — единый host для секций настроек на 4 платформах | feature | M |
 
 ## Что разблокирует
 
 - После #465 размораживается эпик #464: #466 (упаковка плагина) встаёт на готовый адаптер, а за ним #467/#468 (видео и статья о фреймворке) — путь к внешней видимости фреймворка открыт.
+- После #222 будущие settings-секции (#223 save location / large-selection, device-name rename, theme override) втыкаются в готовый host как self-contained sections, не таща за собой собственный route и back-handling.
+
+## Порядок мерджа
+
+#465 || #479 ; (#222 || #326) → #195
+
+`||` — параллельные ветки. #465 (`.claude/`) и #479 (`docs/` + внешняя публикация) изолированы от всего остального и друг от друга. #195 — точка схождения: делит `FileServerRoutes.kt` с #326 (событийный поток на `/upload` vs `/hello`-upsert) и `RootComponent` + `DeviceListScreen` с #222 (inbound-стейты PeerCard vs settings-child и шестерёнка в top bar). Поэтому #195 мержится строго после #222 и #326; сами #222 и #326 друг от друга независимы и идут параллельно.

--- a/docs/sprints/sprint-14.md
+++ b/docs/sprints/sprint-14.md
@@ -1,0 +1,15 @@
+# Sprint 14 · Раскопки в Саартале
+
+**Направления:** .claude framework · publication · transport
+
+## Состав
+
+| # | Issue | Название | Тип | Размер |
+| - | ----- | -------- | --- | ------ |
+| 1 | [#465](https://github.com/khmelevartem/tether/issues/465) | Project-context adapter: decouple framework from repo-specific paths and conventions | infra | L |
+| 2 | [#479](https://github.com/khmelevartem/tether/issues/479) | Manual DI in KMP — article on Habr and Medium | docs | M |
+| 3 | [#386](https://github.com/khmelevartem/tether/issues/386) | Receiver detects truncation of unknown-size uploads | bugfix | M |
+
+## Что разблокирует
+
+- После #465 размораживается эпик #464: #466 (упаковка плагина) встаёт на готовый адаптер, а за ним #467/#468 (видео и статья о фреймворке) — путь к внешней видимости фреймворка открыт.


### PR DESCRIPTION
## Что внутри

Планирование Sprint 14 + закрытие Sprint 13 по факту.

**Sprint 13 — закрыт:** 6/6 задач, плюс 4 внеплановых результата в окне (#461, #419, #462, #443). Добавлены колонка `Итог` и секция «Дополнительные результаты».

**Cost-бэнды пересчитаны** по 128 закрытым-с-PR задачам: S 0.5 · M 3.1 · L 10.5 (`.claude/sizing-bands.json`).

**Sprint 14 · Раскопки в Саартале** — направление «reap the framework» + продуктовые фичи:

| # | Задача | Тип | Размер |
| - | ------ | --- | ------ |
| [#465](https://github.com/khmelevartem/tether/issues/465) | Project-context adapter (старт эпика #464) | infra | L |
| [#479](https://github.com/khmelevartem/tether/issues/479) | Manual-DI статья (Habr+Medium) | docs | M |
| [#195](https://github.com/khmelevartem/tether/issues/195) | Видимый receiver — события, PeerCard, уведомления | feature | M |
| [#326](https://github.com/khmelevartem/tether/issues/326) | Discovery idle-expiry для /hello | feature | S |
| [#222](https://github.com/khmelevartem/tether/issues/222) | Settings nav host на 4 платформах | feature | M |

Порядок мерджа: `#465 || #479 ; (#222 || #326) → #195` — #195 последним (точка схождения по `FileServerRoutes.kt` и `RootComponent`/`DeviceListScreen`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)