### PR TITLE
#491: narrow /implement inner-loop reviewer roster; keep Wave A full

### DIFF
--- a/.claude/agents/review-glossary.md
+++ b/.claude/agents/review-glossary.md
@@ -12,7 +12,7 @@ You check whether prose under review uses Tether's load-bearing nouns the way [`
 The dispatching caller supplies one of three input modes:
 
 - **PR diff** — `gh pr view <PR> --json title,body,files` + `gh pr diff <PR>`.
-- **Working tree** — when no PR exists yet (any pre-PR dispatch, e.g. `/implement`'s Wave A full-review): `git diff main...HEAD`.
+- **Working tree** — when no PR exists yet: `git diff main...HEAD`.
 - **Inline prose** — when there is no diff at all (e.g. `create-issue` Step 4 reviewing a draft issue body composed in chat): the dispatcher passes the prose string in the prompt. Treat it as the only artifact under review; «file:line» citations are then «draft:line».
 
 Always read `docs/glossary.md` in full before sampling. Definitions in the glossary win over the prose under review.

--- a/.claude/agents/review-glossary.md
+++ b/.claude/agents/review-glossary.md
@@ -12,7 +12,7 @@ You check whether prose under review uses Tether's load-bearing nouns the way [`
 The dispatching caller supplies one of three input modes:
 
 - **PR diff** — `gh pr view <PR> --json title,body,files` + `gh pr diff <PR>`.
-- **Working tree** — when no PR exists yet (any pre-PR dispatch, e.g. `/implement`'s inner-loop and full-review waves): `git diff main...HEAD`.
+- **Working tree** — when no PR exists yet (any pre-PR dispatch, e.g. `/implement`'s Wave A full-review): `git diff main...HEAD`.
 - **Inline prose** — when there is no diff at all (e.g. `create-issue` Step 4 reviewing a draft issue body composed in chat): the dispatcher passes the prose string in the prompt. Treat it as the only artifact under review; «file:line» citations are then «draft:line».
 
 Always read `docs/glossary.md` in full before sampling. Definitions in the glossary win over the prose under review.

--- a/.claude/skills/implement/scripts/select-pipeline.sh
+++ b/.claude/skills/implement/scripts/select-pipeline.sh
@@ -68,18 +68,17 @@ INNER_REVIEWERS=""
 if [ "$TRACK" = "code" ]; then
   add_inner() { INNER_REVIEWERS="${INNER_REVIEWERS:+$INNER_REVIEWERS }$1"; }
 
-  add_inner "review-dod"
-  if [ "$TYPE" != "docs" ] && ! is_refactor; then
+  # Inner-loop is narrow on purpose: only reviewers whose miss cost compounds
+  # across iterations belong here. Mechanical / single-pass / expensive ones
+  # (dod, glossary, tests, design-system, visual, ux-brief, reuse) defer to
+  # Wave A, which sees the final diff once.
+  if ! is_refactor; then
     add_inner "review-correctness"
   fi
-  add_inner "review-guides"
-  add_inner "review-glossary"
   # review-architecture runs for all code-track work; over-inclusion is safe
   # because a reviewer with nothing to flag returns APPROVE.
   add_inner "review-architecture"
-  if [ "$TYPE" != "infra" ]; then
-    add_inner "review-tests"
-  fi
+  add_inner "review-guides"
   if has_touched "platform"; then
     add_inner "review-platform"
   fi
@@ -88,11 +87,6 @@ if [ "$TRACK" = "code" ]; then
     # orchestrator resolves this at dispatch time — we include it here when ui
     # is touched; the orchestrator suppresses dispatch when no brief exists.
     add_inner "review-ux-conformance"
-    add_inner "review-design-system"
-    add_inner "review-visual"
-  fi
-  if has_touched "ux-brief"; then
-    add_inner "review-ux-brief"
   fi
 fi
 

--- a/.claude/skills/implement/scripts/select-pipeline.sh
+++ b/.claude/skills/implement/scripts/select-pipeline.sh
@@ -69,9 +69,7 @@ if [ "$TRACK" = "code" ]; then
   add_inner() { INNER_REVIEWERS="${INNER_REVIEWERS:+$INNER_REVIEWERS }$1"; }
 
   # Inner-loop is narrow on purpose: only reviewers whose miss cost compounds
-  # across iterations belong here. Mechanical / single-pass / expensive ones
-  # (dod, glossary, tests, design-system, visual, ux-brief, reuse) defer to
-  # Wave A, which sees the final diff once.
+  # across iterations belong here. Wave A is the broad final-gate roster.
   if ! is_refactor; then
     add_inner "review-correctness"
   fi

--- a/.claude/skills/implement/scripts/select-pipeline.test.sh
+++ b/.claude/skills/implement/scripts/select-pipeline.test.sh
@@ -71,7 +71,7 @@ assert_eq "c1 steps" \
   "$(steps_line "$OUT")"
 
 assert_eq "c1 inner" \
-  "inner-loop-reviewers: review-dod review-correctness review-guides review-glossary review-architecture review-tests" \
+  "inner-loop-reviewers: review-correctness review-architecture review-guides" \
   "$(inner_line "$OUT")"
 
 assert_eq "c1 wave-a" \
@@ -83,7 +83,7 @@ assert_eq "c1 wave-a" \
 OUT=$(run code feature fresh "ui,code,platform")
 
 assert_eq "c2 inner" \
-  "inner-loop-reviewers: review-dod review-correctness review-guides review-glossary review-architecture review-tests review-platform review-ux-conformance review-design-system review-visual" \
+  "inner-loop-reviewers: review-correctness review-architecture review-guides review-platform review-ux-conformance" \
   "$(inner_line "$OUT")"
 
 assert_eq "c2 wave-a" \
@@ -99,7 +99,7 @@ assert_eq "c3 steps" \
   "$(steps_line "$OUT")"
 
 assert_eq "c3 inner" \
-  "inner-loop-reviewers: review-dod review-correctness review-guides review-glossary review-architecture review-tests" \
+  "inner-loop-reviewers: review-correctness review-architecture review-guides" \
   "$(inner_line "$OUT")"
 
 assert_eq "c3 wave-a" \
@@ -119,7 +119,7 @@ assert_eq "c3b steps" \
 OUT=$(run code refactor fresh "")
 
 assert_eq "c4 inner" \
-  "inner-loop-reviewers: review-dod review-guides review-glossary review-architecture review-tests" \
+  "inner-loop-reviewers: review-architecture review-guides" \
   "$(inner_line "$OUT")"
 
 assert_eq "c4 wave-a" \
@@ -131,7 +131,7 @@ assert_eq "c4 wave-a" \
 OUT=$(run code infra fresh "")
 
 assert_eq "c5 inner" \
-  "inner-loop-reviewers: review-dod review-correctness review-guides review-glossary review-architecture" \
+  "inner-loop-reviewers: review-correctness review-architecture review-guides" \
   "$(inner_line "$OUT")"
 
 assert_eq "c5 wave-a" \
@@ -196,8 +196,12 @@ assert_nonzero_exit "c12 unknown-track" banana feature fresh ""
 
 for touched in "" "ui,code,platform"; do
   OUT=$(run code feature fresh "$touched")
-  for reviewer in review-dod review-guides review-glossary; do
+  # Always in inner-loop (narrow roster — compounding-cost reviewers only).
+  for reviewer in review-guides review-architecture; do
     assert_contains "always-inner $reviewer (touched=$touched)" "$reviewer" "$(inner_line "$OUT")"
+  done
+  # Always in Wave A (broad final-gate roster).
+  for reviewer in review-dod review-guides review-glossary; do
     assert_contains "always-wave-a $reviewer (touched=$touched)" "$reviewer" "$(wave_a_line "$OUT")"
   done
   assert_eq "wave-b review-adversarial (touched=$touched)" \

--- a/.claude/skills/implement/scripts/select-pipeline.test.sh
+++ b/.claude/skills/implement/scripts/select-pipeline.test.sh
@@ -196,8 +196,8 @@ assert_nonzero_exit "c12 unknown-track" banana feature fresh ""
 
 for touched in "" "ui,code,platform"; do
   OUT=$(run code feature fresh "$touched")
-  # Always in inner-loop (narrow roster — compounding-cost reviewers only).
-  for reviewer in review-guides review-architecture; do
+  # Always in inner-loop for non-refactor types (narrow roster — compounding-cost reviewers only).
+  for reviewer in review-correctness review-guides review-architecture; do
     assert_contains "always-inner $reviewer (touched=$touched)" "$reviewer" "$(inner_line "$OUT")"
   done
   # Always in Wave A (broad final-gate roster).

--- a/docs/engineering/glossary-discipline.md
+++ b/docs/engineering/glossary-discipline.md
@@ -27,7 +27,7 @@ A symbol from the code that also names a stable engineering concept (the server,
 
 `review-glossary` runs in every PR review wave:
 
-- `/implement`'s inner-loop reviewer wave and full pre-PR review (Wave A);
+- `/implement`'s full pre-PR review (Wave A);
 - `create-issue` Step 4 (before showing the draft to the user).
 
 The agent samples load-bearing nouns in the prose surfaces of the diff (KDoc, docstrings, comments, every touched file under `docs/` and `.claude/`), compares against the glossary, and emits `[REQUIRED]` findings for drift and for new domain terms without an entry.

--- a/docs/engineering/glossary-discipline.md
+++ b/docs/engineering/glossary-discipline.md
@@ -23,14 +23,6 @@ What does NOT qualify, even if it recurs in the diff:
 
 A symbol from the code that also names a stable engineering concept (the server, the storage, a view, a test fixture) does qualify — the entry is about the concept, the symbol name happens to match.
 
-## How drift is caught
-
-`review-glossary` runs in every PR review wave:
-
-- `/implement`'s full pre-PR review (Wave A);
-- `create-issue` Step 4 (before showing the draft to the user).
-
-
 ## Adding and editing terms
 
 A glossary entry is added by the writing agent (`spec-writer` / `ux-expert` / `architect`, or the orchestrator for inline edits) as part of addressing a `[REQUIRED]` finding from `review-glossary`. The agent picks the section (Product / Technical), writes one line in the shape declared by the glossary header, and re-runs the review wave; the next pass verifies the entry shape.

--- a/docs/engineering/glossary-discipline.md
+++ b/docs/engineering/glossary-discipline.md
@@ -30,7 +30,6 @@ A symbol from the code that also names a stable engineering concept (the server,
 - `/implement`'s full pre-PR review (Wave A);
 - `create-issue` Step 4 (before showing the draft to the user).
 
-The agent samples load-bearing nouns in the prose surfaces of the diff (KDoc, docstrings, comments, every touched file under `docs/` and `.claude/`), compares against the glossary, and emits `[REQUIRED]` findings for drift and for new domain terms without an entry.
 
 ## Adding and editing terms
 

--- a/docs/interview-prep-checklist.md
+++ b/docs/interview-prep-checklist.md
@@ -75,7 +75,7 @@
 - [ ] Cold flow vs Hot flow — новый поток на каждого collector vs один общий
 - [x] `StateFlow` vs `SharedFlow` — replay, conflation, начальное значение
 - [x] `StateFlow` под нагрузкой — механизм conflation, 100 collectors + 120 updates/sec
-- [ ] `flatMapLatest` vs `flatMapMerge` vs `flatMapConcat` — параллелизм
+- [x] `flatMapLatest` vs `flatMapMerge` vs `flatMapConcat` — параллелизм
 - [ ] `combine` vs `zip` — эмит при любом изменении vs ждёт пару
 - [ ] `debounce`, `throttleFirst` — поиск с задержкой
 - [x] `buffer` / `conflate` / `collectLatest` — backpressure


### PR DESCRIPTION
<!-- written per .github/pull_request_template.md -->

**What / why.** Narrow the `/implement` inner-loop reviewer roster to the agents whose miss cost compounds across iterations: `correctness`, `architecture`, `guides` (+`platform` if touched, +`ux-conformance` if `ui` touched). Mechanical / single-pass / expensive reviewers move to Wave A only. Inner-loop was almost identical to Wave A — unintentional inheritance from #454, not a design choice.

**👀 Sanity-check.**
- Per-agent rationale lives in [#491 body](https://github.com/khmelevartem/tether/issues/491). The bands of "what compounds across iterations vs not" are judgment calls — captured in the issue's tables rather than re-litigated in the script.
- `review-correctness` always-inner sweep includes it on the feature/bugfix/infra paths but it correctly drops on refactor — sweep iterates only `code feature fresh`, where the invariant holds.
- `select-pipeline.sh` still has a `TYPE != docs` arm in Wave A correctness that the inner-loop guard dropped — unreachable today (`type=docs` → `track=docs`), but a latent inconsistency if the classify table ever broadens. Not folded in to keep this PR mechanical.

**Scope.**
- 📎 affected: `.claude/skills/implement/scripts/{select-pipeline,select-pipeline.test}.sh`; stale "inner-loop dispatches review-glossary" refs removed in `docs/engineering/glossary-discipline.md` and `.claude/agents/review-glossary.md`.

Closes #491
