### PR TITLE
#17: /progress Artifact Spread splits retro/planning into own sector

### DIFF
--- a/.claude/skills/progress/SKILL.md
+++ b/.claude/skills/progress/SKILL.md
@@ -145,7 +145,7 @@ Linking PR ↔ issue by the `#N:` prefix in the PR title. If the PR is a retro /
 Rendered as a Chart.js stacked area chart by day (from sprint cutoff to `--today`). Two stacked areas: feature (`gold.primary`) and infra (`gold.dim`). Below: three cards — total valour / average daily valour / most glorious day.
 
 ### Artifact Spread
-Doughnut of merged PRs by size: S / M / L / unlabeled. Size derived from the `size:S|M|L` label on the linked issue (via `#N:` title prefix); PRs without a matching issue or label → "unlabeled".
+Doughnut of merged PRs by size: S / M / L / ретро-планнинг / прочее. Process PRs are split off first — a title starting with `retro` or `plan sprint` → "process" (own purple sector), since they have no backing issue and would otherwise swamp the grey remainder. For the rest, size is derived from the `size:S|M|L` label on the linked issue (via `#N:` title prefix); a PR without a matching issue or label → "unlabeled" (shown as "прочее" — early/service PRs before the `#N:` convention).
 
 ### Balance of the Week — feature share over the last 7 days
 

--- a/.claude/skills/progress/build.py
+++ b/.claude/skills/progress/build.py
@@ -415,8 +415,12 @@ def glory_of_days(prs_merged: list, issues_by_number: dict, keywords: dict,
 
 
 def artifact_spread(prs_merged: list, issues_by_number: dict) -> dict:
-    counts = {"S": 0, "M": 0, "L": 0, "unlabeled": 0}
+    counts = {"S": 0, "M": 0, "L": 0, "process": 0, "unlabeled": 0}
     for pr in prs_merged:
+        title = pr.get("title", "").lower()
+        if title.startswith("retro") or title.startswith("plan sprint"):
+            counts["process"] += 1
+            continue
         size = _issue_size(pr, issues_by_number)
         counts[size] = counts.get(size, 0) + 1
     return counts
@@ -1212,9 +1216,11 @@ def render_artifact_spread(spread: dict) -> str:
     txt_m = pal("text.muted")
     bg_card = pal("background.card")
 
-    labels = ["S", "M", "L", "unlabeled"]
-    colors = [pal("gold.primary"), pal("gold.secondary"), pal("gold.tertiary"), pal("text.muted_dim")]
-    data = [spread.get(l, 0) for l in labels]
+    keys = ["S", "M", "L", "process", "unlabeled"]
+    labels = ["S", "M", "L", "ретро/планнинг", "прочее"]
+    colors = [pal("gold.primary"), pal("gold.secondary"), pal("gold.tertiary"),
+              pal("graph_nodes.epic.fill"), pal("text.muted_dim")]
+    data = [spread.get(k, 0) for k in keys]
     labels_js = _to_script_json(labels)
     data_js = _to_script_json(data)
     colors_js = _to_script_json(colors)


### PR DESCRIPTION
## Что и зачем

В графе **«Размах Артефактов»** (`/progress`) процессные PR — `retro from #N` и `plan sprint N` — не имеют бэкинг-issue, поэтому валились в серый сектор `unlabeled` и заполняли его собой: **93 из 250** merged-PR были «неразмеченными», из них **75 — ретро+планнинг**. Сектор переставал отражать реальный размах размеченной работы.

## Изменение

Процессные PR отщепляются в отдельный пурпурный сектор **«ретро/планнинг»** до размерной классификации. Серый сектор переименован в **«прочее»** и теперь держит только ранние/служебные PR до конвенции `#N:`.

Было: `S / M / L / unlabeled` → стало: `S / M / L / ретро-планнинг / прочее`.

На текущих данных: `52 / 55 / 50 / 75 / 18` (раньше последние два были одним `93`).

## Затронуто

- `.claude/skills/progress/build.py` — `artifact_spread()` (бакет `process`) + рендер (5 секторов, цвет `graph_nodes.epic.fill`).
- `.claude/skills/progress/SKILL.md` — описание метрики приведено в соответствие.

Чисто аналитический тулинг — рантайм приложения не затронут.

Relates to #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)