### PR TITLE
#498: record and link published manual-DI articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ P2P file transfer between devices on different OSes — over a local Wi-Fi netwo
 - [Tech stack](docs/product/tech-stack.md) — stack choices.
 - [Security](docs/security/README.md) — threat model, pairing, encryption.
 - [Engineering docs](docs/engineering/README.md) — architecture, modules, DI, testing.
+- [Articles](docs/articles/README.md) — long-form write-ups drawn from the codebase.
 
 ## Quick start
 

--- a/docs/articles/README.md
+++ b/docs/articles/README.md
@@ -3,6 +3,10 @@
 Long-form technical articles published from the Tether codebase, plus the reusable
 playbook for preparing the next one.
 
+## Published
+
+- `manual-di-kmp` — RU: <https://habr.com/p/1051804/>, EN: <https://medium.com/proandroiddev/hand-wired-di-in-kotlin-multiplatform-a-composition-root-instead-of-a-framework-ed995fb21b19>.
+
 ## Folder convention
 
 One folder per article: `docs/articles/<slug>/`.

--- a/docs/articles/manual-di-kmp/publishing.md
+++ b/docs/articles/manual-di-kmp/publishing.md
@@ -4,9 +4,8 @@ Article-specific publishing record, decisions, and remaining steps. Generic plat
 
 ## Status
 
-- **Habr (RU, `ru.md`)** — submitted to the Песочница (sandbox); awaiting moderation.
-- **Medium (EN, `en.md`)** — draft submitted to **Kt. Academy** (primary); fallback **ProAndroidDev**, then personal profile. Awaiting editor review.
-  Draft: <https://medium.com/@khmelyovartyom/hand-wired-di-in-kotlin-multiplatform-a-composition-root-instead-of-a-framework-ed995fb21b19>
+- **Habr (RU, `ru.md`)** — published: <https://habr.com/p/1051804/>.
+- **Medium (EN, `en.md`)** — published on **ProAndroidDev**: <https://medium.com/proandroiddev/hand-wired-di-in-kotlin-multiplatform-a-composition-root-instead-of-a-framework-ed995fb21b19>.
 
 ## Habr specifics
 
@@ -17,7 +16,7 @@ Article-specific publishing record, decisions, and remaining steps. Generic plat
 
 ## Medium specifics
 
-- **Publication path:** Kt. Academy (`contact@kt.academy`, cc `marcinmoskala@gmail.com`) → ProAndroidDev (`editors@proandroiddev.com`) → personal profile. First submission is by emailing the draft link; the in-editor *Submit to publication* only lists publications you are already a writer of. ([Write for Kt. Academy](https://blog.kotlin-academy.com/write-for-kotlin-academy-abebd70937ce), [ProAndroidDev guidelines](https://proandroiddev.com/submission-guidelines-b2efa7f46272))
+- **Publication path:** Kt. Academy (`contact@kt.academy`, cc `marcinmoskala@gmail.com`) → ProAndroidDev (`editors@proandroiddev.com`) → personal profile. First submission is by emailing the draft link; the in-editor *Submit to publication* only lists publications you are already a writer of. ([Write for Kt. Academy](https://blog.kotlin-academy.com/write-for-kotlin-academy-abebd70937ce), [ProAndroidDev guidelines](https://proandroiddev.com/submission-guidelines-b2efa7f46272)) ProAndroidDev accepts the piece; the Kt. Academy path is not taken.
 - **Tags (5):** `Kotlin`, `Kotlin Multiplatform`, `Dependency Injection`, `Android`, `Software Architecture`.
 - **Cover:** `hand-wired-cover.jpg` — set as the **feature image**; add an *AI-generated* credit caption.
 - **Free, no paywall.**
@@ -28,7 +27,9 @@ Article-specific publishing record, decisions, and remaining steps. Generic plat
 
 RU (Habr) and EN (Medium) are different-language audiences — running both is fine. If the EN piece is later mirrored (personal blog, dev.to), set the **canonical URL** to the primary copy so search ranking is not split.
 
-## Where to promote (once live)
+## Where to promote
+
+The six external channels below are author-owned — the author actions them manually.
 
 - **Kotlin Slack** (`kotlinlang.slack.com`) — `#multiplatform`, `#dependency-injection`, `#feed`.
 - **Reddit** — r/Kotlin, r/androiddev (substantive post, not a thin promo).
@@ -36,16 +37,10 @@ RU (Habr) and EN (Medium) are different-language audiences — running both is f
 - **Telegram** — RU Kotlin/Android channels for the Habr piece.
 - **LinkedIn** — repost with two lines of reflection (serves the hiring-signal goal).
 - **Hacker News** — possible for the EN piece; submit, don't over-invest.
-- **The Tether repo** — link both articles from the README and `docs/engineering/dependency-injection.md` once live.
+- **The Tether repo** — both articles linked from the README and `docs/engineering/dependency-injection.md`.
 
 Timing: mid-week, morning in the audience timezone (Habr — MSK; Medium/HN — US business hours); seed channels within the first hours of going live.
 
-## After publishing — close #479
+## Closing #479
 
-The DoD requires both published URLs recorded in the issue:
-
-```bash
-gh issue comment 479 --body "Published:
-- Habr (RU): <url>
-- Medium (EN): <url>"
-```
+#479 is closed with both published URLs recorded on it (see the `## Status` links above).

--- a/docs/engineering/dependency-injection.md
+++ b/docs/engineering/dependency-injection.md
@@ -252,6 +252,8 @@ The platform entry point builds the **root Component** (Decompose), passing `App
 
 Per-layer ownership and import rules (which layer may accept which dependencies): [layering.md](layering.md).
 
+A showcase write-up of this manual-DI approach is published and recorded in [docs/articles/README.md](../articles/README.md#published).
+
 ## Open questions
 
 - iOS receive-side: when a non-Ktor `FileServer` implementation lands, the container branches per-platform more aggressively. May be the moment to flip to Metro.


### PR DESCRIPTION
**What / why.** The two-language "hand-wired DI in KMP" article is now live (Habr RU + ProAndroidDev EN). This records both published URLs in the repo and closes the showcase↔code loop: a single `## Published` registry in `docs/articles/README.md` owns the URLs, and the root README + `dependency-injection.md` link to it. `publishing.md` is flipped to the published state.

**👀 Sanity-check.**
- All article URLs live in exactly two homes — the `## Published` registry and `publishing.md §Status` — per long-lived-artifacts §Link-over-inline-copy. The root README and DI doc reference the registry rather than embedding raw URLs, so they satisfy the DoD's "link to the published articles" transitively (one hop). Flagging in case a direct link was intended.
- Deferred: `«manual DI»` has no glossary entry. It is a pre-existing term (already on `main` at `dependency-injection.md:5` and throughout the article), not introduced here, so it is left for a separate follow-up rather than folded into this URL-recording PR.
- `ru.md` / `en.md` are intentionally untouched — the author confirmed no moderation/editorial edits were requested (EN independently confirmed: Medium's og:title + og:description match `en.md` verbatim).

**Scope.**
- ❌ external promotion (Kotlin Slack, Reddit, X/Mastodon, Telegram, LinkedIn, HN): author-owned, actioned manually outside this PR — recorded as such in `publishing.md`.
- 📎 #479 — closed; the published-URLs comment was posted to it.

Closes #498
