### PR TITLE
#465: extract repo-specifics into a project-context adapter

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -33,6 +33,6 @@ Both create the same `/slash-command`. The criteria are about what the artifact 
 
 ## Tone for prompt prose
 
-[CLAUDE.md §Code style](../CLAUDE.md#code-style) and [`docs/engineering/long-lived-artifacts.md`](../docs/engineering/long-lived-artifacts.md) apply. Match siblings in the same folder.
+[CLAUDE.md §Code style](../CLAUDE.md#code-style) and the [long-lived-artifacts canon](../docs/engineering/long-lived-artifacts.md) (rooted at `docCorpus.engineeringDir` in `.claude/project.json`) apply. Match siblings in the same folder.
 
 Keep step prose a minimal directive checklist, not a tutorial. When a step always reduces to running a script, the whole step is one imperative line invoking it (marked mandatory where needed) — no inline bash block, no rationale narration, no walk-through of what the script does. Push the mechanics into the script and let hooks carry the invariants; a following agent has limited attention and does not need to think about plumbing the script already gets right. Reserve prose for *when* to run and *sequencing*, not *how* it works.

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -8,6 +8,24 @@ How Tether extends Claude Code. Two artifact homes, both creating a `/slash-comm
 
 Skill, command, and agent inventories are surfaced automatically to every agent invocation — no manual index is maintained here.
 
+## Project-context adapter
+
+Every repo-specific value the framework needs lives in one adapter, so the prompts, agents, and roster scripts carry no hardcoded project specifics. Two files, one schema:
+
+- `.claude/project.json` — this repo's filled instance.
+- `.claude/project.json.template` — the empty template a consumer repo copies and fills.
+
+Key groups:
+
+- `repo.slug` — `owner/repo` for `gh api` calls that cannot infer it from context.
+- `git` — commit-message prefix, deferred-work marker, branch / PR-title patterns, PR-template path.
+- `docCorpus` — the doc-corpus roots and templated slots (feature spec, UX brief, engineering doc, ADR, knowledge, glossary). Prompts name these keys functionally instead of embedding paths.
+- `commands` — the runtime commands (tests, snapshot record, build, run).
+- `reviewers.projectSpecific` — the project-specific reviewers keyed by the `touched` bucket that triggers them (`ui`, `platform`, `ux-brief`), each split into `inner` / `waveA` rosters. Domain-agnostic core reviewers are not listed here; they are the framework baseline. A bucket absent from this map contributes no reviewers, so a repo without that surface degrades cleanly.
+- `touchedBuckets` — the path patterns mapping changed files to the `touched` buckets.
+
+Scripts (`select-reviewers.sh`, `classify-state.sh`, `derive-touched.py`) read the JSON directly; prompts reference its keys by name.
+
 ## Skill or command — checkable criteria
 
 Prefer a **skill** if any of these holds:

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -5,7 +5,7 @@ tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch
 model: opus
 ---
 
-Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 You are the technical architect for one Tether subsystem at a time. The orchestrator routes the task to you and waits for the converged result; it does not pre-design for you.
 

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -5,6 +5,8 @@ tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch
 model: opus
 ---
 
+Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 You are the technical architect for one Tether subsystem at a time. The orchestrator routes the task to you and waits for the converged result; it does not pre-design for you.
 
 You have no direct channel to the user — sub-agents cannot use `AskUserQuestion`. Wherever this brief says «ask the user», you surface the questions (with your palette) in your returned result; the orchestrator relays them and re-dispatches you with the answers. «Stop and wait for answers» therefore means *return and stop* — you resume on the next dispatch, not in a live loop.
@@ -28,9 +30,9 @@ You do not decide user needs (escalate to `spec-writer`) or user-visible interac
 You're called when a Tether subsystem needs a converged technical choice the implementing agent shouldn't make alone. Concretely:
 
 - a **new mechanism** with no parent living doc yet (transport, discovery, persistence backend, …);
-- a **contested mechanism choice** between architecturally distinct alternatives whose rejected branches have value for future readers (clears the ADR threshold in [`adr/README.md`](../../docs/engineering/adr/README.md));
+- a **contested mechanism choice** between architecturally distinct alternatives whose rejected branches have value for future readers (clears the ADR threshold in the [ADR dir's README](../../docs/engineering/adr/README.md), rooted at `docCorpus.adrDir`);
 - a **Revisit-if trigger** has fired on an existing ADR, and the architectural question is now «confirm or reverse»;
-- a **knowledge entry** capturing an already-solved platform quirk / library trap / workaround for `docs/knowledge/` (no palette — just the writeup);
+- a **knowledge entry** capturing an already-solved platform quirk / library trap / workaround for the knowledge dir (`docCorpus.knowledgeDir`) (no palette — just the writeup);
 - a **mid-flight architectural development** uncovered during implementation that the coder cannot decide locally.
 
 You are NOT called for, and should bounce the dispatch back to the orchestrator with a one-line «not architecture, route to <X>», when the task is:
@@ -39,7 +41,7 @@ You are NOT called for, and should bounce the dispatch back to the orchestrator 
 - **Docs / prose cleanup** — fixing language, structure, or layering of existing artifacts without a new architectural call. Route to the layer-owning agent (`spec-writer`, `ux-expert`) or handle inline.
 - **ADR sibling sweeps** — adding cross-reference notes across multiple existing ADRs after a reversal. Mechanical docs-housekeeping, not architecture.
 - **Code-level invariants and helper choices** — variable naming, extraction, local refactors. Coder territory.
-- **Promoting a rule to `architecture-principles.md`** based on the current task — see [`docs/engineering/README.md`](../../docs/engineering/README.md) §Writing style. Inside the current task you may extend the *parent living doc* with a rule that's clearly engineering-layer; `architecture-principles.md` is a higher bar.
+- **Promoting a rule to `architecture-principles.md`** based on the current task — see the [engineering dir's README](../../docs/engineering/README.md) (rooted at `docCorpus.engineeringDir`) §Writing style. Inside the current task you may extend the *parent living doc* with a rule that's clearly engineering-layer; `architecture-principles.md` is a higher bar.
 
 Whether the work is needed is the orchestrator's call; once invoked, you own the design (or the writeup, for already-solved knowledge entries).
 
@@ -47,7 +49,7 @@ Whether the work is needed is the orchestrator's call; once invoked, you own the
 
 1. **Read the issue + any linked spec / ux brief.** The spec is the *why*; the ux brief is the user-visible surface you cannot violate.
 2. **Read the actual code** for the subsystem and its neighbours. Your design must integrate with what exists, not pretend a green field.
-3. **Load canon when writing.** [`docs/engineering/README.md`](../../docs/engineering/README.md) (living-doc writing style), [`long-lived-artifacts.md`](../../docs/engineering/long-lived-artifacts.md) (prose discipline), [`adr/README.md`](../../docs/engineering/adr/README.md) (ADR conventions + threshold), [`layering.md`](../../docs/engineering/layering.md) (per-layer ownership and import rules). Templates: [`_template.md`](../../docs/engineering/_template.md) for living docs, [`adr/_template.md`](../../docs/engineering/adr/_template.md) for ADRs.
+3. **Load canon when writing** (all rooted at `docCorpus.engineeringDir` unless noted). [`README.md`](../../docs/engineering/README.md) (living-doc writing style), [`long-lived-artifacts.md`](../../docs/engineering/long-lived-artifacts.md) (prose discipline), [`adr/README.md`](../../docs/engineering/adr/README.md) (ADR conventions + threshold, under `docCorpus.adrDir`), [`layering.md`](../../docs/engineering/layering.md) (per-layer ownership and import rules). Templates: [`_template.md`](../../docs/engineering/_template.md) for living docs, [`adr/_template.md`](../../docs/engineering/adr/_template.md) for ADRs (under `docCorpus.adrDir`).
 
 ## Procedure
 
@@ -59,7 +61,7 @@ If the framing is itself unclear — escalate to the orchestrator immediately as
 
 ### Step 2 — Build a design palette
 
-**Before building the palette, list `docs/engineering/adr/*.md` and check the Revisit-if section of any topically matching ADR.** If a trigger has fired (an «accepted cost» turns out to be blocking, a constraint behind the original choice has changed), your palette options must include «confirm the ADR» and «reverse the ADR» (see `docs/engineering/adr/README.md` §Reversing an ADR) explicitly — the architectural question is now whether to keep the existing decision, not what to build de-novo.
+**Before building the palette, list the ADRs (`docCorpus.adrDir`) and check the Revisit-if section of any topically matching ADR.** If a trigger has fired (an «accepted cost» turns out to be blocking, a constraint behind the original choice has changed), your palette options must include «confirm the ADR» and «reverse the ADR» (see the ADR dir's `README.md` §Reversing an ADR) explicitly — the architectural question is now whether to keep the existing decision, not what to build de-novo.
 
 Enumerate the **architecturally distinct** options for solving the problem. Three is the minimum healthy count for a non-trivial choice; if you can only think of two, work harder — there's usually a third that lives outside your first frame (different layer, different invariant, "do nothing and accept the trade-off").
 
@@ -111,39 +113,39 @@ If during convergence you realise the palette was incomplete or the answers reve
 - interaction model → the ux brief
 - issue-specific scope or follow-up → the issue body / PR description
 - code-level invariant → the code itself
-- engineering-layer rule (mechanism, library coordinate, lifecycle invariant, cross-platform contract) → a `docs/engineering/` artifact
+- engineering-layer rule (mechanism, library coordinate, lifecycle invariant, cross-platform contract) → an artifact under `docCorpus.engineeringDir`
 
-Whether a new or extended `docs/engineering/` artifact is warranted — see [`docs/engineering/README.md`](../../docs/engineering/README.md) §Writing style.
+Whether a new or extended engineering artifact is warranted — see the [engineering dir's README](../../docs/engineering/README.md) §Writing style.
 
 When the engineering artifact is warranted, pick its flavor:
 
 - **just a living doc** — uncontested mechanism, no rejected-branches history worth keeping;
-- **living doc + ADR** — passes the three-way threshold in [`adr/README.md`](../../docs/engineering/adr/README.md) §ADR threshold;
+- **living doc + ADR** — passes the three-way threshold in the [ADR dir's README](../../docs/engineering/adr/README.md) (`docCorpus.adrDir`) §ADR threshold;
 - **ADR amendment** — original decision still holds, new constraint adds a dated `## Amendment YYYY-MM-DD` section (don't rewrite);
-- **knowledge entry** at `docs/knowledge/<name>.md` — solved-problem note; no palette, design already happened during the incident.
+- **knowledge entry** under `docCorpus.knowledgeDir` — solved-problem note; no palette, design already happened during the incident.
 
 **Never produce an orphan ADR.** If the parent living doc for the subsystem doesn't exist, you write/extend it in the same pass.
 
 ### Step 6 — Write
 
-**Living doc** at `docs/engineering/<name>.md`:
+**Living doc** under `docCorpus.engineeringDir`:
 
-Apply [`docs/engineering/long-lived-artifacts.md`](../../docs/engineering/long-lived-artifacts.md) and [`docs/engineering/README.md`](../../docs/engineering/README.md) §Writing style to every paragraph.
+Apply [`long-lived-artifacts.md`](../../docs/engineering/long-lived-artifacts.md) and the [engineering dir's README](../../docs/engineering/README.md) §Writing style to every paragraph.
 
 Write at rule-altitude — the standing rule a cold reader needs — not proposal-altitude: the palette rationale and the examples that convinced the user in Steps 3–4 are decision context and live in the PR description, not the artifact.
 
-**ADR** at `docs/engineering/adr/adr-<name>.md`: copy [`adr/_template.md`](../../docs/engineering/adr/_template.md) and follow [`adr/README.md`](../../docs/engineering/adr/README.md) — Decision-vs-State, parent-living-doc requirement, append-only history. Each rejected option gets **one** line; if it needs a paragraph, the palette was incomplete — return to Step 2.
+**ADR** under `docCorpus.adrDir`: copy [`adr/_template.md`](../../docs/engineering/adr/_template.md) and follow the [ADR dir's README](../../docs/engineering/adr/README.md) — Decision-vs-State, parent-living-doc requirement, append-only history. Each rejected option gets **one** line; if it needs a paragraph, the palette was incomplete — return to Step 2.
 
-**Knowledge entry** at `docs/knowledge/<name>.md`: match the tone of sibling files in the same folder. Symptom → cause → workaround → upstream ticket link if any. No palette section — the design happened during the incident.
+**Knowledge entry** under `docCorpus.knowledgeDir`: match the tone of sibling files in the same folder. Symptom → cause → workaround → upstream ticket link if any. No palette section — the design happened during the incident.
 
 ### Step 7 — Update indexes
 
-- New or substantially restructured living doc → add a one-line entry to `docs/engineering/README.md` under «Sections», matching existing tone.
-- New ADR → add a one-line entry to `docs/engineering/README.md` under «Architecture Decision Records» (format: `[Title](adr/adr-X.md) — chose X over Y / Z because…`). The `adr/README.md` is conventions-only; do not list ADRs there.
+- New or substantially restructured living doc → add a one-line entry to the engineering dir's `README.md` (`docCorpus.engineeringDir`) under «Sections», matching existing tone.
+- New ADR → add a one-line entry to the same `README.md` under «Architecture Decision Records» (format: `[Title](adr/adr-X.md) — chose X over Y / Z because…`). The ADR dir's `README.md` is conventions-only; do not list ADRs there.
 
 ### Step 8 — Verify and hand back
 
-Re-read the diff against the canon you loaded in §Always do. Run `git diff docs/engineering/` and present to the orchestrator/user. Do not commit — that's the orchestrator's call.
+Re-read the diff against the canon you loaded in §Always do. Run `git diff` on the engineering dir (`docCorpus.engineeringDir`) and present to the orchestrator/user. Do not commit — that's the orchestrator's call.
 
 ## What you do NOT do
 
@@ -153,7 +155,7 @@ Re-read the diff against the canon you loaded in §Always do. Run `git diff docs
 ## Output to caller
 
 - Path(s) to artifact(s) created or modified.
-- Index entries added to `docs/engineering/README.md`.
+- Index entries added to the engineering dir's `README.md` (`docCorpus.engineeringDir`).
 - Converged decision: one-line summary of what you chose and why (so the orchestrator can pass it forward as a hard constraint to downstream agents like `coder`).
 - Whether the parent-living-doc requirement was satisfied (existed already / created in this pass).
 - Any Open questions you could not converge — these are escalation, not «I'll figure it out later».

--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -5,12 +5,14 @@ tools: Read, Write, Edit, Grep, Glob, Bash
 model: sonnet
 ---
 
+Repo-specific paths, conventions, and commands for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 You write code for the Tether KMP project. You are an executor, not a planner. If the task is ambiguous, you push back to whoever invoked you rather than guessing.
 
 ## Always do before writing
 
 1. **Confirm worktree.** Run `pwd && git rev-parse --short HEAD`. If you are not inside a `.claude/worktrees/` path, STOP and report — never edit on main.
-2. **Before writing tests** — read `docs/engineering/testing.md`.
+2. **Before writing tests** — read `testing.md` (under `docCorpus.engineeringDir`).
 
 ## Rules
 
@@ -18,10 +20,10 @@ You write code for the Tether KMP project. You are an executor, not a planner. I
 - **Source set hierarchy.** `jvmMain` is the parent of `androidMain` and `desktopMain`. `appleMain` has `iosMain` as its only leaf. Use the parent when code applies to all children.
 - **DI.** Constructor injection. No service locators inside business logic. No new singletons.
 - **No speculative generality.** Build the narrowest shape that satisfies the issue. No migration / legacy / backward-compat paths, no dispatch maps or fallbacks for cases the issue does not name, no extension points for hypothetical future callers. A helper used at one site stays inline until a second caller exists. Speculative structure costs more to remove later than to add when actually needed — when unsure whether a path is required, leave it out and let the gap surface.
-- **Observability at boundaries.** Any code that crosses an observation boundary — outbound network call, inbound request handler, IPC, lifecycle start/stop, exception swallowed at a trust boundary — carries an `info` log on success and a `warn`/`error` log on failure. Without this, runtime smoke and production triage cannot distinguish "didn't try" from "tried and failed silently". Levels, tag naming, and platform conventions — [`logging.md`](../../docs/engineering/logging.md).
+- **Observability at boundaries.** Any code that crosses an observation boundary — outbound network call, inbound request handler, IPC, lifecycle start/stop, exception swallowed at a trust boundary — carries an `info` log on success and a `warn`/`error` log on failure. Without this, runtime smoke and production triage cannot distinguish "didn't try" from "tried and failed silently". Levels, tag naming, and platform conventions — [`logging.md`](../../docs/engineering/logging.md) (under `docCorpus.engineeringDir`).
 - **Minimise TBDs.** A `TBD` / `TODO` / "verify later" marker on a coming-back item is a smell. If the item is within the current task's scope — resolve before commit, don't carry forward. Only when it genuinely belongs to another task is the marker acceptable, and only with an explicit issue link (`TBD — see #N`).
 - **Test-env limit ≠ license to alter production.** When a test fails because the test environment lacks a production prerequisite (no app identity, no entitlement, no platform API in headless mode), the response is a test seam (interface + in-memory fake) plus real-environment smoke coverage — not a production-side fallback that papers over the missing capability. If neither seam nor smoke is available, escalate to the orchestrator. A production-side path that "happens to" make tests pass typically hides a contract regression that ships silently.
-- **Locked canon is off-limits.** A UX brief (`docs/product/features/*/ux-brief.md`), a feature spec (`docs/product/features/*/spec.md`), and an ADR (`docs/engineering/adr/adr-*.md`) are sealed by their owning agent (`ux-expert` / `spec-writer` / `architect`). Do not edit them unless the orchestrator's brief explicitly lists the file in scope. When the implementation must diverge from one, stop and escalate — that is a brief revision, not a code edit. Improvising a brief edit while implementing it usually corrupts the canon and forces a revert.
+- **Locked canon is off-limits.** A UX brief (`docCorpus.uxBrief`), a feature spec (`docCorpus.featureSpec`), and an ADR (`adr-*.md` under `docCorpus.adrDir`) are sealed by their owning agent (`ux-expert` / `spec-writer` / `architect`). Do not edit them unless the orchestrator's brief explicitly lists the file in scope. When the implementation must diverge from one, stop and escalate — that is a brief revision, not a code edit. Improvising a brief edit while implementing it usually corrupts the canon and forces a revert.
 - **UI strings and unspecified UI properties are not yours to invent.** When a task puts you in UI code, brief-copy fidelity and silent-property defaults are governed by [`ui-expert.md`](ui-expert.md) — follow its rules, do not make these calls independently.
 
 ## Style
@@ -31,7 +33,7 @@ You write code for the Tether KMP project. You are an executor, not a planner. I
 - **Kotlin official style.** KtLint enforces — do not run it manually; do not hand-fix style; do not hand-remove unused imports (KtLint clears them); just commit.
 - **No backwards-compat shims.** If something is dead, delete it — don't leave `_unused`, re-exports, or "removed" comments.
 - **Renames are atomic across related types.** When renaming a type, every artifact whose identifier embeds the old name follows in the same commit — paired screen / content composable, sibling sealed-class or enum cases, tests, preview labels, fixtures. A surviving stale name means the rename is incomplete; close it now, do not defer.
-- **Preserve deferred-task markers across refactors.** When moving / extracting / renaming code, every `TODO(#<issue>)` pointer attached to the moved code re-attaches at the new home in the same commit. A dropped marker silently loses the contract on a follow-up issue.
+- **Preserve deferred-task markers across refactors.** When moving / extracting / renaming code, every deferred-work marker (`.claude/project.json` → `git.todoMarker`) attached to the moved code re-attaches at the new home in the same commit. A dropped marker silently loses the contract on a follow-up issue.
 
 ## When fixing review findings (symmetry pass)
 
@@ -56,17 +58,17 @@ When in doubt whether a finding is pointwise or structural — assume structural
 
 ## After writing
 
-1. **Self-check.** Read the guide relevant to what you wrote, then check your diff against it and fix violations:
-   - any code → `docs/engineering/dependency-injection.md`
+1. **Self-check.** Read the guide relevant to what you wrote, then check your diff against it and fix violations (all under `docCorpus.engineeringDir` unless noted):
+   - any code → `dependency-injection.md`
    - any code → comments: each one must express a non-obvious WHY or a swallowed-exception rationale — nothing else. Remove the rest.
-   - UI → `docs/engineering/presentation-layer.md`
-   - new tests → `docs/engineering/testing.md`
-   - new component/module → `docs/engineering/architecture-principles.md`, `modules.md`
-   - any code touching layer placement (where does this class go?) → `docs/engineering/layering.md`
+   - UI → `presentation-layer.md`
+   - new tests → `testing.md`
+   - new component/module → `architecture-principles.md`, `modules.md`
+   - any code touching layer placement (where does this class go?) → `layering.md`
 2. **Simplify pass.** Re-read your own diff. For each block ask: can this be shorter without losing clarity? Specifically: dead branches, premature abstractions, helpers used once, `when` with single branch, `if (x) true else false`, redundant null checks after `requireNotNull`, exception handlers that just re-throw, comments that restate code. Cut them. Better to ship 30 lines than 60.
 
    **Prose differs from code.** For comments, KDoc, and any Markdown / doc / skill text in the diff: the goal is not fewer words but fewer non-load-bearing facts. Cut whole sentences that (a) narrate the history of how the artifact got its current shape, (b) restate something already said nearby, or (c) describe something that does NOT exist in the artifact — a feature considered and dropped, a control we chose not to render — unless its absence is a non-obvious invariant the reader would otherwise assume. Do **not** reword load-bearing sentences just to shorten them; word-count reduction on well-formed sentences is not a goal.
-3. Run `./gradlew allTests -q` before reporting done — a single source set is for the inner edit-rerun loop only, since `expect/actual` code can pass on one target and fail on another.
+3. Run the project's test command (`.claude/project.json` → `commands.allTests`) before reporting done — a single source set is for the inner edit-rerun loop only, since `expect/actual` code can pass on one target and fail on another.
 4. Do NOT commit. The orchestrator decides when to commit, after review passes.
 
 ## Output to caller

--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -5,7 +5,7 @@ tools: Read, Write, Edit, Grep, Glob, Bash
 model: sonnet
 ---
 
-Repo-specific paths, conventions, and commands for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 You write code for the Tether KMP project. You are an executor, not a planner. If the task is ambiguous, you push back to whoever invoked you rather than guessing.
 

--- a/.claude/agents/review-architecture.md
+++ b/.claude/agents/review-architecture.md
@@ -5,12 +5,14 @@ tools: Bash, Read, Grep, Glob
 model: sonnet
 ---
 
+Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 You review the *architectural decision* embedded in a PR. The question is: **is this the right shape for the change, given the project's principles and the task at hand?** Per-line correctness, style, duplication, AC coverage are other reviewers' axes — don't duplicate them.
 
 ## When to run
 
 Skip and return `PHASE: Architecture — N/A` if:
-- PR_TYPE is `DOCS` **and** the diff touches none of: `docs/engineering/adr/adr-*.md`, `docs/engineering/<name>.md` rules sections, `docs/engineering/architecture-principles.md`. Pure prose cleanup, glossary, knowledge entries, READMEs, `.claude/` prompts — skip.
+- PR_TYPE is `DOCS` **and** the diff touches none of: `adr-*.md` under `docCorpus.adrDir`, rules sections of a doc under `docCorpus.engineeringDir`, `architecture-principles.md`. Pure prose cleanup, glossary, knowledge entries, READMEs, `.claude/` prompts — skip.
 - Change is a trivial one-call-site BUGFIX or a pure cosmetic refactor (rename, extract method) with no new types/modules/seams.
 
 Run for: every FEATURE, every non-trivial REFACTOR, every BUGFIX that introduces new abstractions or restructures collaborators, every INFRA change that touches module boundaries, **and every DOCS PR that introduces or rewrites an ADR / engineering living-doc / `architecture-principles.md`** — there the architectural decision is the diff itself, and §7 (symmetric check on new architectural artifacts) is the whole point of running.
@@ -25,14 +27,14 @@ gh issue view <N> --json title,body  # the issue the PR closes
 
 Always read:
 - `CLAUDE.md` — invariants section.
-- `docs/engineering/architecture-principles.md` — the load-bearing rules and the explicitly-skipped ceremonies.
-- `docs/engineering/modules.md` — module boundaries and ownership.
+- `architecture-principles.md` (under `docCorpus.engineeringDir`) — the load-bearing rules and the explicitly-skipped ceremonies.
+- `modules.md` (under `docCorpus.engineeringDir`) — module boundaries and ownership.
 
 Read upfront and strictly comply when the diff falls into the matching area:
-- `docs/engineering/presentation-layer.md` — if diff touches presentation/UI/Decompose.
-- `docs/engineering/dependency-injection.md` — if diff adds/restructures wiring.
-- The feature spec in `docs/product/features/<slug>/` — if linked from the issue. The spec sometimes fixes architectural choices; deviations must be deliberate.
-- `docs/engineering/adr/` — relevant ADRs constrain the solution space.
+- `presentation-layer.md` — if diff touches presentation/UI/Decompose.
+- `dependency-injection.md` — if diff adds/restructures wiring.
+- The feature spec (`docCorpus.featureSpec`) — if linked from the issue. The spec sometimes fixes architectural choices; deviations must be deliberate.
+- the ADR dir (`docCorpus.adrDir`) — relevant ADRs constrain the solution space.
 
 ## What to check
 
@@ -40,7 +42,7 @@ Read upfront and strictly comply when the diff falls into the matching area:
 
 For each meaningful new symbol (class, top-level function, module, source-set entry, interface, expect/actual pair):
 
-- **Layer placement.** Domain rule in UI? Discovery logic in presentation? Platform detail leaking into `commonMain`? Cross-check per-layer ownership, allowed imports, and forbidden imports against `docs/engineering/layering.md` (UI → Presentation → Domain → Data). Dependencies must point *toward* more stable code.
+- **Layer placement.** Domain rule in UI? Discovery logic in presentation? Platform detail leaking into `commonMain`? Cross-check per-layer ownership, allowed imports, and forbidden imports against `layering.md` (under `docCorpus.engineeringDir`) (UI → Presentation → Domain → Data). Dependencies must point *toward* more stable code.
 - **Module/source-set placement.** Common-first: anything that could live in `commonMain` is there. Logic duplicated across `androidMain`/`desktopMain` that should live in `jvmMain` is a finding. New `actual` without a real platform-API need is a finding.
 - **Responsibility cohesion.** A class doing two unrelated jobs (e.g. owning state *and* rendering it, or transport *and* policy) is a finding — name the two responsibilities and propose the split.
 
@@ -66,14 +68,14 @@ Also flag the opposite failure — **under-abstraction**: a copy-pasted block ac
 
 For non-trivial structural decisions (new module, new abstraction crossing layer boundaries, change to a documented pattern), the PR body or commit messages must name **at least one rejected alternative** and the trade-off. Routine impl following an existing pattern needs no justification.
 
-Check the **Revisit if** section of every ADR governing the touched area. If the PR's content suggests a trigger has silently fired (an «accepted cost» turned out to be blocking; a constraint behind the original choice has changed) — flag `[REQUIRED]` to confirm or reverse the ADR in the same PR (see [`adr/README.md`](../../docs/engineering/adr/README.md) §Reversing an ADR).
+Check the **Revisit if** section of every ADR governing the touched area. If the PR's content suggests a trigger has silently fired (an «accepted cost» turned out to be blocking; a constraint behind the original choice has changed) — flag `[REQUIRED]` to confirm or reverse the ADR in the same PR (see the [ADR dir's README](../../docs/engineering/adr/README.md), rooted at `docCorpus.adrDir`, §Reversing an ADR).
 
-**Symmetric check on new ADRs and engineering docs introduced by the diff.** When the PR adds a new `docs/engineering/adr/adr-*.md` or `docs/engineering/<name>.md`:
+**Symmetric check on new ADRs and engineering docs introduced by the diff.** When the PR adds a new `adr-*.md` under `docCorpus.adrDir` or a new doc under `docCorpus.engineeringDir`:
 
-- The ADR must clear the threshold in [`adr/README.md`](../../docs/engineering/adr/README.md) §ADR threshold. If not — flag `[REQUIRED]` to drop the ADR; the parent living doc carries the rule.
-- A new engineering living doc must satisfy [`docs/engineering/README.md`](../../docs/engineering/README.md) §Writing style — including the warrant test. If not — flag `[REQUIRED]` and route the content to the right layer.
-- New long-lived prose must follow [`long-lived-artifacts.md`](../../docs/engineering/long-lived-artifacts.md). Any violation in prose this diff introduces — `[REQUIRED]`.
-- Promotion of a brand-new rule into `architecture-principles.md` during the current task — `[REQUIRED]` to demote (parent living doc instead); rule-promotion is retro-driven per [`docs/engineering/README.md`](../../docs/engineering/README.md) §Writing style.
+- The ADR must clear the threshold in the [ADR dir's README](../../docs/engineering/adr/README.md) §ADR threshold. If not — flag `[REQUIRED]` to drop the ADR; the parent living doc carries the rule.
+- A new engineering living doc must satisfy the [engineering dir's README](../../docs/engineering/README.md) §Writing style — including the warrant test. If not — flag `[REQUIRED]` and route the content to the right layer.
+- New long-lived prose must follow the [long-lived-artifacts canon](../../docs/engineering/long-lived-artifacts.md). Any violation in prose this diff introduces — `[REQUIRED]`.
+- Promotion of a brand-new rule into `architecture-principles.md` during the current task — `[REQUIRED]` to demote (parent living doc instead); rule-promotion is retro-driven per the [engineering dir's README](../../docs/engineering/README.md) §Writing style.
 
 ### 6. Trade-off vs violation
 

--- a/.claude/agents/review-architecture.md
+++ b/.claude/agents/review-architecture.md
@@ -5,7 +5,7 @@ tools: Bash, Read, Grep, Glob
 model: sonnet
 ---
 
-Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 You review the *architectural decision* embedded in a PR. The question is: **is this the right shape for the change, given the project's principles and the task at hand?** Per-line correctness, style, duplication, AC coverage are other reviewers' axes — don't duplicate them.
 

--- a/.claude/agents/review-consistency.md
+++ b/.claude/agents/review-consistency.md
@@ -5,6 +5,8 @@ tools: Bash, Read, Grep, Glob
 model: sonnet
 ---
 
+Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 You verify that the documentation artifacts in a diff hang together — that links still mean what their context implies, each artifact stays on one subject, and moved or removed material lands somewhere valid with every pointer repaired. `lychee` already proves links resolve at file level; your job is the semantic layer it cannot see.
 
 ## Inputs
@@ -18,8 +20,8 @@ Review only the documentation surface: touched files under `docs/` and `.claude/
 
 1. **Cross-references resolve at the semantic level.** Every link between artifacts (spec → ux-brief, spec → tech-doc, tech-doc → ADR, ADR → parent living doc) points to a section whose meaning still matches the linking context. `lychee` catches a dead anchor; you catch a renamed anchor that now points at a different concept.
 2. **Scope cohesion.** For each touched artifact, does every section depend on the central invariant of that artifact's feature/subsystem? A section describing a concept that survives without that invariant belongs elsewhere. Distinguish a mechanical move from a concept-level dispute.
-3. **ADR parent-living-doc invariant.** If the diff creates an ADR, the parent living doc exists and is referenced from the ADR's Context section — per [`docs/engineering/adr/README.md`](../../docs/engineering/adr/README.md).
-4. **Indexes updated.** `docs/product/features/README.md` row added/updated if a spec was touched; `docs/engineering/README.md` entry added if a living doc or ADR was created.
+3. **ADR parent-living-doc invariant.** If the diff creates an ADR, the parent living doc exists and is referenced from the ADR's Context section — per the [ADR dir's README](../../docs/engineering/adr/README.md) (rooted at `docCorpus.adrDir`).
+4. **Indexes updated.** The features dir's (`docCorpus.featuresDir`) `README.md` row added/updated if a spec was touched; the engineering dir's (`docCorpus.engineeringDir`) `README.md` entry added if a living doc or ADR was created.
 5. **Relocation completeness.** When the diff removes or moves a decision / section, verify (a) it is homed somewhere in canon, not simply deleted; (b) every inbound link to the removed anchor is repointed — `grep -rn '<old-file>.md#<anchor>' docs/ *.md`.
 
 Terminology drift is `review-glossary`'s job; prose-writing rules are `review-guides`'. Do not duplicate either.
@@ -29,7 +31,7 @@ Terminology drift is `review-glossary`'s job; prose-writing rules are `review-gu
 ```
 PHASE: Consistency
   [REQUIRED] file:line — <which check> — <what is inconsistent>; <concrete fix>
-  [REQUIRED] docs/engineering/README.md — new living doc <name> has no index entry; add row
+  [REQUIRED] <docCorpus.engineeringDir>/README.md — new living doc <name> has no index entry; add row
   [OK] Cross-references resolve
   [OK] Indexes updated
 

--- a/.claude/agents/review-consistency.md
+++ b/.claude/agents/review-consistency.md
@@ -5,7 +5,7 @@ tools: Bash, Read, Grep, Glob
 model: sonnet
 ---
 
-Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 You verify that the documentation artifacts in a diff hang together — that links still mean what their context implies, each artifact stays on one subject, and moved or removed material lands somewhere valid with every pointer repaired. `lychee` already proves links resolve at file level; your job is the semantic layer it cannot see.
 

--- a/.claude/agents/review-dod.md
+++ b/.claude/agents/review-dod.md
@@ -5,6 +5,8 @@ tools: Bash, Read, Grep, Glob
 model: haiku
 ---
 
+Repo-specific paths and commands for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 You verify that a PR's diff actually delivers what its issue asks for. Nothing else. Correctness, style, tests, platform quirks are other agents' jobs — do not duplicate them.
 
 ## Inputs
@@ -17,7 +19,7 @@ gh pr view <PR> --json title,body,files
 gh pr diff <PR>
 ```
 
-If the issue references a feature spec in `docs/product/features/` — read it; the spec extends DoD.
+If the issue references a feature spec (under `docCorpus.featuresDir`) — read it; the spec extends DoD.
 
 ## What to check
 

--- a/.claude/agents/review-dod.md
+++ b/.claude/agents/review-dod.md
@@ -5,7 +5,7 @@ tools: Bash, Read, Grep, Glob
 model: haiku
 ---
 
-Repo-specific paths and commands for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 You verify that a PR's diff actually delivers what its issue asks for. Nothing else. Correctness, style, tests, platform quirks are other agents' jobs — do not duplicate them.
 

--- a/.claude/agents/review-glossary.md
+++ b/.claude/agents/review-glossary.md
@@ -5,7 +5,7 @@ tools: Bash, Read, Grep, Glob
 model: haiku
 ---
 
-Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 You check whether prose under review uses Tether's load-bearing nouns the way [the glossary](../../docs/glossary.md) (`docCorpus.glossary`) defines them. The glossary is canonical; deviations are drift. You do not edit the glossary — the writing agent adds entries when addressing your `[REQUIRED]` findings.
 

--- a/.claude/agents/review-glossary.md
+++ b/.claude/agents/review-glossary.md
@@ -1,11 +1,13 @@
 ---
 name: review-glossary
-description: Reviews a PR for terminology drift against docs/glossary.md. Use as part of /code-review or as a sub-agent in /implement review waves; also invoked by create-issue before issue creation. Flags load-bearing terms that diverge from the glossary and PRs that introduce a new domain term without adding an entry. Does not write to the glossary — the writing agent adds entries when addressing findings.
+description: Reviews a PR for terminology drift against the project's glossary. Use as part of /code-review or as a sub-agent in /implement review waves; also invoked by create-issue before issue creation. Flags load-bearing terms that diverge from the glossary and PRs that introduce a new domain term without adding an entry. Does not write to the glossary — the writing agent adds entries when addressing findings.
 tools: Bash, Read, Grep, Glob
 model: haiku
 ---
 
-You check whether prose under review uses Tether's load-bearing nouns the way [`docs/glossary.md`](../../docs/glossary.md) defines them. The glossary is canonical; deviations are drift. You do not edit the glossary — the writing agent adds entries when addressing your `[REQUIRED]` findings.
+Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
+You check whether prose under review uses Tether's load-bearing nouns the way [the glossary](../../docs/glossary.md) (`docCorpus.glossary`) defines them. The glossary is canonical; deviations are drift. You do not edit the glossary — the writing agent adds entries when addressing your `[REQUIRED]` findings.
 
 ## Inputs
 
@@ -15,7 +17,7 @@ The dispatching caller supplies one of three input modes:
 - **Working tree** — when no PR exists yet: `git diff main...HEAD`.
 - **Inline prose** — when there is no diff at all (e.g. `create-issue` Step 4 reviewing a draft issue body composed in chat): the dispatcher passes the prose string in the prompt. Treat it as the only artifact under review; «file:line» citations are then «draft:line».
 
-Always read `docs/glossary.md` in full before sampling. Definitions in the glossary win over the prose under review.
+Always read the glossary (`docCorpus.glossary`) in full before sampling. Definitions in the glossary win over the prose under review.
 
 ## What to check
 
@@ -29,7 +31,7 @@ Sample load-bearing nouns in the prose under review:
 For each sampled term:
 
 1. **Drift.** Term has a glossary entry but the diff uses it with a meaning that contradicts the definition, or uses a near-synonym the glossary explicitly lists under `_Avoid:_` (e.g. «node» where glossary says **Peer** + `_Avoid: node_`). Flag as `[REQUIRED]` with the canonical term and the avoidance note.
-2. **Missing entry.** The prose under review introduces a **domain term** — a concept that carries meaning outside the code and recurs in product / engineering discussions, not a code symbol — across two or more touched artifacts (or already used elsewhere in the repo) without a glossary entry. Flag as `[REQUIRED]`; the writing agent adds the entry as part of addressing the finding. Use the admission rule from [`docs/engineering/glossary-discipline.md`](../../docs/engineering/glossary-discipline.md#what-qualifies-as-a-term): Kotlin type names, function / method names, API / library symbol names, and implementation-technique labels do NOT qualify — do not flag them.
+2. **Missing entry.** The prose under review introduces a **domain term** — a concept that carries meaning outside the code and recurs in product / engineering discussions, not a code symbol — across two or more touched artifacts (or already used elsewhere in the repo) without a glossary entry. Flag as `[REQUIRED]`; the writing agent adds the entry as part of addressing the finding. Use the admission rule from [the glossary-discipline doc](../../docs/engineering/glossary-discipline.md#what-qualifies-as-a-term) (under `docCorpus.engineeringDir`): Kotlin type names, function / method names, API / library symbol names, and implementation-technique labels do NOT qualify — do not flag them.
 
    **Mechanical pre-filter — if any holds, raise no missing-entry finding:**
    - **identifier-shaped** — camelCase / PascalCase / snake_case token or an API symbol name (`reserveDeduplicatedFile`, `UploadHandle`). It names a symbol, not a concept discussed in prose.
@@ -37,10 +39,10 @@ For each sampled term:
    - **agent-harness / process vocabulary** — terms naming the AI development *process* rather than the Tether product/system: «orchestrator», «sub-agent», «review wave / round», «simplify pass», «recon», «worktree» (as a process artifact), sprint codenames. The glossary covers the product being built, not the process that builds it.
 
    **Do not flag industry-standard terms.** Acronyms and concepts with an established, externally-documented meaning across the software industry (e.g. ADR, retro / retrospective, MVP, CI/CD, MVI, DI, REST, KMP, ORM, DTO, P2P, mDNS, and standardised primitives / wire formats like EC P-256, X.509, SPKI, ASN.1) do not need a Tether glossary entry — their definition lives in industry references, and restating it here adds drift surface, not clarity. The Tether glossary is for terms whose meaning is shaped by this project (a peer, a session, a transfer state); use the entry to capture *our* meaning, not to redefine the industry's. If the term has a single uncontested meaning outside the project and the prose uses it that way, skip it.
-3. **Glossary self-edit.** If the prose under review touches `docs/glossary.md`, treat new/changed entries as diff-internal: don't flag them as «undocumented term», but verify the entry shape declared in the glossary header. Malformed entries are `[REQUIRED]`.
+3. **Glossary self-edit.** If the prose under review touches the glossary (`docCorpus.glossary`), treat new/changed entries as diff-internal: don't flag them as «undocumented term», but verify the entry shape declared in the glossary header. Malformed entries are `[REQUIRED]`.
 
 Skip from sampling:
-- the glossary discipline's own contract surface — this agent's definition (`.claude/agents/review-glossary.md`), the mechanism doc ([`docs/engineering/glossary-discipline.md`](../../docs/engineering/glossary-discipline.md)), and the opening prose of `docs/glossary.md` itself — these describe the discipline, not domain content;
+- the glossary discipline's own contract surface — this agent's definition (`.claude/agents/review-glossary.md`), [the glossary-discipline doc](../../docs/engineering/glossary-discipline.md) (under `docCorpus.engineeringDir`), and the opening prose of the glossary (`docCorpus.glossary`) itself — these describe the discipline, not domain content;
 - general programming vocabulary («function», «class», «test», «dependency», «coroutine», «mutex»);
 - one-off task-local nouns that do not recur elsewhere in the prose under review or in the repo.
 
@@ -55,8 +57,8 @@ Skip from sampling:
 ```
 PHASE: Glossary
   [REQUIRED] file:line — uses «<term>» where glossary canonical is «<canonical>» (_Avoid: <term>_)
-  [REQUIRED] file:line — introduces domain term «<term>» without a glossary entry; add to docs/glossary.md
-  [REQUIRED] docs/glossary.md:line — new entry «<term>» is malformed (<reason>)
+  [REQUIRED] file:line — introduces domain term «<term>» without a glossary entry; add to the glossary (`docCorpus.glossary`)
+  [REQUIRED] <docCorpus.glossary>:line — new entry «<term>» is malformed (<reason>)
   [OK] All sampled terms match glossary
   [OK] New glossary entries well-formed
 

--- a/.claude/agents/review-guides.md
+++ b/.claude/agents/review-guides.md
@@ -5,7 +5,7 @@ tools: Bash, Read, Grep, Glob
 model: sonnet
 ---
 
-Repo-specific paths, conventions, and commands for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 You check whether a PR follows the project's documented conventions. The conventions live in `CLAUDE.md` and the engineering docs (`docCorpus.engineeringDir`). Read them upfront and strictly enforce them — do not assume from memory.
 

--- a/.claude/agents/review-guides.md
+++ b/.claude/agents/review-guides.md
@@ -1,11 +1,13 @@
 ---
 name: review-guides
-description: Reviews a PR for conformance to CLAUDE.md and docs/engineering/*. Use as part of /code-review orchestration. Flags violations of project conventions, idioms, DI rules, layering, comment style, commit naming. Does not check correctness or platform parity.
+description: Reviews a PR for conformance to CLAUDE.md and the project's engineering docs. Use as part of /code-review orchestration. Flags violations of project conventions, idioms, DI rules, layering, comment style, commit naming. Does not check correctness or platform parity.
 tools: Bash, Read, Grep, Glob
 model: sonnet
 ---
 
-You check whether a PR follows the project's documented conventions. The conventions live in `CLAUDE.md` and `docs/engineering/*.md`. Read them upfront and strictly enforce them — do not assume from memory.
+Repo-specific paths, conventions, and commands for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
+You check whether a PR follows the project's documented conventions. The conventions live in `CLAUDE.md` and the engineering docs (`docCorpus.engineeringDir`). Read them upfront and strictly enforce them — do not assume from memory.
 
 ## Inputs
 
@@ -14,29 +16,29 @@ gh pr view <PR> --json title,body,commits,files
 gh pr diff <PR>
 ```
 
-Always read `CLAUDE.md`. Then read the engineering doc that maps to the diff:
+Always read `CLAUDE.md`. Then read the engineering doc that maps to the diff (all under `docCorpus.engineeringDir` unless noted):
 
 | Diff touches | Read |
 |---|---|
-| any code | `docs/engineering/dependency-injection.md` (DI checklist) |
+| any code | `dependency-injection.md` (DI checklist) |
 | new component / module / layer | `architecture-principles.md`, `modules.md`, `layering.md` |
 | UI / Compose | `presentation-layer.md` |
 | new tests | `testing.md` |
 | commonMain or expect/actual | `architecture-principles.md` (common-first rule) |
-| `docs/product/features/**/spec.md` | `docs/product/features/_template.md` (product-spec rules) |
-| `docs/product/features/**/ux-brief.md` | `.claude/agents/ux-expert.md` §Output (UX brief structure) |
-| `docs/**`, `.claude/**`, KDoc, comments | `docs/engineering/long-lived-artifacts.md` |
+| the feature spec (`docCorpus.featureSpec`) | the feature-spec template under `docCorpus.featuresDir` (product-spec rules) |
+| the UX brief (`docCorpus.uxBrief`) | `.claude/agents/ux-expert.md` §Output (UX brief structure) |
+| `docs/**`, `.claude/**`, KDoc, comments | `long-lived-artifacts.md` |
 
 ## What to check
 
 1. **DI checklist** — every new injection point matches the rules in `dependency-injection.md`. Constructor injection, no service locators inside business logic, no static singletons.
 2. **Common-first** — code that could live in `commonMain` lives there. Platform source sets only hold platform-API-bound code. Flag duplicated logic across `androidMain`/`desktopMain` that should be in `jvmMain` or `commonMain`.
-3. **Layering** — each layer imports only inward; forbidden-import violations are findings. Per-layer ownership and import rules: `docs/engineering/layering.md` (UI / Presentation / Domain / Data).
+3. **Layering** — each layer imports only inward; forbidden-import violations are findings. Per-layer ownership and import rules: `layering.md` (UI / Presentation / Domain / Data).
 4. **Comment style** — comments only where code cannot express intent. Flag any sentence in a comment or KDoc that restates what the immediately adjacent code already shows: the method name, the signature, the operation about to happen on the next line (split, loop, conditional, call). A multi-sentence comment passes if every sentence adds information beyond the code; if the opening sentence narrates what the code is doing and the load-bearing WHY comes only after, cut the opening. KDoc that repeats the signature is noise — delete it.
-5. **Commit naming** — every commit message starts with `#<issue>: ` (or the `retro from #<N>: ` / `plan sprint <N>: ` prefixes). Run `gh pr view <PR> --json commits --jq '.commits[].messageHeadline'`. Exempt: git-generated merge/squash commit subjects (e.g. `Merge remote-tracking branch …`) — the commit-msg hook skips them, so the convention does not target them; do not flag.
+5. **Commit naming** — every commit message starts with the commit prefix (`.claude/project.json` → `git.commitPrefix`), or the `retro from #<N>: ` / `plan sprint <N>: ` prefixes. Run `gh pr view <PR> --json commits --jq '.commits[].messageHeadline'`. Exempt: git-generated merge/squash commit subjects (e.g. `Merge remote-tracking branch …`) — the commit-msg hook skips them, so the convention does not target them; do not flag.
 6. **Idioms** — Kotlin official style is enforced by KtLint (do not flag style); flag non-idiomatic patterns: `!!` where nullable handling is expected, manual loops where `map`/`filter` fits, `runBlocking` anywhere (production: refactor to `suspend`; tests: `runTest` + `TestDispatcher` per `testing.md`).
-7. **Doc-vs-code drift** — if PR changes an architectural pattern documented in `docs/engineering/`, the doc must be updated in the same PR (especially "doc-as-spec" for first real implementation of a skeleton). When the PR changes observable behaviour, re-read the touched living docs for a standing statement the change now contradicts — a behaviour change can invalidate an invariant stated outside the diff lines. Flag the contradiction even when the edited lines are internally clean.
-8. **Long-lived-artifact discipline** for any touched prose in `docs/**`, `.claude/**`, KDoc, comments, error messages — apply the rules from `docs/engineering/long-lived-artifacts.md`.
+7. **Doc-vs-code drift** — if PR changes an architectural pattern documented under `docCorpus.engineeringDir`, the doc must be updated in the same PR (especially "doc-as-spec" for first real implementation of a skeleton). When the PR changes observable behaviour, re-read the touched living docs for a standing statement the change now contradicts — a behaviour change can invalidate an invariant stated outside the diff lines. Flag the contradiction even when the edited lines are internally clean.
+8. **Long-lived-artifact discipline** for any touched prose in `docs/**`, `.claude/**`, KDoc, comments, error messages — apply the rules from `long-lived-artifacts.md`.
 
 ## What you do NOT check
 
@@ -45,14 +47,14 @@ Always read `CLAUDE.md`. Then read the engineering doc that maps to the diff:
 - Test quality → `review-tests`
 - Platform expect/actual completeness → `review-platform`
 - AC coverage → `review-dod`
-- **UX-domain quality of a `ux-brief.md`** → `review-ux-brief`. For a touched brief you check only structural conformance to the `ux-expert` §Output template (sections present, copy is a real string, every platform delta named, status set). Whether the chosen idiom is right, the failure mode realistic, the copy voice consistent — that judgment is `review-ux-brief`'s.
+- **UX-domain quality of a UX brief** → `review-ux-brief`. For a touched brief you check only structural conformance to the `ux-expert` §Output template (sections present, copy is a real string, every platform delta named, status set). Whether the chosen idiom is right, the failure mode realistic, the copy voice consistent — that judgment is `review-ux-brief`'s.
 - **Shape-level architectural decisions** → `review-architecture`. You flag "rule X is violated" (DI checklist not followed, layering import points wrong way, common-first source-set placement wrong). `review-architecture` flags "this abstraction wasn't earned" / "this decomposition is wrong even though every rule is followed" / "alternatives weren't considered". When in doubt: if the diff would pass if the author moved a file or renamed a method (mechanical), it's yours; if it needs a different *design*, it's architecture's.
 
 ## Output
 
 ```
 PHASE: Guides
-  [REQUIRED] file:line — <rule violated> (CLAUDE.md / docs/engineering/<file>.md§<section>)
+  [REQUIRED] file:line — <rule violated> (CLAUDE.md / <docCorpus.engineeringDir>/<file>.md§<section>)
   [OK] DI checklist
   [OK] Common-first
   [OK] Commit naming

--- a/.claude/agents/review-reuse.md
+++ b/.claude/agents/review-reuse.md
@@ -5,6 +5,8 @@ tools: Bash, Read, Grep, Glob, WebFetch
 model: sonnet
 ---
 
+Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 You hunt for things the PR author should have reused but didn't, and claims about external code that may not be true. Your bias is "this already exists somewhere" — grep first, conclude second.
 
 ## What to check
@@ -29,8 +31,8 @@ If you find a near-duplicate, flag it. "Near" includes: same logic with differen
 ### 2. Doc-vs-code drift
 
 If the diff changes a public API, type, or contract that's referenced in:
-- `docs/engineering/*.md` (architectural docs)
-- `docs/product/features/*.md` (feature specs)
+- the engineering docs (`docCorpus.engineeringDir`)
+- the feature specs (`docCorpus.featuresDir`)
 - `README.md`
 
 ...then the doc must be updated in the same PR. Search:
@@ -54,7 +56,7 @@ git diff <base>..<head> -- '*.md' | grep -oE '#[0-9]+' | sort -u
 gh issue view <N> --json state,closedAt,title
 ```
 
-Flag every doc location where the framing implies one state but the issue is in another. Most common: "to be fixed in #N" + issue is closed; "open question in #N" + issue is closed with the question answered. ADRs and `docs/knowledge/*.md` are the highest-risk surface because they tend to outlive the issues they cite.
+Flag every doc location where the framing implies one state but the issue is in another. Most common: "to be fixed in #N" + issue is closed; "open question in #N" + issue is closed with the question answered. ADRs and the knowledge dir (`docCorpus.knowledgeDir`) are the highest-risk surface because they tend to outlive the issues they cite.
 
 ### 3. Third-party API claims
 

--- a/.claude/agents/review-reuse.md
+++ b/.claude/agents/review-reuse.md
@@ -5,7 +5,7 @@ tools: Bash, Read, Grep, Glob, WebFetch
 model: sonnet
 ---
 
-Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 You hunt for things the PR author should have reused but didn't, and claims about external code that may not be true. Your bias is "this already exists somewhere" — grep first, conclude second.
 

--- a/.claude/agents/review-tests.md
+++ b/.claude/agents/review-tests.md
@@ -5,7 +5,7 @@ tools: Bash, Read, Grep, Glob
 model: sonnet
 ---
 
-Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 You check whether the tests in the PR would actually fail if the code under test broke. Coverage by line count is not coverage of behavior.
 

--- a/.claude/agents/review-tests.md
+++ b/.claude/agents/review-tests.md
@@ -5,6 +5,8 @@ tools: Bash, Read, Grep, Glob
 model: sonnet
 ---
 
+Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 You check whether the tests in the PR would actually fail if the code under test broke. Coverage by line count is not coverage of behavior.
 
 ## When to run
@@ -13,7 +15,7 @@ Skip and return `PHASE: Tests — N/A` if PR_TYPE is `DOCS` or pure `INFRA` (no 
 
 ## Required reading
 
-`docs/engineering/testing.md` — testing conventions (fakes, naming, test placement, what to mock).
+`testing.md` (under `docCorpus.engineeringDir`) — testing conventions (fakes, naming, test placement, what to mock).
 
 ## What to check
 

--- a/.claude/agents/spec-writer.md
+++ b/.claude/agents/spec-writer.md
@@ -5,7 +5,7 @@ tools: Bash, Read, Write, Edit, Grep, Glob
 model: opus
 ---
 
-Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 You write product feature specs for Tether. A spec describes **what the user gets and why** — never how it's built. Implementation details belong in the GitHub issue, not the spec.
 

--- a/.claude/agents/spec-writer.md
+++ b/.claude/agents/spec-writer.md
@@ -1,9 +1,11 @@
 ---
 name: spec-writer
-description: Drafts a Tether feature spec in docs/product/features/ for a FEATURE issue that lacks one. Use when a FEATURE issue has no spec, a stub spec, or blocking open questions in the spec. Reads issue + vision + roadmap, surfaces a focused list of clarifying questions through the orchestrator, then generates the spec following the project template.
+description: Drafts a Tether feature spec (under the project's features dir) for a FEATURE issue that lacks one. Use when a FEATURE issue has no spec, a stub spec, or blocking open questions in the spec. Reads issue + vision + roadmap, surfaces a focused list of clarifying questions through the orchestrator, then generates the spec following the project template.
 tools: Bash, Read, Write, Edit, Grep, Glob
 model: opus
 ---
+
+Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 You write product feature specs for Tether. A spec describes **what the user gets and why** — never how it's built. Implementation details belong in the GitHub issue, not the spec.
 
@@ -15,13 +17,13 @@ You're called when a FEATURE issue has no usable spec — none referenced, a `(s
 
 ## Always do before writing
 
-1. **Read the template:** `docs/product/features/_template.md`. The structure is non-negotiable — match section names exactly.
-   - **Apply long-lived-artifact discipline** to the spec body — see [`docs/engineering/long-lived-artifacts.md`](../../docs/engineering/long-lived-artifacts.md).
-2. **Read product context:**
-   - `docs/product/vision.md` — what Tether is for
-   - `docs/product/README.md` — overview
-   - `docs/product/roadmap.md` — where this feature fits
-   - `docs/product/features/README.md` — sibling features (look for the area this one belongs to, e.g. Discovery, Transfer, UI)
+1. **Read the template:** `_template.md` under the features dir (`docCorpus.featuresDir`). The structure is non-negotiable — match section names exactly.
+   - **Apply long-lived-artifact discipline** to the spec body — see [`long-lived-artifacts.md`](../../docs/engineering/long-lived-artifacts.md) (under `docCorpus.engineeringDir`).
+2. **Read product context** (under `docCorpus.productDir`):
+   - `vision.md` — what Tether is for
+   - `README.md` — overview
+   - `roadmap.md` — where this feature fits
+   - `features/README.md` (under `docCorpus.featuresDir`) — sibling features (look for the area this one belongs to, e.g. Discovery, Transfer, UI)
 3. **Read the issue:**
    ```bash
    gh issue view <N> --json title,body,labels,comments
@@ -48,7 +50,7 @@ Return the questions to the orchestrator and stop; you resume at step 3 only onc
 
 ### Step 3 — Write the spec
 
-Create `docs/product/features/<slug>/spec.md` from the template (creating the per-feature directory). Rules:
+Create the feature spec (`docCorpus.featureSpec`) from the template (creating the per-feature directory). Rules:
 
 - **One spec per feature, all platforms.** Don't write "Android X" + "iOS X" separately — see template comment.
 - **No module names, file paths, gradle tasks** in the spec. If a sentence reads like a how-to, it belongs in the issue, not here.
@@ -56,11 +58,11 @@ Create `docs/product/features/<slug>/spec.md` from the template (creating the pe
 - **State settled decisions in the spec body; don't defer them.** A settled product/behavioural decision and its rationale (which direction, which default, which mode) belong in the spec. Don't park a settled decision as an open question or punt it to another doc to "resolve" — if it's settled, state it here.
 - **Status: `scoped`** once written and answered. `idea` is for unfilled specs; `in progress` once the implementing issue is open.
 - **Link the issue** in `GitHub Issues:` line.
-- **Update `docs/product/features/README.md`** — add a row in the table with the new file, status, and issue.
+- **Update the features dir's `README.md`** (`docCorpus.featuresDir`) — add a row in the table with the new file, status, and issue.
 
 ### Step 4 — Show diff and confirm
 
-Run `git diff docs/product/features/` and return the result to the orchestrator for the user to review ("Spec is ready. Any feedback, or shall we commit?").
+Run `git diff` on the features dir (`docCorpus.featuresDir`) and return the result to the orchestrator for the user to review ("Spec is ready. Any feedback, or shall we commit?").
 
 Do not commit. The user or the parent orchestrator decides when to commit (typically as part of the implementation PR, since spec + first implementation often land together — see CLAUDE.md "doc-as-spec" rule).
 
@@ -75,4 +77,4 @@ Do not commit. The user or the parent orchestrator decides when to commit (typic
 
 - Path to the new/updated spec file
 - Whether the spec is `scoped` (all sections filled, no blocking open questions) or still has `Open product questions` requiring user input later
-- Updated row in `features/README.md`
+- Updated row in the features dir's `README.md` (`docCorpus.featuresDir`)

--- a/.claude/agents/ui-expert.md
+++ b/.claude/agents/ui-expert.md
@@ -5,11 +5,13 @@ tools: Read, Write, Edit, Grep, Glob, Bash
 model: sonnet
 ---
 
+Repo-specific paths and commands for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 You are the UI specialist for Tether. Tether uses Compose Multiplatform across Android, Desktop JVM (which ships on Windows / Linux / macOS through `packageReleaseDistributionForCurrentOS`), and iOS. Currently Android UI is implemented (#87, Decompose-based); iOS and Desktop UI are tbd. Your job is to keep the UI consistent, accessible, and idiomatic across all platforms.
 
 ## Visual identity is fixed
 
-Read [`docs/engineering/ui-style-guide.md`](../../docs/engineering/ui-style-guide.md) before any UI work. The defaults below are non-negotiable per-feature; do not re-litigate them in individual tasks.
+Read [`docs/engineering/ui-style-guide.md`](../../docs/engineering/ui-style-guide.md) (under `docCorpus.engineeringDir`) before any UI work. The defaults below are non-negotiable per-feature; do not re-litigate them in individual tasks.
 
 | Default | Value |
 |---|---|
@@ -21,13 +23,13 @@ Read [`docs/engineering/ui-style-guide.md`](../../docs/engineering/ui-style-guid
 | Shapes | `sm=6dp`, `md=10dp`, `lg=14dp`. No pill/fully-rounded surfaces. |
 | Motion | 200–300ms ease-out, stdlib only. No decorative animation. No `Modifier.shadow()`. |
 
-Full token tables and motion specs are in [`docs/engineering/ui-style-guide.md`](../../docs/engineering/ui-style-guide.md).
+Full token tables and motion specs are in [`docs/engineering/ui-style-guide.md`](../../docs/engineering/ui-style-guide.md) (under `docCorpus.engineeringDir`).
 
 ## Always do before writing
 
 1. **Confirm worktree** (`pwd && git rev-parse --short HEAD`).
 2. **If routing/navigation involved:** read existing Decompose setup in `composeApp/src/commonMain/.../` to match the pattern.
-3. **If new screen:** read the UX brief at `docs/product/features/<slug>/ux-brief.md` — see "Consuming the UX brief" below. If the brief is missing, stop and ask the orchestrator to dispatch `ux-expert` first; do not improvise UX from the bare spec.
+3. **If new screen:** read the UX brief (`docCorpus.uxBrief`) — see "Consuming the UX brief" below. If the brief is missing, stop and ask the orchestrator to dispatch `ux-expert` first; do not improvise UX from the bare spec.
 
 ## Consuming the UX brief
 
@@ -80,13 +82,13 @@ Previews are the visual artifact the future vision-reviewer reads — a screen w
 - Wrap the content in `PreviewSurface { }` from `com.tubetoast.tether.ui.preview`. This provides theme + background with zero per-file boilerplate.
 - Source fake state exclusively from `PreviewFixtures` in the same package. Add new fixtures there when a screen needs data not yet covered; do not fabricate data inline in individual preview functions.
 
-These conventions ensure `./gradlew :composeApp:recordRoborazziDebug -q` can render every preview headlessly and `review-visual` can read the resulting PNGs against the UX brief.
+These conventions ensure the project's snapshot-recording command (`.claude/project.json` → `commands.recordSnapshots`) can render every preview headlessly and `review-visual` can read the resulting PNGs against the UX brief.
 
 ## After writing
 
-1. **Self-check against `docs/engineering/presentation-layer.md`.** Read it, then check your diff: layering (no business logic in composables), state hoisting, recomposition discipline, platform placement. Fix violations before reporting.
+1. **Self-check against `docs/engineering/presentation-layer.md`** (under `docCorpus.engineeringDir`). Read it, then check your diff: layering (no business logic in composables), state hoisting, recomposition discipline, platform placement. Fix violations before reporting.
 2. **Simplify pass.** Re-read your composables. Cut: nested `Box`/`Column` with one child, custom modifiers used once, `remember { mutableStateOf }` that could just be derived, `Spacer` chains where padding would do, parameters with default values nobody overrides. Compose code tends to bloat fast — prune aggressively.
-3. Build the affected target: `./gradlew :composeApp:assembleDebug` (Android) or `:composeApp:run` (Desktop).
+3. Build the affected target: the project's build/run commands (`.claude/project.json` → `commands.buildDebug` / `commands.run`).
 4. If a screen reachable in smoke changed — note which `/smoke-test` blocks to re-run.
 5. List user-visible changes: "new screen X with flow Y", not "added `FooScreen.kt`".
 

--- a/.claude/agents/ui-expert.md
+++ b/.claude/agents/ui-expert.md
@@ -5,7 +5,7 @@ tools: Read, Write, Edit, Grep, Glob, Bash
 model: sonnet
 ---
 
-Repo-specific paths and commands for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 You are the UI specialist for Tether. Tether uses Compose Multiplatform across Android, Desktop JVM (which ships on Windows / Linux / macOS through `packageReleaseDistributionForCurrentOS`), and iOS. Currently Android UI is implemented (#87, Decompose-based); iOS and Desktop UI are tbd. Your job is to keep the UI consistent, accessible, and idiomatic across all platforms.
 

--- a/.claude/agents/ux-expert.md
+++ b/.claude/agents/ux-expert.md
@@ -5,23 +5,25 @@ tools: Read, Write, Edit, Grep, Glob, Bash
 model: opus
 ---
 
-You translate a feature spec (`docs/product/features/<slug>/spec.md`) into a UX brief (`docs/product/features/<slug>/ux-brief.md`) that a UI engineer can implement without making product decisions. You decide *what the user sees, in what order, with what affordances, on each target platform* — Android, iOS, macOS, Desktop (JVM). No human designer is in the loop; your brief is the design.
+Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
+You translate a feature spec (`docCorpus.featureSpec`) into a UX brief (`docCorpus.uxBrief`) that a UI engineer can implement without making product decisions. You decide *what the user sees, in what order, with what affordances, on each target platform* — Android, iOS, macOS, Desktop (JVM). No human designer is in the loop; your brief is the design.
 
 ## Visual identity is fixed
 
 The visual system (palette, typography, iconography, spacing) is locked. Reference patterns by their conceptual name (e.g. "the empty searching state of the device list", "the transfer-progress bar") — do not specify color values, density tokens, or icon families. `ui-expert` maps concepts to tokens.
 
-Full reference — read upfront and strictly comply: [`docs/product/design.md`](../../docs/product/design.md), [`docs/engineering/ui-style-guide.md`](../../docs/engineering/ui-style-guide.md).
+Full reference — read upfront and strictly comply: [`docs/product/design.md`](../../docs/product/design.md) (under `docCorpus.productDir`), [`docs/engineering/ui-style-guide.md`](../../docs/engineering/ui-style-guide.md) (under `docCorpus.engineeringDir`).
 
 ## When invoked
 
-You're called when a FEATURE issue's scope includes user-facing UI (screen, component, navigation) and the `ux-brief.md` is missing, stale relative to the spec, or has blocking open UX questions. Whether the UX brief is needed is the orchestrator's call; once invoked, you own the interaction design before any UI code is written.
+You're called when a FEATURE issue's scope includes user-facing UI (screen, component, navigation) and the UX brief (`docCorpus.uxBrief`) is missing, stale relative to the spec, or has blocking open UX questions. Whether the UX brief is needed is the orchestrator's call; once invoked, you own the interaction design before any UI code is written.
 
 ## Always do before writing
 
 1. **Read the feature spec.** It's the source of truth for *what / why*; your job is the *how-it-feels*.
-2. **Read product context** where relevant: `docs/product/vision.md`, `docs/product/audience.md`.
-3. **Apply long-lived-artifact discipline** to brief prose — see [`docs/engineering/long-lived-artifacts.md`](../../docs/engineering/long-lived-artifacts.md).
+2. **Read product context** where relevant (under `docCorpus.productDir`): `vision.md`, `audience.md`.
+3. **Apply long-lived-artifact discipline** to brief prose — see [`docs/engineering/long-lived-artifacts.md`](../../docs/engineering/long-lived-artifacts.md) (under `docCorpus.engineeringDir`).
 
 ## Core principles
 
@@ -37,7 +39,7 @@ When you don't know the right idiom for a platform, **say so explicitly** in the
 
 ## Output: the UX brief
 
-Write to `docs/product/features/<slug>/ux-brief.md`. Structure:
+Write to the UX brief (`docCorpus.uxBrief`). Structure:
 
 ```markdown
 # UX brief — <Feature name>

--- a/.claude/agents/ux-expert.md
+++ b/.claude/agents/ux-expert.md
@@ -5,7 +5,7 @@ tools: Read, Write, Edit, Grep, Glob, Bash
 model: opus
 ---
 
-Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 You translate a feature spec (`docCorpus.featureSpec`) into a UX brief (`docCorpus.uxBrief`) that a UI engineer can implement without making product decisions. You decide *what the user sees, in what order, with what affordances, on each target platform* — Android, iOS, macOS, Desktop (JVM). No human designer is in the loop; your brief is the design.
 

--- a/.claude/commands/progress-boring.md
+++ b/.claude/commands/progress-boring.md
@@ -1,6 +1,6 @@
 Project progress snapshot: infra/features by PR + MVP readiness by roadmap.
 
-Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 ## What to collect
 

--- a/.claude/commands/progress-boring.md
+++ b/.claude/commands/progress-boring.md
@@ -1,21 +1,23 @@
 Project progress snapshot: infra/features by PR + MVP readiness by roadmap.
 
+Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 ## What to collect
 
 1. **PR statistics via GraphQL.** One `gh api graphql` request with pagination over `repository.pullRequests` — fetching `number, title, state, createdAt, mergedAt, additions, deletions, changedFiles, commits.totalCount, comments.totalCount, reviews.totalCount, reviewThreads.totalCount` at once. The REST list endpoint `/pulls` does not return `commits`/`comments`/`review_comments` per PR — GraphQL or per-PR detail calls are needed.
 
-2. **MVP scope.** Read `docs/product/roadmap.md` (section `## MVP`) — list of MVP items. Read `docs/product/features/README.md` — feature statuses and linked issues. Read the latest `docs/sprints/sprint-*.md` (with the highest number) — what is in progress now.
+2. **MVP scope.** Read `roadmap.md` (section `## MVP`, under `docCorpus.productDir`) — list of MVP items. Read the features dir's `README.md` (`docCorpus.featuresDir`) — feature statuses and linked issues. Read the latest `docs/sprints/sprint-*.md` (with the highest number) — what is in progress now.
 
 ## PR categorization
 
 **Feature** — PR touches product code or fills in / edits a product spec:
 - `composeApp/src/**` (except `build.gradle.kts`-only), implementation of discovery / FileServer / pairing / UI;
-- `docs/product/features/**` — filling in feature specs;
-- `docs/product/vision.md`, `roadmap.md`, `security.md`, `monetization.md` — product content.
+- the features dir (`docCorpus.featuresDir`) — filling in feature specs;
+- the product docs root (`docCorpus.productDir`): `vision.md`, `roadmap.md`, `security.md`, `monetization.md` — product content.
 
 **Infra** — everything else:
 - `.claude/**` (skills, agents, hooks, commands);
-- `docs/engineering/**`, ADRs;
+- the engineering docs root (`docCorpus.engineeringDir`), ADRs;
 - retro PRs (title starts with `retro`);
 - sprint planning, `docs/sprints/**`;
 - Gradle build, CI, configs;
@@ -25,14 +27,14 @@ If a PR is mixed — categorize by the dominant part (>50% of the diff). If in d
 
 ## MVP readiness
 
-For each item from `roadmap.md ## MVP` assess readiness (0–100%) based on evidence:
+For each item from `roadmap.md ## MVP` (under `docCorpus.productDir`) assess readiness (0–100%) based on evidence:
 
-- 100% — feature has status `done` in `features/README.md` AND there are merged PRs covering all platforms.
+- 100% — feature has status `done` in the features dir's `README.md` (`docCorpus.featuresDir`) AND there are merged PRs covering all platforms.
 - 50–80% — partial: either protocol layer without UI, or platform parity incomplete (e.g., Android+iOS done, Desktop tbd).
 - 10–30% — only spec `scoped`, no code; or only one of several components.
 - 0% — neither code nor spec with status ≥`scoped`.
 
-Don't guess — justify each assessment with PR numbers and/or lines in `features/README.md`. If the evidence is unclear — mark `?` and ask.
+Don't guess — justify each assessment with PR numbers and/or lines in the features dir's `README.md` (`docCorpus.featuresDir`). If the evidence is unclear — mark `?` and ask.
 
 ## Velocity per day
 

--- a/.claude/project.json
+++ b/.claude/project.json
@@ -1,0 +1,52 @@
+{
+  "repo": { "slug": "khmelevartem/tether" },
+  "git": {
+    "commitPrefix": "#<issue>: ",
+    "todoMarker": "TODO(#<issue>)",
+    "prTitlePattern": "^#<issue>",
+    "branchPatterns": ["^(feature|docs)/[0-9]+", "^[0-9]+"],
+    "prTemplate": ".github/pull_request_template.md"
+  },
+  "docCorpus": {
+    "productDir": "docs/product/",
+    "featuresDir": "docs/product/features/",
+    "featureSpec": "docs/product/features/<slug>/spec.md",
+    "uxBrief": "docs/product/features/<slug>/ux-brief.md",
+    "engineeringDir": "docs/engineering/",
+    "adrDir": "docs/engineering/adr/",
+    "knowledgeDir": "docs/knowledge/",
+    "glossary": "docs/glossary.md"
+  },
+  "commands": {
+    "allTests": "./gradlew allTests -q",
+    "recordSnapshots": "./gradlew :composeApp:recordRoborazziDebug -q",
+    "buildDebug": "./gradlew :composeApp:assembleDebug",
+    "run": "./gradlew :composeApp:run"
+  },
+  "reviewers": {
+    "projectSpecific": {
+      "ui": {
+        "inner": ["review-ux-conformance"],
+        "waveA": ["review-ux-conformance", "review-design-system", "review-visual"]
+      },
+      "platform": {
+        "inner": ["review-platform"],
+        "waveA": ["review-platform"]
+      },
+      "ux-brief": {
+        "inner": [],
+        "waveA": ["review-ux-brief"]
+      }
+    }
+  },
+  "touchedBuckets": {
+    "uxBrief": "docs/product/features/.+/ux-brief\\.md",
+    "ui": "composeApp/src/",
+    "platformSourceSets": ["androidMain", "appleMain", "iosMain", "jvmMain", "desktopMain"],
+    "docsPrefix": "docs/",
+    "engdocPrefix": "docs/engineering/",
+    "claudePrefix": ".claude/",
+    "testSourceSets": ["commonTest", "androidUnitTest", "androidInstrumentedTest", "iosTest", "jvmTest", "desktopTest", "appleTest"],
+    "testFilename": "Tests?\\.kt$"
+  }
+}

--- a/.claude/project.json.template
+++ b/.claude/project.json.template
@@ -1,0 +1,39 @@
+{
+  "repo": { "slug": "OWNER/REPO" },
+  "git": {
+    "commitPrefix": "#<issue>: ",
+    "todoMarker": "TODO(#<issue>)",
+    "prTitlePattern": "^#<issue>",
+    "branchPatterns": [],
+    "prTemplate": ""
+  },
+  "docCorpus": {
+    "productDir": "",
+    "featuresDir": "",
+    "featureSpec": "",
+    "uxBrief": "",
+    "engineeringDir": "",
+    "adrDir": "",
+    "knowledgeDir": "",
+    "glossary": ""
+  },
+  "commands": {
+    "allTests": "",
+    "recordSnapshots": "",
+    "buildDebug": "",
+    "run": ""
+  },
+  "reviewers": {
+    "projectSpecific": {}
+  },
+  "touchedBuckets": {
+    "uxBrief": "",
+    "ui": "",
+    "platformSourceSets": [],
+    "docsPrefix": "",
+    "engdocPrefix": "",
+    "claudePrefix": "",
+    "testSourceSets": [],
+    "testFilename": ""
+  }
+}

--- a/.claude/skills/check-review/SKILL.md
+++ b/.claude/skills/check-review/SKILL.md
@@ -3,7 +3,7 @@ name: check-review
 description: Read the latest review comments on the PR you are working on, classify each as pointwise or structural (re-auditing the whole diff for structural ones), reject reviewer-priority labels in favor of own value assessment, fix valid ones, reply to invalid ones in the original thread via `in_reply_to`, push. Use when the user says "check review", "process PR comments", "address review", "посмотри ревью", "обработай комменты", or invokes `/check-review`.
 ---
 
-Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 Review the latest comments on the PR you are working on. Assess which of them are valid, fix the valid ones. If there are invalid ones, reply to them explaining why you consider them invalid. Push the changes.
 

--- a/.claude/skills/check-review/SKILL.md
+++ b/.claude/skills/check-review/SKILL.md
@@ -3,6 +3,8 @@ name: check-review
 description: Read the latest review comments on the PR you are working on, classify each as pointwise or structural (re-auditing the whole diff for structural ones), reject reviewer-priority labels in favor of own value assessment, fix valid ones, reply to invalid ones in the original thread via `in_reply_to`, push. Use when the user says "check review", "process PR comments", "address review", "посмотри ревью", "обработай комменты", or invokes `/check-review`.
 ---
 
+Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 Review the latest comments on the PR you are working on. Assess which of them are valid, fix the valid ones. If there are invalid ones, reply to them explaining why you consider them invalid. Push the changes.
 
 ## Important: pointwise fix vs structural finding
@@ -39,7 +41,7 @@ Before agreeing to move an "optional" item out of scope, ask yourself:
 
 If at least one of these questions is answered "yes", and the overall volume does not exceed a reasonable extension — **do it in this same PR**. The "optional" tag does not cancel the value of the fix or exempt you from it.
 
-"Scope grows critically" = new target / new component / changing a public contract / needing to change adjacent layers / unpredictable volume due to revealing a hidden bug. Volume in lines is not the main criterion; the main criterion is relevance to the current task. Full fold-vs-defer test — [`scope-discipline.md`](../../../docs/engineering/scope-discipline.md); provenance is not an axis.
+"Scope grows critically" = new target / new component / changing a public contract / needing to change adjacent layers / unpredictable volume due to revealing a hidden bug. Volume in lines is not the main criterion; the main criterion is relevance to the current task. Full fold-vs-defer test — the [scope-discipline canon](../../../docs/engineering/scope-discipline.md) (under `docCorpus.engineeringDir`); provenance is not an axis.
 
 Especially careful: when the reviewer themselves referenced a DoD item or edge case from the issue, the "optional" tag in that case often means "not a blocker for me personally", but strictly speaking this is a **gap in the DoD**, and closing it is the responsibility of the current task's assignee, not the next review or a future contributor. Do not offload your DoD onto someone else's backlog.
 

--- a/.claude/skills/check-review/SKILL.md
+++ b/.claude/skills/check-review/SKILL.md
@@ -49,16 +49,16 @@ Especially careful: when the reviewer themselves referenced a DoD item or edge c
 
 **ALWAYS** reply **in the thread of the original comment**, never as a separate top-level PR comment. The link "suggestion → reaction" must be visible in one place — otherwise the reviewer doesn't understand what exactly you replied to, and the thread remains "hanging".
 
-Any inline review comment (including one attached to a review submission) lives in `pulls/PR/comments` and is replied to via `in_reply_to`:
+Any inline review comment (including one attached to a review submission) lives in `pulls/PR/comments` and is replied to via `in_reply_to`. `<repo.slug>` in the calls below — `.claude/project.json` → `repo.slug`:
 
 ```bash
 # 1. Find the COMMENT_ID of the needed comment in the thread
-gh api repos/OWNER/REPO/pulls/PR/comments \
+gh api repos/<repo.slug>/pulls/PR/comments \
   --jq '.[] | {id, user: .user.login, path, line, in_reply_to_id, body}'
 
 # 2. Reply in the same thread (in_reply_to can point to any comment
 #    in the thread — GitHub will attach the reply to the root automatically)
-gh api repos/OWNER/REPO/pulls/PR/comments \
+gh api repos/<repo.slug>/pulls/PR/comments \
   -X POST \
   -F in_reply_to=COMMENT_ID \
   -F body="reply text"
@@ -70,10 +70,10 @@ A review body (general review text not attached to a line) has no separate threa
 
 ```bash
 # Get the current review body
-gh api repos/OWNER/REPO/pulls/PR/reviews/REVIEW_ID --jq '.body'
+gh api repos/<repo.slug>/pulls/PR/reviews/REVIEW_ID --jq '.body'
 
 # Update the body — original + separator + reaction
-gh api repos/OWNER/REPO/pulls/PR/reviews/REVIEW_ID \
+gh api repos/<repo.slug>/pulls/PR/reviews/REVIEW_ID \
   -X PUT \
   -F body="$(printf '%s\n\n---\n\n%s' "ORIGINAL_REVIEW_TEXT" "reaction text")"
 ```

--- a/.claude/skills/choose-issue/SKILL.md
+++ b/.claude/skills/choose-issue/SKILL.md
@@ -3,6 +3,8 @@ name: choose-issue
 description: Quick read-only look at the current `docs/sprints/sprint-NN.md` — pull issue numbers from the composition table + merge order, batch-check OPEN/PR status via `gh`, query `blocked_by` only for 🟢 items, and propose 1–3 candidates to start now with one-sentence justifications. No Gradle, no edits. Use when the user says "what to pick next", "next task from sprint", "что взять из спринта", "следующая задача", or invokes `/choose-issue`.
 ---
 
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 Quick look: what to pick from the current sprint right now. Read-only and `gh` only, no Gradle.
 
 ## 1. Sprint
@@ -35,8 +37,10 @@ Marking:
 
 For each 🟢:
 ```bash
-gh api repos/khmelevartem/tether/issues/<N>/dependencies/blocked_by --jq '.[] | "\(.number) \(.state)"'
+gh api repos/<repo.slug>/issues/<N>/dependencies/blocked_by --jq '.[] | "\(.number) \(.state)"'
 ```
+
+`<repo.slug>` — `.claude/project.json` → `repo.slug`.
 
 If there is an open blocker → 🔴. Also account for the in-sprint chains from the `## Порядок мерджа` section.
 

--- a/.claude/skills/close-issue/SKILL.md
+++ b/.claude/skills/close-issue/SKILL.md
@@ -3,7 +3,7 @@ name: close-issue
 description: Finish a GitHub issue and merge its PR — pull main, walk acceptance criteria, gate on manual smoke + user confirmation, ask one interview-prep comprehension question, sweep PR review comments, update docs touched by the change, record any engineering decisions made in chat, post-factum size label, squash-merge, follow-ups, optional retro. Use when the user says "close issue N", "merge the PR", "finish task N", "ship #N", or invokes `/close-issue`.
 ---
 
-Repo-specific paths and commands for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 Complete task <issue number> and merge the PR.
 

--- a/.claude/skills/close-issue/SKILL.md
+++ b/.claude/skills/close-issue/SKILL.md
@@ -3,6 +3,8 @@ name: close-issue
 description: Finish a GitHub issue and merge its PR — pull main, walk acceptance criteria, gate on manual smoke + user confirmation, ask one interview-prep comprehension question, sweep PR review comments, update docs touched by the change, record any engineering decisions made in chat, post-factum size label, squash-merge, follow-ups, optional retro. Use when the user says "close issue N", "merge the PR", "finish task N", "ship #N", or invokes `/close-issue`.
 ---
 
+Repo-specific paths and commands for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 Complete task <issue number> and merge the PR.
 
 Work strictly step by step. Each step is a stop point: if something is not done, report it explicitly and wait for the user's confirmation or correction. Do not proceed to the next step without an explicit OK.
@@ -19,7 +21,7 @@ Run `/pull-main` — it will pull `origin/main` and assess semantic overlap with
 
 Obtain the list of acceptance criteria:
 - from the issue (DoD / Acceptance Criteria section)
-- from the feature spec in `docs/product/features/`, if there is a file for this task
+- from the feature spec (`docCorpus.featureSpec`), if there is a file for this task
 
 **If neither a DoD nor a feature spec exists** (typical for infrastructure and meta tasks) — extract the goals from the issue body, formulate a verifiable checklist yourself, and explicitly show it to the user with the note "AC extracted from issue body, confirm or adjust". Do not proceed to the next step until the user has confirmed.
 
@@ -27,7 +29,7 @@ For each criterion, explicitly state the status: ✅ done / ❌ not done / ❓ i
 
 If there are ❌ items — stop. Do not continue until they are resolved.
 
-**Checking warnings.** The `-q` flag hides Gradle/KGP warnings. Run one pass without it and verify that no new warnings have appeared:
+**Checking warnings.** The `-q` flag hides Gradle/KGP warnings. Run the project's test command (`commands.allTests`) without `-q` and verify that no new warnings have appeared:
 
 ```bash
 ./gradlew allTests 2>&1 | grep -i "warning\|warn" | grep -v "^w: KLIB"
@@ -92,35 +94,35 @@ Make sure all review comments are resolved (resolved or replied to with a justif
 
 ## Step 4 — Update documentation
 
-### 4.1 Status in features/README.md
+### 4.1 Status in the features dir's README.md
 
-If the task implemented a feature from `docs/product/features/README.md` — update its status to `done`.
+If the task implemented a feature from the features dir's `README.md` (`docCorpus.featuresDir`) — update its status to `done`.
 If this is an intermediate task (part of a feature) — update the status only if the feature is fully complete.
 
 ### 4.2 Affected documentation
 
 Review the PR diff and determine: were any architectural or product decisions made during this task that diverge from the current documentation?
 
-Files to check:
-- `docs/product/` — if feature behavior, target audience, or stack changed
-- `docs/engineering/` — if architectural principles, module layout, or DI rules changed
+Roots to check:
+- the product docs root (`docCorpus.productDir`) — if feature behavior, target audience, or stack changed
+- the engineering docs root (`docCorpus.engineeringDir`) — if architectural principles, module layout, or DI rules changed
 - `CLAUDE.md` — if build, testing processes, or project structure changed
 
 If the documentation is out of date — update it. Small edits do immediately, large ones — create a separate issue.
 
-**Apply the writing discipline.** Before writing or editing any long-lived artifact here, re-read [`long-lived-artifacts.md`](../../../docs/engineering/long-lived-artifacts.md) and apply it — do not write from memory.
+**Apply the writing discipline.** Before writing or editing any long-lived artifact here, re-read [`long-lived-artifacts.md`](../../../docs/engineering/long-lived-artifacts.md) (under `docCorpus.engineeringDir`) and apply it — do not write from memory.
 
-**Doc-as-spec on first implementation of an architectural sketch.** If the PR is the first real implementation of a pattern that was a sketch in `docs/engineering/` (marker: "skeleton lands in #N" or code examples without a working implementation) — the doc must be updated in the same PR. Otherwise, the next implementor will follow an outdated example.
+**Doc-as-spec on first implementation of an architectural sketch.** If the PR is the first real implementation of a pattern that was a sketch under the engineering docs root (marker: "skeleton lands in #N" or code examples without a working implementation) — the doc must be updated in the same PR. Otherwise, the next implementor will follow an outdated example.
 
-**New runtime flag — the entry-point doc must mention it.** If the PR introduces a new runtime flag (env var, JVM system property, CLI option, build flag) that affects observable application behavior — the README or the corresponding entry-point section must mention it with at least one line and a link to the engineering doc. Engineering doc as the only documentation location does not count as coverage: a contributor / user looks in the README, not in `docs/engineering/`.
+**New runtime flag — the entry-point doc must mention it.** If the PR introduces a new runtime flag (env var, JVM system property, CLI option, build flag) that affects observable application behavior — the README or the corresponding entry-point section must mention it with at least one line and a link to the engineering doc. An engineering doc as the only documentation location does not count as coverage: a contributor / user looks in the README, not under `docCorpus.engineeringDir`.
 
-**New rule in a live document — audit actual code.** If the PR adds or extends a policy or rule in `docs/engineering/` (sensitive-data policy, naming convention, layering rule, etc.) — run it against the code actually touched in the fresh PR and make sure the diff does not violate the just-introduced rule. Otherwise the doc will immediately diverge from reality, or the rule will silently create invisible violations.
+**New rule in a live document — audit actual code.** If the PR adds or extends a policy or rule under the engineering docs root (sensitive-data policy, naming convention, layering rule, etc.) — run it against the code actually touched in the fresh PR and make sure the diff does not violate the just-introduced rule. Otherwise the doc will immediately diverge from reality, or the rule will silently create invisible violations.
 
 ---
 
 ## Step 5 — Record engineering decisions made along the way
 
-Review the issue, the conversation with the user, and comments in the PR: were any architectural / technical / process decisions made that are **not recorded** in `docs/engineering/` or `CLAUDE.md`?
+Review the issue, the conversation with the user, and comments in the PR: were any architectural / technical / process decisions made that are **not recorded** under the engineering docs root (`docCorpus.engineeringDir`) or `CLAUDE.md`?
 
 Examples of such decisions:
 - Choice of library, technology, or specific pattern
@@ -132,7 +134,7 @@ If such a decision exists and is not recorded anywhere — **before merging**, r
 
 Do not let a decision live only in the chat: sessions are lost, and the next contributor (or yourself a month later) won't see the history and will reopen the same question.
 
-**Apply the writing discipline.** Before writing or editing any long-lived artifact while recording a decision (doc, ADR, KDoc, `.claude/**`), re-read [`long-lived-artifacts.md`](../../../docs/engineering/long-lived-artifacts.md) and apply it — do not write from memory.
+**Apply the writing discipline.** Before writing or editing any long-lived artifact while recording a decision (doc, ADR, KDoc, `.claude/**`), re-read [`long-lived-artifacts.md`](../../../docs/engineering/long-lived-artifacts.md) (under `docCorpus.engineeringDir`) and apply it — do not write from memory.
 
 ---
 
@@ -157,7 +159,7 @@ Don't treat this as "a poor estimate" — scope often grows along the way due to
 
 Before merging — while the PR can still absorb a fix — surface every loose end. Sources: the issue's "Consequences" / "Out of scope", TODO/FIXME in the diff, anything deferred or scoped out during the work, and any cheap fix you spotted in a file you already touched.
 
-State **each** item as: **"\<known problem / unfinished item\>. Can do now because … / Can't do now because …"** — your honest read of whether it belongs in this PR, per [`scope-discipline.md`](../../../docs/engineering/scope-discipline.md). Then ask the user **"What do you disagree with?"** and **stop**.
+State **each** item as: **"\<known problem / unfinished item\>. Can do now because … / Can't do now because …"** — your honest read of whether it belongs in this PR, per the [scope-discipline canon](../../../docs/engineering/scope-discipline.md) (under `docCorpus.engineeringDir`). Then ask the user **"What do you disagree with?"** and **stop**.
 
 Hard stop-point: the user redirects do-now-vs-defer here, while the merge is still reversible — not after, when a cheap in-file fix can no longer ride along.
 

--- a/.claude/skills/close-issue/SKILL.md
+++ b/.claude/skills/close-issue/SKILL.md
@@ -29,7 +29,7 @@ For each criterion, explicitly state the status: ✅ done / ❌ not done / ❓ i
 
 If there are ❌ items — stop. Do not continue until they are resolved.
 
-**Checking warnings.** The `-q` flag hides Gradle/KGP warnings. Run the project's test command (`commands.allTests`) without `-q` and verify that no new warnings have appeared:
+**Checking warnings.** `commands.allTests` carries `-q`, which hides Gradle/KGP warnings. Re-run the project's test command with `-q` stripped and filter for warnings — for this repo:
 
 ```bash
 ./gradlew allTests 2>&1 | grep -i "warning\|warn" | grep -v "^w: KLIB"

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -5,7 +5,7 @@ description: Multi-agent code review for a PR. Fans out to specialized sub-agent
 
 # /code-review — Multi-agent orchestrator
 
-Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 You are the orchestrator. You do NOT review code yourself. You collect context, fan out to specialized review agents, aggregate findings, and post one comment to GitHub.
 

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -5,6 +5,8 @@ description: Multi-agent code review for a PR. Fans out to specialized sub-agent
 
 # /code-review — Multi-agent orchestrator
 
+Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 You are the orchestrator. You do NOT review code yourself. You collect context, fan out to specialized review agents, aggregate findings, and post one comment to GitHub.
 
 ## Input
@@ -26,13 +28,13 @@ Note the PR number `<PR>` and issue number `<N>` — pass both to every agent.
 Read PR body and diff. Classify once: `FEATURE | BUGFIX | REFACTOR | INFRA | DOCS | DEPENDENCY`. Some agents skip based on type (see their frontmatter). Note which agents to skip; do not launch skipped ones.
 
 Skip matrix:
-- `DOCS` → skip `review-correctness`, `review-platform`, `review-tests`, `review-ux-conformance`, `review-design-system`, `review-visual`, `review-architecture` (but a DOCS PR editing a `ux-brief.md` still runs `review-ux-brief` — see the next row)
+- `DOCS` → skip `review-correctness`, `review-platform`, `review-tests`, `review-ux-conformance`, `review-design-system`, `review-visual`, `review-architecture` (but a DOCS PR editing a UX brief still runs `review-ux-brief` — see the next row)
 - `INFRA` → skip `review-tests`
 - pure `REFACTOR` → skip `review-correctness` (only behavior-preserving)
 - trivial one-call-site `BUGFIX` or cosmetic refactor (rename / extract method) with no new types / modules / seams → skip `review-architecture`
 - diff doesn't touch any platform source set → skip `review-platform`
-- diff doesn't touch `composeApp/src/**` → skip `review-ux-conformance`, `review-design-system`, and `review-visual`. When Compose **is** touched: dispatch `review-design-system` and `review-visual` (the latter narrows its checklist without a brief). For `review-ux-conformance`, **first resolve the brief**: find the feature slug(s) — `gh pr view <PR> --json closingIssuesReferences,body`, else glob `docs/product/features/**/ux-brief.md` and topic-match the PR title / changed paths — and dispatch it only if at least one resolved feature has a `ux-brief.md`, passing the brief path(s) in the prompt. No brief → don't dispatch (a brief may legitimately be absent for cosmetic / refactor changes); this gate is the orchestrator's, so the agent is never launched only to self-skip.
-- diff doesn't touch any `docs/product/features/**/ux-brief.md` → skip `review-ux-brief` (runs regardless of PR type whenever a brief is edited; it judges the brief's UX-domain quality, independent of any Compose change)
+- diff doesn't touch `composeApp/src/**` → skip `review-ux-conformance`, `review-design-system`, and `review-visual`. When Compose **is** touched: dispatch `review-design-system` and `review-visual` (the latter narrows its checklist without a brief). For `review-ux-conformance`, **first resolve the brief**: find the feature slug(s) — `gh pr view <PR> --json closingIssuesReferences,body`, else glob the UX briefs under the features dir (`docCorpus.featuresDir`) and topic-match the PR title / changed paths — and dispatch it only if at least one resolved feature has a UX brief (`docCorpus.uxBrief`), passing the brief path(s) in the prompt. No brief → don't dispatch (a brief may legitimately be absent for cosmetic / refactor changes); this gate is the orchestrator's, so the agent is never launched only to self-skip.
+- diff doesn't touch any UX brief under the features dir (`docCorpus.uxBrief`) → skip `review-ux-brief` (runs regardless of PR type whenever a brief is edited; it judges the brief's UX-domain quality, independent of any Compose change)
 - diff touches no `docs/` or `.claude/**` → skip `review-consistency` (it checks doc cross-references, scope cohesion, indexes, and relocation completeness; runs whenever documentation is touched, regardless of PR type)
 
 ## Step 3 — Wave 1: launch all applicable reviewers in parallel
@@ -51,8 +53,8 @@ Agents to launch (subject to skip matrix):
 - `review-consistency` (if diff touches `docs/` or `.claude/**`)
 - `review-correctness`
 - `review-tests`
-- `review-ux-conformance` (only if `composeApp/src/**` touched AND a touched feature has a `ux-brief.md` — see skip matrix; pass the resolved brief path(s) in the prompt)
-- `review-ux-brief` (if diff touches `docs/product/features/**/ux-brief.md`)
+- `review-ux-conformance` (only if `composeApp/src/**` touched AND a touched feature has a UX brief — see skip matrix; pass the resolved brief path(s) in the prompt)
+- `review-ux-brief` (if diff touches a UX brief under the features dir, `docCorpus.uxBrief`)
 - `review-design-system` (if diff touches `composeApp/src/**`)
 - `review-visual` (renders PNGs itself when invoked; reads them against the brief)
 

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -5,9 +5,11 @@ description: Create a GitHub issue via `gh` CLI — single issue or epic + sub-i
 
 # Create Issue
 
+Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 ## Body responsibility
 
-The body answers **what** and **why**, plus where to start looking. **How** is decided later, during implementation, against `docs/engineering/`. Pre-baked APIs, exhaustive Affected modules, file-by-file DoD, Error handling, Non-functional requirements become hard constraints on the implementer and pollute their context with details that drift from reality the moment design diverges — keep them out. If the user dictates a specific approach in chat, capture it as one Entry-point line, not as a contract.
+The body answers **what** and **why**, plus where to start looking. **How** is decided later, during implementation, against the engineering docs (`docCorpus.engineeringDir`). Pre-baked APIs, exhaustive Affected modules, file-by-file DoD, Error handling, Non-functional requirements become hard constraints on the implementer and pollute their context with details that drift from reality the moment design diverges — keep them out. If the user dictates a specific approach in chat, capture it as one Entry-point line, not as a contract.
 
 ## Issue language
 
@@ -44,7 +46,7 @@ Two cheap reads before the interview. They cut the interview in half.
 
 ### Project conventions
 
-If unread in this session: `CLAUDE.md`, and the topical [`docs/engineering/`](../../../docs/engineering/) doc matching the task area. These set test commands, conventions, and existing rules — the DoD inherits from them.
+If unread in this session: `CLAUDE.md`, and the topical doc under the engineering dir (`docCorpus.engineeringDir`, [relative path](../../../docs/engineering/)) matching the task area. These set test commands, conventions, and existing rules — the DoD inherits from them.
 
 ### Similar closed issues
 
@@ -56,7 +58,7 @@ Worth 1–2 hits — link them in the body as references so the implementer has 
 
 ### Feature spec
 
-For FEATURE tasks: `ls docs/product/features/`. If a spec exists for this feature, **read it** — Acceptance Criteria and Out of scope come directly into the issue. Spec wins over user description on conflict; clarify before drafting.
+For FEATURE tasks: list the features dir (`docCorpus.featuresDir`). If a spec exists for this feature, **read it** — Acceptance Criteria and Out of scope come directly into the issue. Spec wins over user description on conflict; clarify before drafting.
 
 ## Interview
 
@@ -98,7 +100,7 @@ Show the draft in chat as markdown. Do not write to disk before approval.
 
 ## Glossary review
 
-After drafting, dispatch the `review-glossary` sub-agent on the draft body (pass the prose string in the prompt — there's no diff yet). Turn drift flags into edits. If a term is missing from `docs/glossary.md`, ask the user whether to add an entry now or treat it as task-local.
+After drafting, dispatch the `review-glossary` sub-agent on the draft body (pass the prose string in the prompt — there's no diff yet). Turn drift flags into edits. If a term is missing from the glossary (`docCorpus.glossary`), ask the user whether to add an entry now or treat it as task-local.
 
 ## Create
 
@@ -146,7 +148,7 @@ Size is human review effort, not diff size. At filing, predict it as **how many 
 
 ## What to avoid
 
-- **Pre-baking design** — file paths as commitments, signatures dictating contracts, package placement for new top-level types. Those are `/implement` + architect decisions against `docs/engineering/architecture-principles.md`. Issue body: "touches the file-server boundary", not "lives in `com.example.network.foo`".
+- **Pre-baking design** — file paths as commitments, signatures dictating contracts, package placement for new top-level types. Those are `/implement` + architect decisions against `architecture-principles.md` (under `docCorpus.engineeringDir`). Issue body: "touches the file-server boundary", not "lives in `com.example.network.foo`".
 - **Code-term DoD** — "test passes", "class exists" alone. State what a user / observer sees.
 - **Padding** — filling sections to fill them. Drop optional sections that have nothing to say.
 - **Skipping Out of scope** on non-trivial tasks — even one bullet narrows the agent's path.

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -5,7 +5,7 @@ description: Create a GitHub issue via `gh` CLI — single issue or epic + sub-i
 
 # Create Issue
 
-Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 ## Body responsibility
 

--- a/.claude/skills/create-issue/TEMPLATE.md
+++ b/.claude/skills/create-issue/TEMPLATE.md
@@ -1,8 +1,10 @@
 # GitHub Issue Body Template
 
+Repo-specific paths and commands for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 Mandatory body sections in order: **Context → Goal → Entry point → Definition of Done → Out of scope**. Everything else is optional and dropped when there's nothing to say. Task type and size live on the issue as labels, not in the body.
 
-The body answers **what** and **why**, plus where to start looking. It does not pre-bake **how** — that is decided during implementation, against `docs/engineering/`.
+The body answers **what** and **why**, plus where to start looking. It does not pre-bake **how** — that is decided during implementation, against the engineering docs (`docCorpus.engineeringDir`).
 
 ## Template
 
@@ -47,7 +49,7 @@ Sections that **never** appear in the body:
 - Contract / API signatures / interface bodies — shape is decided during implementation.
 - Affected modules with package paths — landmarks go in Entry point as prose.
 - Code landmarks with `rg` / `grep` commands — Entry point line suffices.
-- Non-functional requirements — only if the user explicitly stated a threshold; otherwise the implementer consults `docs/engineering/`.
+- Non-functional requirements — only if the user explicitly stated a threshold; otherwise the implementer consults the engineering docs (`docCorpus.engineeringDir`).
 - Error handling — same; an architecture concern, not an issue-body concern.
 - `**Relationships:**` block — native GitHub fields only.
 - `**Open questions:**` block — a principal unresolved question means the task is not ready; file a preceding research task and link it as `blocked_by`. See SKILL.md §Unresolved blocking questions.
@@ -77,7 +79,7 @@ Both mandatory; pass via `--label "size:<…>,<type>"` on `gh issue create`.
 | `pnpm test src/cache.test.ts passes` | Returning from product page to search results shows the previous list instantly (no API call in first 100ms) |
 | `New endpoint `/v2/search` returns 200` | Search query returns matching results within 200ms p95 |
 
-Commands are fine where they're the cheapest evidence of behaviour (`./gradlew allTests -q passes` for a bugfix whose evidence is a failing-then-passing test). Avoid commands as a stand-in for the behaviour itself.
+Commands are fine where they're the cheapest evidence of behaviour (the project's test command, `commands.allTests`, passing for a bugfix whose evidence is a failing-then-passing test). Avoid commands as a stand-in for the behaviour itself.
 
 ## Paired sides of a contract — in one task
 

--- a/.claude/skills/create-issue/TEMPLATE.md
+++ b/.claude/skills/create-issue/TEMPLATE.md
@@ -1,6 +1,6 @@
 # GitHub Issue Body Template
 
-Repo-specific paths and commands for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 Mandatory body sections in order: **Context → Goal → Entry point → Definition of Done → Out of scope**. Everything else is optional and dropped when there's nothing to say. Task type and size live on the issue as labels, not in the body.
 

--- a/.claude/skills/grooming/SKILL.md
+++ b/.claude/skills/grooming/SKILL.md
@@ -3,7 +3,7 @@ name: grooming
 description: Run a backlog grooming session — close the current sprint-NN.md by actuals (task statuses, extra results within the window), go through open issues, find unfiled tasks via gap-analysis (platform symmetry, TODOs in code, MVP blockers from the roadmap) and compose a compact candidate for the next sprint in a fixed format (directions tag / composition / what it unblocks / optional merge order). Use when the user says "groom", "grooming", "plan the sprint", "close the sprint".
 ---
 
-Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 Run a backlog grooming session and compose a candidate plan for the next sprint.
 

--- a/.claude/skills/grooming/SKILL.md
+++ b/.claude/skills/grooming/SKILL.md
@@ -3,6 +3,8 @@ name: grooming
 description: Run a backlog grooming session — close the current sprint-NN.md by actuals (task statuses, extra results within the window), go through open issues, find unfiled tasks via gap-analysis (platform symmetry, TODOs in code, MVP blockers from the roadmap) and compose a compact candidate for the next sprint in a fixed format (directions tag / composition / what it unblocks / optional merge order). Use when the user says "groom", "grooming", "plan the sprint", "close the sprint".
 ---
 
+Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 Run a backlog grooming session and compose a candidate plan for the next sprint.
 
 ---
@@ -62,12 +64,12 @@ This rewrites [`.claude/sizing-bands.json`](../../sizing-bands.json); commit it 
 
 ## Step 1 — Product context
 
-Read in sequence:
+Read in sequence (under `docCorpus.productDir` unless noted):
 
-1. `docs/product/vision.md` — why the product exists
-2. `docs/product/README.md` — overview
-3. `docs/product/roadmap.md` — stages and priorities
-4. `docs/product/features/README.md` — list of features and their status
+1. `vision.md` — why the product exists
+2. `README.md` — overview
+3. `roadmap.md` — stages and priorities
+4. `features/README.md` (under `docCorpus.featuresDir`) — list of features and their status
 
 Goal: understand which roadmap stage we are at, what has already been implemented, what comes next.
 
@@ -104,11 +106,11 @@ For each open issue assess:
 |----------|----------|
 | No known blockers | — |
 | Clear DoD exists | — |
-| If a feature — spec exists in `docs/product/features/` | — |
+| If a feature — spec exists under the features dir (`docCorpus.featuresDir`) | — |
 | Spec referenced in the issue body | — |
 | Does not conflict with other candidates in the codebase | — |
 
-If there is no spec in `docs/product/features/` for new functionality — flag this explicitly as a risk.
+If there is no spec under the features dir (`docCorpus.featuresDir`) for new functionality — flag this explicitly as a risk.
 
 ---
 
@@ -144,7 +146,7 @@ Each such location is a potentially unfiled task. Don't file minor TODOs inside 
 
 ### 4.3 Roadmap blockers
 
-Re-read `docs/product/roadmap.md`. For each MVP item check: is there an issue moving it forward? If an MVP item has no issue at all — that's a gap.
+Re-read `roadmap.md` (under `docCorpus.productDir`). For each MVP item check: is there an issue moving it forward? If an MVP item has no issue at all — that's a gap.
 
 ### 4.4 What to do with found gaps
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -5,7 +5,7 @@ description: Drive a GitHub issue to a review-ready PR end to end — implementa
 
 # /implement — Issue-to-PR orchestrator
 
-Repo-specific paths, conventions, and commands for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 You are the orchestrator for a single GitHub issue. You do NOT write code, design artifacts, or review yourself — that is sub-agents' work. You classify, route, aggregate, and gate.
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -5,6 +5,8 @@ description: Drive a GitHub issue to a review-ready PR end to end — implementa
 
 # /implement — Issue-to-PR orchestrator
 
+Repo-specific paths, conventions, and commands for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 You are the orchestrator for a single GitHub issue. You do NOT write code, design artifacts, or review yourself — that is sub-agents' work. You classify, route, aggregate, and gate.
 
 **Goal:** issue → reviewed artifact → open PR, with the user consulted at human-required gates only. Merge is always a manual user decision.
@@ -30,7 +32,7 @@ Hold only the plan, per-iteration finding summaries, and gate decisions. Do not 
 
 What matters is the intention and the benefit the issue can bring, note its verbatim scope boundaries. If the issue has a prebaked reason or solution - it's just a proposal, not a directive. You must come with your own reasoning, design or justification throughout the whole workflow - not directly you as an agent, but with dispatching of proper subagents.
 
-If touching adjacent classes or neighbouring platforms is needed for a quality solution — expand scope in this PR. Whether to fold a finding or defer it → [`docs/engineering/scope-discipline.md`](../../../docs/engineering/scope-discipline.md).
+If touching adjacent classes or neighbouring platforms is needed for a quality solution — expand scope in this PR. Whether to fold a finding or defer it → the [scope-discipline canon](../../../docs/engineering/scope-discipline.md) (rooted at `docCorpus.engineeringDir`).
 
 ## Re-entry contract
 

--- a/.claude/skills/implement/prompts/recon-brief.md
+++ b/.claude/skills/implement/prompts/recon-brief.md
@@ -1,4 +1,4 @@
-Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 Read-only sweep for issue #<N>. Return a compact digest — binding constraints and relevant paths, no file dumps:
 

--- a/.claude/skills/implement/prompts/recon-brief.md
+++ b/.claude/skills/implement/prompts/recon-brief.md
@@ -1,11 +1,13 @@
+Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 Read-only sweep for issue #<N>. Return a compact digest — binding constraints and relevant paths, no file dumps:
 
-- **Product features** — `ls docs/product/features/` (+ `README.md` index). Slug(s) matching this issue; binding constraints from each `spec.md` / `ux-brief.md` in 1-2 lines.
-- **Product context** — `docs/product/*.md`. The framing that binds this issue's scope / audience / timing.
-- **Engineering living docs** — `docs/engineering/*.md`. Present-tense rules whose topic matches the task; flag any rule the planned change would violate.
-- **ADR** — `docs/engineering/adr/adr-*.md`. ADRs matching the topic; for each, its **Revisit if** section and whether this task trips a trigger.
-- **Knowledge** — `docs/knowledge/*.md`. Solved-problem notes relevant to the task.
-- **Glossary** — `docs/glossary.md`. Terms this issue's domain touches, with their locked definitions.
+- **Product features** — list the features dir (`docCorpus.featuresDir`) (+ its `README.md` index). Slug(s) matching this issue; binding constraints from each feature spec / UX brief (`docCorpus.featureSpec` / `docCorpus.uxBrief`) in 1-2 lines.
+- **Product context** — the product docs root (`docCorpus.productDir`). The framing that binds this issue's scope / audience / timing.
+- **Engineering living docs** — the engineering docs root (`docCorpus.engineeringDir`). Present-tense rules whose topic matches the task; flag any rule the planned change would violate.
+- **ADR** — the ADR dir (`docCorpus.adrDir`). ADRs matching the topic; for each, its **Revisit if** section and whether this task trips a trigger.
+- **Knowledge** — the knowledge dir (`docCorpus.knowledgeDir`). Solved-problem notes relevant to the task.
+- **Glossary** — the glossary (`docCorpus.glossary`). Terms this issue's domain touches, with their locked definitions.
 - **Prior `#<N>` mentions** — ranked list of file:line hits across the repo with one-line summary of what each expects. Every hit must be addressed in this PR or explicitly deferred to another issue.
 
 For each layer in `docLayers`, note whether the target artifact exists, is a stub, or has open questions. Flag whether a doc already covers the subsystem this task targets.

--- a/.claude/skills/implement/prompts/simplify-pass.md
+++ b/.claude/skills/implement/prompts/simplify-pass.md
@@ -1,4 +1,4 @@
-Repo-specific paths, conventions, and commands for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 All findings are resolved. Make one simplification pass over the diff: remove dead branches, inline single-use helpers, collapse trivial wrappers.
 

--- a/.claude/skills/implement/prompts/simplify-pass.md
+++ b/.claude/skills/implement/prompts/simplify-pass.md
@@ -1,7 +1,9 @@
+Repo-specific paths, conventions, and commands for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 All findings are resolved. Make one simplification pass over the diff: remove dead branches, inline single-use helpers, collapse trivial wrappers.
 
-**For every comment / KDoc / prose paragraph in the diff — including `.claude/skills/**`, `docs/`, and Markdown — apply CLAUDE.md §Code style and [`docs/engineering/long-lived-artifacts.md`](../../../../docs/engineering/long-lived-artifacts.md).**
+**For every comment / KDoc / prose paragraph in the diff — including `.claude/skills/**`, `docs/`, and Markdown — apply CLAUDE.md §Code style and the [long-lived-artifacts canon](../../../../docs/engineering/long-lived-artifacts.md) (rooted at `docCorpus.engineeringDir`).**
 
 **Do not rephrase prose for brevity.** If a sentence is load-bearing and free of the issues above, leave its wording alone. Cut whole sentences when they fail the rule; otherwise keep them as written.
 
-Do not change behaviour; do not touch anything outside the diff. Run `./gradlew allTests -q` after.
+Do not change behaviour; do not touch anything outside the diff. Run the project's test command (`commands.allTests`) after.

--- a/.claude/skills/implement/scripts/classify-state.sh
+++ b/.claude/skills/implement/scripts/classify-state.sh
@@ -46,7 +46,7 @@ import json, sys, re
 try:
   with open('$CONFIG') as f:
     config = json.load(f)
-except FileNotFoundError:
+except (FileNotFoundError, json.JSONDecodeError):
   config = {}
 pattern_template = config.get('git', {}).get('prTitlePattern', '^#<issue>')
 pattern = pattern_template.replace('<issue>', '([0-9]+)')
@@ -63,7 +63,7 @@ import json, re, sys
 try:
   with open('$CONFIG') as f:
     data = json.load(f)
-except FileNotFoundError:
+except (FileNotFoundError, json.JSONDecodeError):
   data = {}
 patterns = data.get('git', {}).get('branchPatterns', [])
 branch = '$BRANCH'
@@ -115,7 +115,7 @@ import json, sys, re
 try:
   with open('$CONFIG') as f:
     config = json.load(f)
-except FileNotFoundError:
+except (FileNotFoundError, json.JSONDecodeError):
   config = {}
 pattern_template = config.get('git', {}).get('prTitlePattern', '^#<issue>')
 data = json.loads(sys.stdin.read())

--- a/.claude/skills/implement/scripts/classify-state.sh
+++ b/.claude/skills/implement/scripts/classify-state.sh
@@ -20,6 +20,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG="$SCRIPT_DIR/../../../project.json"
+
 # ── Resolve current branch ────────────────────────────────────────────────────
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
@@ -40,18 +43,38 @@ print(data[0]['number'] if data else '')
 if [ -n "$HEAD_PR" ]; then
   CURRENT_ISSUE=$(echo "$HEAD_PR_JSON" | python3 -c "
 import json, sys, re
+try:
+  with open('$CONFIG') as f:
+    config = json.load(f)
+except FileNotFoundError:
+  config = {}
+pattern_template = config.get('git', {}).get('prTitlePattern', '^#<issue>')
+pattern = pattern_template.replace('<issue>', '([0-9]+)')
 data = json.loads(sys.stdin.read())
 title = data[0]['title'] if data else ''
-m = re.match(r'^#([0-9]+)', title)
+m = re.match(pattern, title)
 print(m.group(1) if m else '')
 " 2>/dev/null || echo "")
 fi
 
 if [ -z "$CURRENT_ISSUE" ]; then
-  CURRENT_ISSUE=$(printf '%s' "$BRANCH" | grep -oE '^(feature|docs)/[0-9]+' | grep -oE '[0-9]+' || true)
-fi
-if [ -z "$CURRENT_ISSUE" ]; then
-  CURRENT_ISSUE=$(printf '%s' "$BRANCH" | grep -oE '^[0-9]+' || true)
+  CURRENT_ISSUE=$(python3 -c "
+import json, re, sys
+try:
+  with open('$CONFIG') as f:
+    data = json.load(f)
+except FileNotFoundError:
+  data = {}
+patterns = data.get('git', {}).get('branchPatterns', [])
+branch = '$BRANCH'
+for p in patterns:
+  m = re.match(p, branch)
+  if m:
+    digits = re.search(r'[0-9]+', m.group(0))
+    if digits:
+      print(digits.group(0))
+      sys.exit(0)
+" 2>/dev/null || true)
 fi
 
 # ── Resolve target issue number ───────────────────────────────────────────────
@@ -89,10 +112,17 @@ if [ -n "$HEAD_PR" ] && [ -n "$CURRENT_ISSUE" ] && [ "$CURRENT_ISSUE" = "$ISSUE"
 else
   PR_NUMBER=$(gh pr list --state open --limit 500 --json number,title 2>/dev/null | python3 -c "
 import json, sys, re
+try:
+  with open('$CONFIG') as f:
+    config = json.load(f)
+except FileNotFoundError:
+  config = {}
+pattern_template = config.get('git', {}).get('prTitlePattern', '^#<issue>')
 data = json.loads(sys.stdin.read())
 issue = '$ISSUE'
+pattern = pattern_template.replace('<issue>', re.escape(issue)) + r'([: ]|\$)'
 for pr in data:
-  if re.match(r'^#' + re.escape(issue) + r'([: ]|\$)', pr['title']):
+  if re.match(pattern, pr['title']):
     print(pr['number'])
     sys.exit(0)
 print('-')
@@ -135,38 +165,7 @@ else
   DIFF_FILES=""
 fi
 
-TOUCHED=$(echo "$DIFF_FILES" | python3 -c "
-import sys, re
-
-lines = [l.strip() for l in sys.stdin.read().splitlines() if l.strip()]
-result = set()
-
-TEST_SOURCESET_RE = re.compile(r'/(commonTest|androidUnitTest|androidInstrumentedTest|iosTest|jvmTest|desktopTest|appleTest)/')
-TEST_FILENAME_RE = re.compile(r'Tests?\.kt$')
-
-for f in lines:
-  # ux-brief must be tested before docs (more specific)
-  if re.match(r'docs/product/features/.+/ux-brief\.md', f):
-    result.add('ux-brief')
-  # compose UI
-  if re.match(r'composeApp/src/', f):
-    result.add('ui')
-    result.add('code')
-  # platform source sets
-  if re.search(r'/(androidMain|appleMain|iosMain|jvmMain|desktopMain)/', f):
-    result.add('platform')
-  # general source (exclude test source sets and test filenames)
-  if re.match(r'.+/src/', f) and not TEST_SOURCESET_RE.search(f) and not TEST_FILENAME_RE.search(f):
-    result.add('code')
-  if f.startswith('docs/'):
-    result.add('docs')
-    if f.startswith('docs/engineering/'):
-      result.add('engdoc')
-  if f.startswith('.claude/'):
-    result.add('claude')
-
-print(','.join(sorted(result)))
-" 2>/dev/null || true)
+TOUCHED=$(echo "$DIFF_FILES" | python3 "$SCRIPT_DIR/derive-touched.py" "$CONFIG" 2>/dev/null || true)
 
 echo "touched=$TOUCHED"
 

--- a/.claude/skills/implement/scripts/classify-state.test.sh
+++ b/.claude/skills/implement/scripts/classify-state.test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Golden tests for the touched-bucket derivation classify-state.sh delegates to
+# derive-touched.py, against the repo's live .claude/project.json.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DERIVE="$SCRIPT_DIR/derive-touched.py"
+CONFIG="$SCRIPT_DIR/../../../project.json"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL [$label]"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+derive() {
+  printf '%s\n' "$@" | python3 "$DERIVE" "$CONFIG"
+}
+
+# ── Case 1: one file per bucket ──────────────────────────────────────────────
+
+OUT=$(derive \
+  "docs/product/features/foo/ux-brief.md" \
+  "composeApp/src/commonMain/kotlin/Foo.kt" \
+  "shared/src/androidMain/kotlin/Bar.kt" \
+  "shared/src/commonTest/kotlin/BazTests.kt" \
+  "shared/src/commonMain/kotlin/QuxTests.kt" \
+  "docs/engineering/foo.md" \
+  "docs/glossary.md" \
+  ".claude/skills/implement/steps.md" \
+  "README.md")
+
+assert_eq "all buckets fire, tests excluded from code" \
+  "claude,code,docs,engdoc,platform,ui,ux-brief" "$OUT"
+
+# ── Case 2: empty file list yields empty touched ────────────────────────────
+
+OUT=$(derive)
+assert_eq "empty diff yields empty touched" "" "$OUT"
+
+# ── Case 3: docs outside docs/engineering/ excludes engdoc ──────────────────
+
+OUT=$(derive "docs/glossary.md")
+assert_eq "docs without engineering/ omits engdoc" "docs" "$OUT"
+
+# ── Case 4: test-suffixed filename in a non-test dir is still excluded ──────
+
+OUT=$(derive "shared/src/commonMain/kotlin/FooTests.kt")
+assert_eq "Tests.kt filename excluded even outside a test source set" "" "$OUT"
+
+# ── Case 5: non-Compose, non-platform source still counts as code ──────────
+
+OUT=$(derive "shared/src/commonMain/kotlin/Repository.kt")
+assert_eq "commonMain source counts as code, not ui" "code" "$OUT"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+TOTAL=$((PASS + FAIL))
+echo "Results: $PASS/$TOTAL passed"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/.claude/skills/implement/scripts/derive-touched.py
+++ b/.claude/skills/implement/scripts/derive-touched.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# Derives the `touched` bucket set for classify-state.sh from a newline-separated
+# file list on stdin and the adapter config at .claude/project.json.
+# Usage: derive-touched.py <path-to-project.json>
+# Output: comma-separated sorted bucket names (ui, code, platform, docs, engdoc,
+# claude, ux-brief), possibly empty.
+
+import json
+import re
+import sys
+
+
+def derive(lines, buckets):
+    result = set()
+
+    platform_alt = "|".join(buckets.get("platformSourceSets", []))
+    test_sourceset_alt = "|".join(buckets.get("testSourceSets", []))
+    test_sourceset_re = re.compile("/(" + test_sourceset_alt + ")/") if test_sourceset_alt else None
+    test_filename = buckets.get("testFilename", "")
+    test_filename_re = re.compile(test_filename) if test_filename else None
+    ux_brief_pattern = buckets.get("uxBrief", "")
+    ui_pattern = buckets.get("ui", "")
+    docs_prefix = buckets.get("docsPrefix", "")
+    engdoc_prefix = buckets.get("engdocPrefix", "")
+    claude_prefix = buckets.get("claudePrefix", "")
+
+    for f in lines:
+        if ux_brief_pattern and re.match(ux_brief_pattern, f):
+            result.add("ux-brief")
+        if ui_pattern and re.match(ui_pattern, f):
+            result.add("ui")
+            result.add("code")
+        if platform_alt and re.search("/(" + platform_alt + ")/", f):
+            result.add("platform")
+        is_test = (test_sourceset_re and test_sourceset_re.search(f)) or (
+            test_filename_re and test_filename_re.search(f)
+        )
+        if re.match(r".+/src/", f) and not is_test:
+            result.add("code")
+        if docs_prefix and f.startswith(docs_prefix):
+            result.add("docs")
+            if engdoc_prefix and f.startswith(engdoc_prefix):
+                result.add("engdoc")
+        if claude_prefix and f.startswith(claude_prefix):
+            result.add("claude")
+
+    return result
+
+
+if __name__ == "__main__":
+    config_path = sys.argv[1] if len(sys.argv) > 1 else ".claude/project.json"
+    try:
+        with open(config_path) as f:
+            config = json.load(f)
+    except FileNotFoundError:
+        config = {}
+
+    lines = [l.strip() for l in sys.stdin.read().splitlines() if l.strip()]
+    result = derive(lines, config.get("touchedBuckets", {}))
+    print(",".join(sorted(result)))

--- a/.claude/skills/implement/scripts/derive-touched.py
+++ b/.claude/skills/implement/scripts/derive-touched.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     try:
         with open(config_path) as f:
             config = json.load(f)
-    except FileNotFoundError:
+    except (FileNotFoundError, json.JSONDecodeError):
         config = {}
 
     lines = [l.strip() for l in sys.stdin.read().splitlines() if l.strip()]

--- a/.claude/skills/implement/scripts/select-reviewers.sh
+++ b/.claude/skills/implement/scripts/select-reviewers.sh
@@ -45,7 +45,7 @@ import json, sys
 try:
   with open('$CONFIG') as f:
     data = json.load(f)
-except FileNotFoundError:
+except (FileNotFoundError, json.JSONDecodeError):
   data = {}
 names = data.get('reviewers', {}).get('projectSpecific', {}).get('$bucket', {}).get('$wave', [])
 print(' '.join(names))

--- a/.claude/skills/implement/scripts/select-reviewers.sh
+++ b/.claude/skills/implement/scripts/select-reviewers.sh
@@ -30,6 +30,28 @@ if [ "$TRACK" != "code" ] && [ "$TRACK" != "docs" ]; then
   exit 1
 fi
 
+# ── Project-specific reviewer config ─────────────────────────────────────────
+# Core reviewers stay hardcoded below — they are the framework baseline. Only
+# the per-bucket rosters come from the adapter config, so a consumer repo with
+# an empty or absent bucket degrades to no reviewers for that bucket.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG="$SCRIPT_DIR/../../../project.json"
+
+project_reviewers() {
+  local bucket="$1" wave="$2"
+  python3 -c "
+import json, sys
+try:
+  with open('$CONFIG') as f:
+    data = json.load(f)
+except FileNotFoundError:
+  data = {}
+names = data.get('reviewers', {}).get('projectSpecific', {}).get('$bucket', {}).get('$wave', [])
+print(' '.join(names))
+" 2>/dev/null || true
+}
+
 # ── Helpers ─────────────────────────────────────────────────────────────────
 
 has_touched() {
@@ -65,13 +87,13 @@ if [ "$TRACK" = "code" ]; then
   add_inner "review-architecture"
   add_inner "review-guides"
   if has_touched "platform"; then
-    add_inner "review-platform"
+    for r in $(project_reviewers "platform" "inner"); do add_inner "$r"; done
   fi
   if has_touched "ui"; then
     # review-ux-conformance requires a ux-brief for the touched feature; the
     # orchestrator resolves this at dispatch time — we include it here when ui
     # is touched; the orchestrator suppresses dispatch when no brief exists.
-    add_inner "review-ux-conformance"
+    for r in $(project_reviewers "ui" "inner"); do add_inner "$r"; done
   fi
 else
   # docs track — foundation gate before dependent layers are written on top.
@@ -108,15 +130,13 @@ if [ "$TRACK" = "code" ]; then
     add_a "review-tests"
   fi
   if has_touched "platform"; then
-    add_a "review-platform"
+    for r in $(project_reviewers "platform" "waveA"); do add_a "$r"; done
   fi
   if has_touched "ui"; then
-    add_a "review-ux-conformance"
-    add_a "review-design-system"
-    add_a "review-visual"
+    for r in $(project_reviewers "ui" "waveA"); do add_a "$r"; done
   fi
   if has_touched "ux-brief"; then
-    add_a "review-ux-brief"
+    for r in $(project_reviewers "ux-brief" "waveA"); do add_a "$r"; done
   fi
 else
   add_a "review-dod"
@@ -131,7 +151,7 @@ else
     add_a "review-architecture"
   fi
   if has_touched "ux-brief"; then
-    add_a "review-ux-brief"
+    for r in $(project_reviewers "ux-brief" "waveA"); do add_a "$r"; done
   fi
 fi
 

--- a/.claude/skills/implement/scripts/select-reviewers.test.sh
+++ b/.claude/skills/implement/scripts/select-reviewers.test.sh
@@ -229,6 +229,46 @@ for reviewer in $INNER_LIST; do
   fi
 done
 
+# ── Config-driven path: project.json controls the project-specific rosters ──
+#
+# The reviewer names above (review-ux-conformance, review-platform, ...) are not
+# hardcoded in the script — they come from project.json's reviewers.projectSpecific.
+# Prove it by pointing the script at a config with an empty `ui` bucket and
+# checking the ui-touched roster loses exactly its project-specific reviewers.
+
+CONFIG_REAL="$SCRIPT_DIR/../../../project.json"
+CONFIG_BACKUP="$(mktemp)"
+cp "$CONFIG_REAL" "$CONFIG_BACKUP"
+trap 'cp "$CONFIG_BACKUP" "$CONFIG_REAL"; rm -f "$CONFIG_BACKUP"' EXIT
+
+python3 -c "
+import json
+with open('$CONFIG_REAL') as f:
+    data = json.load(f)
+data['reviewers']['projectSpecific']['ui'] = {'inner': [], 'waveA': []}
+with open('$CONFIG_REAL', 'w') as f:
+    json.dump(data, f)
+"
+
+OUT=$(run code feature "ui,code,platform")
+assert_eq "empty config ui bucket drops ui reviewers from inner" \
+  "inner-loop-reviewers: review-correctness review-architecture review-guides review-platform" \
+  "$(inner_line "$OUT")"
+assert_eq "empty config ui bucket drops ui reviewers from wave-a" \
+  "wave-a-reviewers: review-dod review-glossary review-reuse review-tests" \
+  "$(wave_a_line "$OUT")"
+
+cp "$CONFIG_BACKUP" "$CONFIG_REAL"
+
+# Restored config reproduces the filled rosters (case 2) byte-identical.
+OUT=$(run code feature "ui,code,platform")
+assert_eq "restored config reproduces c2 inner" \
+  "inner-loop-reviewers: review-correctness review-architecture review-guides review-platform review-ux-conformance" \
+  "$(inner_line "$OUT")"
+assert_eq "restored config reproduces c2 wave-a" \
+  "wave-a-reviewers: review-dod review-glossary review-reuse review-tests review-design-system review-visual" \
+  "$(wave_a_line "$OUT")"
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 
 TOTAL=$((PASS + FAIL))

--- a/.claude/skills/implement/steps.md
+++ b/.claude/skills/implement/steps.md
@@ -1,6 +1,6 @@
 # Step catalog
 
-Repo-specific paths, conventions, and commands for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 ## Principles 
 

--- a/.claude/skills/implement/steps.md
+++ b/.claude/skills/implement/steps.md
@@ -1,5 +1,7 @@
 # Step catalog
 
+Repo-specific paths, conventions, and commands for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 ## Principles 
 
 Each `##` section is one step. 
@@ -126,7 +128,7 @@ Otherwise post the confirmed cause as a comment on issue #\<N\> via `gh issue co
 
 **Applies to:** `track=code AND reentry=fresh`.
 
-When the root cause describes a class of bugs, or parallel implementations contain the same defect — consider fixing one level up: a type / container / contract change that makes the class impossible. Compare costs: N point-fixes vs 1 structural fix. If you choose point-fix — list parallel defective locations explicitly; fold or defer each per [`docs/engineering/scope-discipline.md`](../../../docs/engineering/scope-discipline.md), filing a follow-up issue for any deferred before coding. Announce the decision: `fix-level: structural`, or `fix-level: point-fix → siblings <list>, follow-up #<M> filed` — so the follow-up obligation is on-screen, not assumed.
+When the root cause describes a class of bugs, or parallel implementations contain the same defect — consider fixing one level up: a type / container / contract change that makes the class impossible. Compare costs: N point-fixes vs 1 structural fix. If you choose point-fix — list parallel defective locations explicitly; fold or defer each per the [scope-discipline canon](../../../docs/engineering/scope-discipline.md) (rooted at `docCorpus.engineeringDir`), filing a follow-up issue for any deferred before coding. Announce the decision: `fix-level: structural`, or `fix-level: point-fix → siblings <list>, follow-up #<M> filed` — so the follow-up obligation is on-screen, not assumed.
 
 
 ---
@@ -141,11 +143,11 @@ Decide which artifact layers this issue needs.
 
 | Layer | Needed when | Artifact | Writer |
 |---|---|---|---|
-| **spec** | FEATURE AND `docs/product/features/<slug>/spec.md` is missing, `(stub)`, or has blocking open questions | `docs/product/features/<slug>/spec.md` | `spec-writer` |
-| **ux** | FEATURE with user-facing UI AND `ux-brief.md` is missing or stale relative to spec changes | `docs/product/features/<slug>/ux-brief.md` | `ux-expert` |
-| **tech** | Subsystem with a non-trivial mechanism not covered by `docs/engineering/<name>.md`, or existing doc is outdated | `docs/engineering/<name>.md` | `architect` |
-| **ADR** | Architectural choice clearing the three-way threshold in `docs/engineering/adr/README.md` §ADR threshold | `docs/engineering/adr/adr-<name>.md` | `architect` |
-| **knowledge** | Solved problem / platform quirk worth capturing (from a retro or closed BUGFIX) | `docs/knowledge/<name>.md` | `architect` |
+| **spec** | FEATURE AND the feature spec (`.claude/project.json` → `docCorpus.featureSpec`) is missing, `(stub)`, or has blocking open questions | the feature spec (`docCorpus.featureSpec`) | `spec-writer` |
+| **ux** | FEATURE with user-facing UI AND the UX brief (`docCorpus.uxBrief`) is missing or stale relative to spec changes | the UX brief (`docCorpus.uxBrief`) | `ux-expert` |
+| **tech** | Subsystem with a non-trivial mechanism not covered by an engineering doc under `docCorpus.engineeringDir`, or existing doc is outdated | `<docCorpus.engineeringDir>/<name>.md` | `architect` |
+| **ADR** | Architectural choice clearing the three-way threshold in `docCorpus.adrDir`'s README §ADR threshold | `<docCorpus.adrDir>/adr-<name>.md` | `architect` |
+| **knowledge** | Solved problem / platform quirk worth capturing (from a retro or closed BUGFIX) | `<docCorpus.knowledgeDir>/<name>.md` | `architect` |
 | **.claude** | Deliverable edits a skill prompt, agent definition, slash command, hook, or settings | `.claude/skills/…` / `.claude/agents/…` / `.claude/commands/…` | orchestrator (inline) |
 
 Multiple layers per issue are normal. Classification ambiguity → SKILL.md §Framing ambiguity (user stop).
@@ -220,7 +222,7 @@ Form a list of actionable blocks (sequential or parallel) to dispatch to writing
 * reviewers findings
 * fail description
 
-**For structural findings, the action must contain a symmetry pass** — check sibling files, sibling methods, sibling platforms, sibling source sets for the same anti-pattern, and fix in this same pass. Whether an adjacent fix is folded here or deferred is the single criterion in [`docs/engineering/scope-discipline.md`](../../../docs/engineering/scope-discipline.md) — apply it, do not invent a local rule. If it defers, the agent escalates to the orchestrator — never silently skip.
+**For structural findings, the action must contain a symmetry pass** — check sibling files, sibling methods, sibling platforms, sibling source sets for the same anti-pattern, and fix in this same pass. Whether an adjacent fix is folded here or deferred is the single criterion in the [scope-discipline canon](../../../docs/engineering/scope-discipline.md) (rooted at `docCorpus.engineeringDir`) — apply it, do not invent a local rule. If it defers, the agent escalates to the orchestrator — never silently skip.
 
 **Review transmission accuracy.** Pass findings close to the reviewer's original wording; do not narrow or soften. If several findings converge on one principle — name the principle explicitly and list ALL sites where it applies. If interpretation is unclear → escalate to the user before re-dispatching, not after the next review round.
 
@@ -256,7 +258,7 @@ Dispatch every corresponding writing agent with a proper prompt:
 
 Order matters — lower layers depend on upper ones for vocabulary and scope.
 
-**Prose discipline carry-forward.** Every dispatch brief must instruct the sub-agent to load and every direct edit must follow the principles of  [`docs/engineering/long-lived-artifacts.md`](../../../docs/engineering/long-lived-artifacts.md) before writing and apply it to every paragraph.
+**Prose discipline carry-forward.** Every dispatch brief must instruct the sub-agent to load and every direct edit must follow the principles of the [long-lived-artifacts canon](../../../docs/engineering/long-lived-artifacts.md) (rooted at `docCorpus.engineeringDir`) before writing and apply it to every paragraph.
 
 ---
 ## Step 17 — commit
@@ -288,7 +290,7 @@ If it fails → go back to `transform input to actions` step with a clear proble
 What round of `fast-review` is it?
 
 - 1-4 → **Refresh roster, then dispatch review.** Run `classify-state.sh` to recompute `touched` from the live committed diff, then `select-reviewers.sh <track> <type> <touched>` to get the current `inner-loop-reviewers` roster. Dispatch exactly those reviewers. 
-	- When reviewing the UI changes: resolve the feature slug from the issue number (spec link or `docs/product/features/<slug>/` reference in the body, else glob `docs/product/features/**/ux-brief.md` and topic-match the changed paths); pass the resolved brief path in the `review-ux-conformance` prompt. Suppress the dispatch entirely when no brief exists. Announce the outcome (`ux-conformance: brief <path> → dispatched` / `ux-conformance: no brief → suppressed`) so this orchestrator-owned judgment is not silently skipped behind the scripted roster.
+	- When reviewing the UI changes: resolve the feature slug from the issue number (spec link or a features-dir (`docCorpus.featuresDir`) reference in the body, else glob the UX briefs under the features dir and topic-match the changed paths); pass the resolved brief path in the `review-ux-conformance` prompt. Suppress the dispatch entirely when no brief exists. Announce the outcome (`ux-conformance: brief <path> → dispatched` / `ux-conformance: no brief → suppressed`) so this orchestrator-owned judgment is not silently skipped behind the scripted roster.
 - 5+ → escalate to the user with remaining findings; signals a plan/scope problem the loop cannot fix.
    
 If every reviewer says `APPROVE` and zero `[REQUIRED]` → step done, reset the counter, move forward.
@@ -379,7 +381,7 @@ No force-push. Do not block on explicit OK before push — green runtime checks 
 
 Open the PR for the just-pushed branch:
 
-1. Read [`.github/pull_request_template.md`](../../../.github/pull_request_template.md) and compose the body using only the sections it defines — do not add sections of your own.
+1. Read the PR template (`.claude/project.json` → `git.prTemplate`) and compose the body using only the sections it defines — do not add sections of your own.
 2. Write the body to a file (e.g. `/tmp/pr-<N>-body.md`); `--body` with an in-shell heredoc silently corrupts multiline markdown and can drop `Closes #<N>`.
 3. Then run:
 

--- a/.claude/skills/progress/SKILL.md
+++ b/.claude/skills/progress/SKILL.md
@@ -3,6 +3,8 @@ name: progress
 description: Project progress snapshot as an RPG character sheet from Skyrim — hero class, level+XP from PR statistics, MVP chapters with progress bars, legendary artifacts (top PRs), quest map (dependency graph clustered by schools), Seal of Debt (planned vs improvised). Numbers wrapped in RPG language; bare percentages only in purely statistical tables. Use when the user asks for "progress", "project status", "snapshot", "how things are going" — or explicitly calls `/progress`. For dry numbers without RPG framing — separate command `/progress-boring`.
 ---
 
+Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 Project progress snapshot as an RPG character sheet. Tether is not a project — it's a saga. The user is the Dragonborn developer. The roadmap is the main story line, infra is side quests and crafting, MVP is the final dungeon.
 
 Tone: seriously epic with light self-irony. Translating numbers into RPG language is mandatory in narrative blocks; pure statistical tables (Hot Battles, Heavy Marches) — bare numbers are acceptable.
@@ -29,7 +31,7 @@ Outputs into `--raw-data`: `prs.json`, `issues.json`, `blocked_by.json`, `loc.js
 
 ## MVP chapters — compose in chat
 
-Read `docs/product/roadmap.md` §MVP and `docs/product/features/README.md`. **One chapter per MVP product feature** (the feature index is the unit, *not* the roadmap bullet): merge roadmap bullets that belong to the same feature — multi-file transfer + live progress + cancel + receiver are all one *File transfer* chapter, backed by its epic(s). A feature may legitimately span more than one epic (File transfer = `#8` UI + `#119` reliability); that's fine, list both. Aim for ≤ 8 chapters. Completed (100 %) chapters are hidden behind a "показать завершённые" toggle by default, so keep them in the list — don't drop them. Chapters cover MVP *product* features only; infra, Post-MVP, and system-integration epics stay out. The coverage caption under the table is **computed** — it lists every open `EPIC:`-titled hub no chapter references, so it never goes stale when new epics appear (you don't hand-maintain that list). For each chapter name the backing epic where the feature has one. Write the result to `/tmp/tether-progress-mvp.json`:
+Read `roadmap.md` §MVP and `features/README.md` (both under `docCorpus.productDir` / `docCorpus.featuresDir`). **One chapter per MVP product feature** (the feature index is the unit, *not* the roadmap bullet): merge roadmap bullets that belong to the same feature — multi-file transfer + live progress + cancel + receiver are all one *File transfer* chapter, backed by its epic(s). A feature may legitimately span more than one epic (File transfer = `#8` UI + `#119` reliability); that's fine, list both. Aim for ≤ 8 chapters. Completed (100 %) chapters are hidden behind a "показать завершённые" toggle by default, so keep them in the list — don't drop them. Chapters cover MVP *product* features only; infra, Post-MVP, and system-integration epics stay out. The coverage caption under the table is **computed** — it lists every open `EPIC:`-titled hub no chapter references, so it never goes stale when new epics appear (you don't hand-maintain that list). For each chapter name the backing epic where the feature has one. Write the result to `/tmp/tether-progress-mvp.json`:
 
 ```json
 [
@@ -41,7 +43,7 @@ Read `docs/product/roadmap.md` §MVP and `docs/product/features/README.md`. **On
 
 Text is in Russian (the whole report is). `title` — just the evocative chapter name (the seal column already renders the Roman numeral, so no `Глава N:` prefix). `subtitle` — a one-line flavour caption.
 
-- `epic` (optional) — list of backing issue numbers from `docs/product/features/README.md`, e.g. `[457]` or `[8, 119]`. Each renders as the issue's **full title**, clickable, linking to GitHub. The chapters table has no free-text evidence column — put the backing issues here, not prose.
+- `epic` (optional) — list of backing issue numbers from the features dir's `README.md` (`docCorpus.featuresDir`), e.g. `[457]` or `[8, 119]`. Each renders as the issue's **full title**, clickable, linking to GitHub. The chapters table has no free-text evidence column — put the backing issues here, not prose.
 - `percent` — **auto-computed when omitted**: `build.py` takes the size-weighted completion of the epics' direct sub-issues (`Σ weight(closed) ÷ Σ weight(all)`, weights from `.claude/sizing-bands.json`, `unlabeled`→`valor_size.unlabeled`). Prefer this — it's the answer to "progress by tasks, not by eye". Supply an explicit `percent` only to **override**: chapters with no epic (shipped mDNS / device-name → manual), a subset of a shared epic (live-progress draws on #8 but isn't all of it), or a decision-plus-impl pair (#123/#140) where the weighted child count misreads. When you do override, that's a judgement call — keep it honest.
 
 ## Build the snapshot

--- a/.claude/skills/progress/SKILL.md
+++ b/.claude/skills/progress/SKILL.md
@@ -3,7 +3,7 @@ name: progress
 description: Project progress snapshot as an RPG character sheet from Skyrim — hero class, level+XP from PR statistics, MVP chapters with progress bars, legendary artifacts (top PRs), quest map (dependency graph clustered by schools), Seal of Debt (planned vs improvised). Numbers wrapped in RPG language; bare percentages only in purely statistical tables. Use when the user asks for "progress", "project status", "snapshot", "how things are going" — or explicitly calls `/progress`. For dry numbers without RPG framing — separate command `/progress-boring`.
 ---
 
-Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 Project progress snapshot as an RPG character sheet. Tether is not a project — it's a saga. The user is the Dragonborn developer. The roadmap is the main story line, infra is side quests and crafting, MVP is the final dungeon.
 

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -3,7 +3,7 @@ name: retro
 description: Run a retrospective on a GitHub task (issue + PR) to identify systemic gaps and systemic successes, propose changes to CLAUDE.md / docs / skills / commands / hooks, and apply approved ones on a separate retro branch with PR title `retro from #<PR>: …`. Use when the user says "retro", "retrospective", "разбор по задаче", "look back at task N", or invokes `/retro`.
 ---
 
-Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 Run a retrospective on task <issue number> (and the associated PR, if any).
 

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -3,6 +3,8 @@ name: retro
 description: Run a retrospective on a GitHub task (issue + PR) to identify systemic gaps and systemic successes, propose changes to CLAUDE.md / docs / skills / commands / hooks, and apply approved ones on a separate retro branch with PR title `retro from #<PR>: …`. Use when the user says "retro", "retrospective", "разбор по задаче", "look back at task N", or invokes `/retro`.
 ---
 
+Repo-specific paths for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 Run a retrospective on task <issue number> (and the associated PR, if any).
 
 The goal is not a report for its own sake and not a catalog of pointwise mistakes, but **systemic improvements**: what in the prompts, commands, skills, documentation, or project structure needs to change so that future assignees can do quality work more easily. Every conclusion must end with an action.
@@ -27,7 +29,7 @@ It measures the **current** main-thread context (not peak, which stays high afte
 
 ## Step 0 — Load the writing discipline
 
-Every change a retro produces is a long-lived artifact. Read [`docs/engineering/long-lived-artifacts.md`](../../../docs/engineering/long-lived-artifacts.md) before drafting any wording and apply it through the analysis and proposed edits, not only at the Step 6 commit gate.
+Every change a retro produces is a long-lived artifact. Read [`docs/engineering/long-lived-artifacts.md`](../../../docs/engineering/long-lived-artifacts.md) (under `docCorpus.engineeringDir`) before drafting any wording and apply it through the analysis and proposed edits, not only at the Step 6 commit gate.
 
 ---
 
@@ -59,14 +61,14 @@ Focus: **system → action**, not "agent → attentiveness".
 - **No trace in the end-state.** A signal that left nothing in the final diff (an option pruned, an approach abandoned, a premise that removed work before it was written) is invisible to a review of the merged artifacts and is exactly where the heaviest cost hides. Reconstruct it from the sequence, not the result.
 
 **Systemic gaps:**
-- A gap in `CLAUDE.md` / `docs/engineering/` / a skill / a template that made the mistake *programmatic*?
+- A gap in `CLAUDE.md` / the engineering docs (`docCorpus.engineeringDir`) / a skill / a template that made the mistake *programmatic*?
 - Did the assignee / reviewer rely on something that turned out to be incorrect or outdated (doc, example, 3rd-party claim)?
 - A class of review comments that can be caught by tooling / a hook / a rule — not by attention?
 - What was missing in the issue/spec to start without clarifications?
 
 **Systemic successes:**
 - What went unexpectedly smoothly, and why?
-- Is there a reproducible logic — to codify as a principle in `docs/engineering/`, a check in a skill, an item in a command template?
+- Is there a reproducible logic — to codify as a principle in the engineering docs (`docCorpus.engineeringDir`), a check in a skill, an item in a command template?
 - A free multiplier (one action → multiple platforms/tasks)? By what mechanism, how to extend it to similar cases?
 
 If there are neither gaps nor successes worth recording — close with "I see no systemic changes", don't invent action items for the sake of form.
@@ -94,8 +96,8 @@ Based on steps 2–3, identify specific systemic changes. Categories:
 | `.claude/commands/*.md` | One of the remaining single-file templates (`merge`, `progress-boring`) gave unclear instructions or missed a scenario |
 | `.claude/agents/<name>.md` | A sub-agent's brief is incomplete, allowed an out-of-scope decision, or missed a check |
 | `CLAUDE.md` | A convention / process / project structure is not recorded — the agent had to guess |
-| `docs/engineering/` | An architectural principle / pattern is recorded incorrectly, incompletely, or its examples diverge from reality |
-| `docs/product/features/` | A feature spec is incomplete or missing where it would have been useful |
+| the engineering docs (`docCorpus.engineeringDir`) | An architectural principle / pattern is recorded incorrectly, incompletely, or its examples diverge from reality |
+| the features dir (`docCorpus.featuresDir`) | A feature spec is incomplete or missing where it would have been useful |
 | `.claude/skills/create-issue` | Issues came out with insufficient context for direct implementation |
 | Hook in `scripts/install-hooks.sh` | A class of errors is catchable automatically at the git operation level, not only by instruction |
 
@@ -128,7 +130,7 @@ For each confirmed improvement:
 
 **If the change is small** (edit in a document, clarification in a command) — do it right now and show the diff.
 
-**Long-lived-artifacts compliance check before commit.** Every prose edit retro produces lands in a long-lived artifact by construction. Before committing, audit every paragraph and bullet against [`docs/engineering/long-lived-artifacts.md`](../../../docs/engineering/long-lived-artifacts.md).
+**Long-lived-artifacts compliance check before commit.** Every prose edit retro produces lands in a long-lived artifact by construction. Before committing, audit every paragraph and bullet against [`docs/engineering/long-lived-artifacts.md`](../../../docs/engineering/long-lived-artifacts.md) (under `docCorpus.engineeringDir`).
 
 **If the change requires a separate task** — create an issue via the `create-issue` skill. The name should read as a useful increment to the workflow, for example:
 - "Add check X to code-review.md"

--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -5,7 +5,7 @@ description: Run a basic smoke test (happy-path) across Tether platforms — Des
 
 # Smoke-test skill
 
-Repo-specific commands for this project live in `.claude/project.json` — consult it; references below name their config keys.
+Repo-specific values for this project live in `.claude/project.json` — consult it; references below name their config keys.
 
 Runs basic smoke scenarios across Tether targets and produces a human-readable report.
 

--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: smoke-test
-description: Run a basic smoke test (happy-path) across Tether platforms — Desktop CLI (cli jar + /health + mDNS + stdin commands), Desktop↔Desktop send via CLI, Android (if an adb device is connected) with send-from-Desktop, iOS simulator (xcodebuild + simctl) with mDNS publish + cross-discovery. Use this skill when the user says "run smoke", "run smoke test", "basic smoke", "basic regression", "check the build across platforms before merge", "smoke test". Not to be confused with unit tests (`./gradlew allTests`) — smoke is a runtime check that everything starts and peers can discover each other, not logic correctness.
+description: Run a basic smoke test (happy-path) across Tether platforms — Desktop CLI (cli jar + /health + mDNS + stdin commands), Desktop↔Desktop send via CLI, Android (if an adb device is connected) with send-from-Desktop, iOS simulator (xcodebuild + simctl) with mDNS publish + cross-discovery. Use this skill when the user says "run smoke", "run smoke test", "basic smoke", "basic regression", "check the build across platforms before merge", "smoke test". Not to be confused with the project's test command — smoke is a runtime check that everything starts and peers can discover each other, not logic correctness.
 ---
 
 # Smoke-test skill
 
+Repo-specific commands for this project live in `.claude/project.json` — consult it; references below name their config keys.
+
 Runs basic smoke scenarios across Tether targets and produces a human-readable report.
 
-**This is smoke, not regression.** The goal — in 1–3 minutes — is to see that nothing is fundamentally broken (CLI starts, FileServer responds, mDNS is published, stdin commands work, send roundtrip OK, native targets compile). Business logic correctness is the job of `./gradlew allTests`.
+**This is smoke, not regression.** The goal — in 1–3 minutes — is to see that nothing is fundamentally broken (CLI starts, FileServer responds, mDNS is published, stdin commands work, send roundtrip OK, native targets compile). Business logic correctness is the job of the project's test command (`commands.allTests`).
 
 ## What the skill does NOT check (out of scope for automation)
 
@@ -328,8 +330,8 @@ Don't ask the user for clarification — the skill must be "zero-question": ever
 
 ## What NOT to do
 
-- **Don't use `./gradlew :composeApp:run`** — that is the Compose UI, not the CLI.
-- **Don't run `allTests`** — that is a different tool. Smoke ≤3 minutes.
+- **Don't use the project's run command (`commands.run`)** — that is the Compose UI, not the CLI.
+- **Don't run the project's test command (`commands.allTests`)** — that is a different tool. Smoke ≤3 minutes.
 - **Don't modify application code** even if you see a problem. Report it in the report, file a separate issue.
 - **Don't go into `~/Downloads`** beyond your own files — that is user content.
 - **Don't run `./gradlew clean`** — it will eat the cache and slow down the next run.

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -53,4 +53,5 @@ ADRs in [`adr/`](adr/) capture the *why* behind one-time architectural choices. 
 - [Key-value persistence — DataStore](adr/adr-persistence-key-value.md) — chose `androidx.datastore-preferences-core` direct over wrapper libraries and per-store actuals.
 - [Sheet and modal primitives](adr/adr-sheet-modal-primitives.md) — chose Compose Unstyled over ad-hoc Compose Foundation overlay, Material 3, and Android-only sheet libraries.
 - [SAS pairing protocol](adr/adr-sas-pairing-protocol.md) — chose to authenticate the static identity keys (SAS over the full transcript, contributory co-committed nonce) over app-level ephemeral ECDH in pairing; session confidentiality comes from the pinned TLS channel.
+- [Project-context adapter](adr/adr-project-context-adapter.md) — chose to render prompt templates at install time and commit the rendered instance over the LLM reading config at runtime or gitignore-and-render-at-session-start.
 

--- a/docs/engineering/adr/adr-project-context-adapter.md
+++ b/docs/engineering/adr/adr-project-context-adapter.md
@@ -1,0 +1,83 @@
+# Project-context adapter — render templates at install time, commit the rendered instance
+
+**Status:** Accepted — 2026-07-06
+**Issue:** [#465](https://github.com/khmelevartem/tether/issues/465)
+
+## Context
+
+The `.claude/` framework — skills, agents, commands, and the roster/state scripts — hardcodes this repository's specifics. Epic [#464](https://github.com/khmelevartem/tether/issues/464) wants that framework reusable across projects; this decision decouples the repo-specifics into a single adapter so a consuming project supplies only its own configuration.
+
+Two distinct consumers read the framework, and they differ in kind. The scripts are deterministic bash: they can read a config file at runtime and behave identically every time. The prompts are markdown read by an LLM at dispatch time, where determinism is a property that must be engineered, not assumed. The first cut had both consumers read `.claude/project.json` at runtime. Making the LLM resolve config keys mid-run is the weak point: it lowers runtime determinism (the model must consult and resolve a key instead of reading a concrete path), it degrades prompt prose, and — per [`scope-discipline.md` §Two overrides](../scope-discipline.md#two-overrides) — it was introduced by this very change, so it is in-scope to resolve here rather than ship and clean up later.
+
+## Decision drivers
+
+| Driver | Why it matters |
+|---|---|
+| Runtime determinism for the LLM | An agent should read a concrete path, not resolve a config key mid-run; every runtime indirection is a place the model can diverge. |
+| Portability toward a standalone framework repo | The framework should live in its own repository, with a consuming repo supplying only its config; the boundary drawn here is what [#466](https://github.com/khmelevartem/tether/issues/466) extracts. |
+| Skills hot-reload | A skill file created or edited after session start is picked up on its next invocation without a restart; new skills become available mid-session. |
+| Agents do not hot-reload | The sub-agent registry is frozen at session boot; an agent definition created mid-session is not dispatchable — the Agent tool rejects it. |
+| Worktrees do not receive gitignored files | Creating a worktree checks out only tracked files, so gitignored content is absent in a freshly created worktree. |
+
+The three harness properties above were each established by direct in-session experiment against the Claude Code harness, not read from documentation; the harness does not document them.
+
+## Considered options
+
+The decision splits along four sub-questions. Each is recorded with its rejected alternatives, because the chosen shape only makes sense against what it declined.
+
+### Adapter representation
+
+**Chosen — a single `project.json` read directly by both consumers.** One machine-readable file is the sole repo-specific input.
+
+**Rejected — two files: a machine-readable JSON plus a prose "project profile" document.** The prose half reads more cleanly on its own, but it imposes a permanent two-file sync burden and makes the prose a second-class consumer that can silently drift from the JSON.
+
+### How prompts consume config
+
+**Chosen — render.** A script substitutes config values into prompt *templates* at install time, so at runtime the LLM reads only concrete, fully-resolved prompts.
+
+**Rejected — the LLM resolves config keys at runtime.** Non-deterministic, degrades the prose, and is exactly the causal-coupling debt this change would otherwise introduce and defer.
+
+### Where rendered output lives
+
+**Chosen — commit the rendered instance and guard it with a regeneration gate.** The rendered prompts are checked in as a generated artifact; a gate re-renders and fails if the committed output diverges from what the templates and config produce.
+
+**Rejected — gitignore the rendered output and render it via a session-start hook.** Refuted by the worktree and agent-registry drivers together: a freshly created worktree has no rendered files at boot, and the agent registry is frozen at boot and never refreshes, so an agent-heavy run in a fresh worktree would start with an empty agent registry — a silent failure. Skills alone could survive this because they hot-reload; agents cannot.
+
+**Rejected — a hybrid that commits agents but gitignores and renders skills and commands.** Removes the fresh-worktree agent failure, but introduces a split-brain committed/generated boundary and a residual dependency on undocumented session-start-versus-discovery ordering. The complexity is not worth what it buys.
+
+### Scripts
+
+**Chosen — scripts stay config-driven, reading the committed `project.json` at runtime.** They are already deterministic and golden-tested; rendering them would add a representation without removing a runtime read they can safely perform.
+
+## Decision
+
+We adopt a **render-at-install** adapter: repo-specifics live in one committed `project.json`, prompt templates carry placeholders that a renderer substitutes at install time, and the rendered instance is committed as a generated artifact kept honest by a regeneration gate. Scripts stay config-driven at runtime.
+
+The framework *source* is the unit that later extracts into its own repository ([#466](https://github.com/khmelevartem/tether/issues/466)): it holds the prompt templates mirroring the output tree, the generic scripts, the renderer, a config validator, the config schema, and the tests. The rendered instance under the operational `.claude/{agents,skills,commands}` locations is committed alongside it. `project.json` (filled) and its empty template are the only repo-specific inputs, both committed.
+
+Placeholders are dotted config keys; the renderer substitutes them in markdown and copies scripts verbatim, deterministically and idempotently. A validator runs before render and separates fatal from soft failure: invalid JSON, a required key absent, or a placeholder with no config value blocks the render; an optional layer being absent warns and proceeds by graceful degradation.
+
+The gate is enforced by the existing skill-test CI surface. It checks placeholder coverage (every placeholder resolves to a config key), no-leak (no template embeds a hardcoded repo literal — which turns the "no hardcoded repo path in a shipped prompt" acceptance criterion into a machine-enforced check), render idempotence, and rendered-output validity (link check plus the existing golden script tests).
+
+## Costs accepted
+
+- **A committed generated artifact.** The rendered instance is a second representation of the templates; it produces diff noise on every render and is only kept honest by the regeneration gate.
+- **Editing a prompt is a two-step edit.** A prompt change means editing its template and re-rendering, never editing the shipped file directly.
+- **Config changes lag one session.** A config change takes effect only from the next session, because the agent registry is frozen at boot. This is named as an accepted consequence rather than worked around.
+
+## Consequences
+
+- The [#465](https://github.com/khmelevartem/tether/issues/465) acceptance criterion moves from a human grep to a CI gate.
+- The framework source becomes extractable into its own repository; [#466](https://github.com/khmelevartem/tether/issues/466) packaging builds directly on the boundary this draws.
+
+## Revisit if
+
+- **The harness gains agent hot-reload, or the session-start hook is documented to run before sub-agent discovery.** Either makes gitignore-and-render-at-session-start viable and lets the committed-artifact cost be dropped. Re-check the two harness properties before acting.
+- **Render or placeholder volume grows enough to warrant a real build step** rather than string substitution.
+
+## References
+
+- Parent living doc: the render/install mechanism is not built yet (this ADR is doc-only), so its operational living doc will be authored when the mechanism is implemented; the framework's current structural overview lives in [`.claude/README.md`](../../../.claude/README.md).
+- [`scope-discipline.md` §Two overrides](../scope-discipline.md#two-overrides) — why the runtime-read coupling is resolved in this change rather than deferred.
+- [`long-lived-artifacts.md`](../long-lived-artifacts.md) — writing discipline this ADR follows.
+- Issue [#465](https://github.com/khmelevartem/tether/issues/465) and its scope-expansion comment; epic [#464](https://github.com/khmelevartem/tether/issues/464); follow-up [#466](https://github.com/khmelevartem/tether/issues/466).


### PR DESCRIPTION
**What / why.** Decouple the `.claude/` framework from this repo's hardcoded paths, conventions, and commands into one adapter, so the framework can be reused across projects and eventually extracted to its own repo (epic #464). This PR's scope expanded mid-flight: beyond the adapter, it records the architectural decision for **how** the framework installs into a project — render prompt templates at install time and commit the rendered instance — see the new ADR.

**👀 Sanity-check.**
- **The render-at-install layer is decided but not yet implemented.** [`adr-project-context-adapter.md`](docs/engineering/adr/adr-project-context-adapter.md) records the chosen model (templates + `project.json` → concrete prompts rendered at install, committed behind a regeneration gate). The prompt changes currently in this PR are the *interim* shape — prompts reference `project.json` keys read at runtime. The renderer + templates + regen-gate land in a follow-up layer on this same branch before merge.
- **Committed rendered instance over gitignore-and-render-at-session-start** — chosen because two in-session experiments showed the harness freezes the agent registry at session boot (agents don't hot-reload) and worktrees don't receive gitignored files, so a fresh-worktree agent-heavy run would start with no agents. Full reasoning + rejected alternatives in the ADR §Considered options.
- **Single `project.json`** (both consumers read one file) over a two-file json+prose split; **scripts stay config-driven** (deterministic, golden-tested) rather than rendered.
- **No behavioural change** in the current layer — golden tests kept byte-identical (`select-reviewers` 49/49, new `classify-state` 5/5, `skill-structure` 14/14) + an enforcement probe confirming the golden gate reddens on injected drift.

**Scope.**
- ❌ not touched: project-specific reviewer *internals* (`review-design-system`/`visual`/`platform`/`ux-*` tokens, package namespace, smoke-test platform logic) — this repo's adapter instance, out of scope per the issue.
- ❌ deferred to #466: extracting the framework into its own repo, packaging/install tooling, AI-assisted first-time setup.
- 📎 affected: `.claude/README.md` — §Project-context adapter documents the schema (filled example + empty template); new ADR + engineering ADR index entry.

Closes #465
